### PR TITLE
Allow using the CSS min and max calculations and the CSS filter functions

### DIFF
--- a/src/rules/no-global-function-names/__tests__/index.js
+++ b/src/rules/no-global-function-names/__tests__/index.js
@@ -40,6 +40,22 @@ testRule({
     },
     {
       code: `
+      a {
+       min-width: min(30vw, 300px);
+      }
+    `,
+      description: "An allowed global function"
+    },
+    {
+      code: `
+      a {
+       min-width: max(30vw, 300px);
+      }
+    `,
+      description: "An allowed global function"
+    },
+    {
+      code: `
       @use "sass:color";
       a {
        background: color.red(#6b717f);

--- a/src/rules/no-global-function-names/__tests__/index.js
+++ b/src/rules/no-global-function-names/__tests__/index.js
@@ -72,6 +72,14 @@ testRule({
     },
     {
       code: `
+      a {
+       filter: alpha(opacity=50);
+      }
+    `,
+      description: "An allowed global function"
+    },
+    {
+      code: `
       @use "sass:color";
       a {
        background: color.red(#6b717f);
@@ -360,17 +368,6 @@ testRule({
       column: 21,
       message: messages.rejected("lightness"),
       description: "lightness"
-    },
-    {
-      code: `
-      a {
-        background: alpha(#6b717f);
-      }
-    `,
-      line: 3,
-      column: 21,
-      message: messages.rejected("alpha"),
-      description: "alpha"
     },
     {
       code: `

--- a/src/rules/no-global-function-names/__tests__/index.js
+++ b/src/rules/no-global-function-names/__tests__/index.js
@@ -56,6 +56,14 @@ testRule({
     },
     {
       code: `
+      a {
+       filter: invert(1);
+      }
+    `,
+      description: "An allowed global function"
+    },
+    {
+      code: `
       @use "sass:color";
       a {
        background: color.red(#6b717f);

--- a/src/rules/no-global-function-names/__tests__/index.js
+++ b/src/rules/no-global-function-names/__tests__/index.js
@@ -64,6 +64,14 @@ testRule({
     },
     {
       code: `
+      a {
+       filter: saturate(140%);
+      }
+    `,
+      description: "An allowed global function"
+    },
+    {
+      code: `
       @use "sass:color";
       a {
        background: color.red(#6b717f);

--- a/src/rules/no-global-function-names/index.js
+++ b/src/rules/no-global-function-names/index.js
@@ -39,8 +39,6 @@ const rules = {
   ceil: "math",
   floor: "math",
   abs: "math",
-  min: "math",
-  max: "math",
   random: "math",
   unit: "math",
   unitless: "math",

--- a/src/rules/no-global-function-names/index.js
+++ b/src/rules/no-global-function-names/index.js
@@ -13,7 +13,6 @@ const rules = {
   saturation: "color",
   lightness: "color",
   complement: "color",
-  alpha: "color",
   "adjust-color": "color",
   "scale-color": "color",
   "change-color": "color",

--- a/src/rules/no-global-function-names/index.js
+++ b/src/rules/no-global-function-names/index.js
@@ -13,7 +13,6 @@ const rules = {
   saturation: "color",
   lightness: "color",
   complement: "color",
-  invert: "color",
   alpha: "color",
   "adjust-color": "color",
   "scale-color": "color",

--- a/src/rules/no-global-function-names/index.js
+++ b/src/rules/no-global-function-names/index.js
@@ -74,7 +74,6 @@ const rules = {
   darken: "color",
   desaturate: "color",
   opacify: "color",
-  saturate: "color",
   transparentize: "color"
 };
 


### PR DESCRIPTION
The Sass functions should indeed be migrated to the sass:math module. But min() and max() can also be the CSS functions (and with first-class calc in Sass, it will parse it as a calculation if possible).

Closes #560
Closes #562
Closes #486