### PR TITLE
Consider the use of sass modules in at-each-key-value-single-line rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Please also see the [example configs](./docs/examples/) for special cases.
 
 ### `@`-each
 
-- [`at-each-key-value-single-line`](./src/rules/at-each-key-value-single-line/README.md): This is a rule that checks for situations where users have done a loop using map-keys and grabbed the value for that key inside of the loop.
+- [`at-each-key-value-single-line`](./src/rules/at-each-key-value-single-line/README.md): This is a rule that checks for situations where users have done a loop using map-keys or map.keys and grabbed the value for that key inside of the loop.
 
 ### `@`-else
 

--- a/src/rules/at-each-key-value-single-line/README.md
+++ b/src/rules/at-each-key-value-single-line/README.md
@@ -36,6 +36,19 @@ $font-weights: (
 }
 ```
 
+```scss
+@use 'sass:map';
+
+$font-weights: (
+  "regular": 400,
+  "medium": 500,
+  "bold": 700
+);
+@each $key in map.keys($font-weights) {
+  $value: map.get($font-weights, $key);
+}
+```
+
 The following patterns are _not_ considered violations:
 
 ```scss
@@ -61,7 +74,32 @@ $other-weights: (
 ```
 
 ```scss
-$font-weights: ("regular": 400, "medium": 500, "bold": 700);
+@use 'sass:map';
 
+$font-weights: (
+  "regular": 400,
+  "medium": 500,
+  "bold": 700
+);
+$other-weights: (
+  "regular": 400,
+  "medium": 500,
+  "bold": 700
+);
+
+@each $key, $value in map.keys($font-weights) {
+  $value: map.get($other-weights, $key);
+}
+```
+
+```scss
+$font-weights: ("regular": 400, "medium": 500, "bold": 700);
 @each $key, $value in map-keys($font-weights) {...}
+```
+
+```scss
+@use 'sass:map';
+
+$font-weights: ("regular": 400, "medium": 500, "bold": 700);
+@each $key, $value in map.keys($font-weights) {...}
 ```

--- a/src/rules/at-each-key-value-single-line/__tests__/index.js
+++ b/src/rules/at-each-key-value-single-line/__tests__/index.js
@@ -28,7 +28,16 @@ testRule({
         @each $key in map.keys($font-weights) {}
       `,
       description:
-        "Loop that just gets keys + has no need for values when using sass module with default namespace"
+        "Loop that just gets keys + has no need for values when loading sass module with default namespace"
+    },
+    {
+      code: `
+        @use "sass:map";
+        $font-weights: ("regular": 400, "medium": 500, "bold": 700);
+        @each $key in map-keys($font-weights) {}
+      `,
+      description:
+        "Loop that just gets keys + has no need for values when loading sass module with default namespace but using global function"
     },
     {
       code: `
@@ -37,7 +46,16 @@ testRule({
         @each $key in keys($font-weights) {}
       `,
       description:
-        "Loop that just gets keys + has no need for values when using sass module with no namespace"
+        "Loop that just gets keys + has no need for values when loading sass module with no namespace"
+    },
+    {
+      code: `
+        @use "sass:map" as *;
+        $font-weights: ("regular": 400, "medium": 500, "bold": 700);
+        @each $key in map-keys($font-weights) {}
+      `,
+      description:
+        "Loop that just gets keys + has no need for values when loading sass module with no namespace but using global function"
     },
     {
       code: `
@@ -46,7 +64,16 @@ testRule({
         @each $key in ns.keys($font-weights) {}
       `,
       description:
-        "Loop that just gets keys + has no need for values when using sass module with custom namespace"
+        "Loop that just gets keys + has no need for values when loading sass module with custom namespace"
+    },
+    {
+      code: `
+        @use "sass:map" as ns;
+        $font-weights: ("regular": 400, "medium": 500, "bold": 700);
+        @each $key in map-keys($font-weights) {}
+      `,
+      description:
+        "Loop that just gets keys + has no need for values when loading sass module with custom namespace but using global function"
     },
     {
       code: `
@@ -69,7 +96,19 @@ testRule({
         }
       `,
       description:
-        "map.get pattern used with different hash than loop when using sass module with default namespace"
+        "map.get pattern used with different hash than loop when loading sass module with default namespace"
+    },
+    {
+      code: `
+        @use "sass:map";
+        $font-weights: ("regular": 400, "medium": 500, "bold": 700);
+        $other-weights: ("regular": 400, "medium": 500, "bold": 700);
+        @each $key, $value in map-keys($font-weights) {
+         $value: map-get($other-weights, $key);
+        }
+      `,
+      description:
+        "map.get pattern used with different hash than loop when loading sass module with default namespace but using global function"
     },
     {
       code: `
@@ -81,7 +120,19 @@ testRule({
         }
       `,
       description:
-        "map.get pattern used with different hash than loop when using sass module with no namespace"
+        "map.get pattern used with different hash than loop when loading sass module with no namespace"
+    },
+    {
+      code: `
+        @use "sass:map" as *;
+        $font-weights: ("regular": 400, "medium": 500, "bold": 700);
+        $other-weights: ("regular": 400, "medium": 500, "bold": 700);
+        @each $key, $value in map-keys($font-weights) {
+         $value: map-get($other-weights, $key);
+        }
+      `,
+      description:
+        "map.get pattern used with different hash than loop when loading sass module with no namespace but using global function"
     },
     {
       code: `
@@ -93,7 +144,19 @@ testRule({
         }
       `,
       description:
-        "map.get pattern used with different hash than loop when using sass module with custom namespace"
+        "map.get pattern used with different hash than loop when loading sass module with custom namespace"
+    },
+    {
+      code: `
+        @use "sass:map" as ns;
+        $font-weights: ("regular": 400, "medium": 500, "bold": 700);
+        $other-weights: ("regular": 400, "medium": 500, "bold": 700);
+        @each $key, $value in map-keys($font-weights) {
+         $value: map-get($other-weights, $key);
+        }
+      `,
+      description:
+        "map.get pattern used with different hash than loop when loading sass module with custom namespace but using global function"
     }
   ],
 
@@ -119,7 +182,20 @@ testRule({
         }
       `,
       description:
-        "Loop that gets keys + then grabs values inside the map when using sass module with default namespace",
+        "Loop that gets keys + then grabs values inside the map when loading sass module with default namespace",
+      message: messages.expected,
+      line: 4
+    },
+    {
+      code: `
+        @use "sass:map";
+        $font-weights: ("regular": 400, "medium": 500, "bold": 700);
+        @each $key in map-keys($font-weights) {
+          $value: map-get($font-weights, $key);
+        }
+      `,
+      description:
+        "Loop that gets keys + then grabs values inside the map when loading sass module with default namespace but using global function",
       message: messages.expected,
       line: 4
     },
@@ -132,7 +208,20 @@ testRule({
         }
       `,
       description:
-        "Loop that gets keys + then grabs values inside the map when using sass module with no namespace",
+        "Loop that gets keys + then grabs values inside the map when loading sass module with no namespace",
+      message: messages.expected,
+      line: 4
+    },
+    {
+      code: `
+        @use "sass:map" as *;
+        $font-weights: ("regular": 400, "medium": 500, "bold": 700);
+        @each $key in map-keys($font-weights) {
+          $value: map-get($font-weights, $key);
+        }
+      `,
+      description:
+        "Loop that gets keys + then grabs values inside the map when loading sass module with no namespace but using global function",
       message: messages.expected,
       line: 4
     },
@@ -145,7 +234,20 @@ testRule({
         }
       `,
       description:
-        "Loop that gets keys + then grabs values inside the map when using sass module with custom namespace",
+        "Loop that gets keys + then grabs values inside the map when loading sass module with custom namespace",
+      message: messages.expected,
+      line: 4
+    },
+    {
+      code: `
+        @use "sass:map" as ns;
+        $font-weights: ("regular": 400, "medium": 500, "bold": 700);
+        @each $key in map-keys($font-weights) {
+          $value: map-get($font-weights, $key);
+        }
+      `,
+      description:
+        "Loop that gets keys + then grabs values inside the map when loading sass module with custom namespace but using global function",
       message: messages.expected,
       line: 4
     }

--- a/src/rules/at-each-key-value-single-line/__tests__/index.js
+++ b/src/rules/at-each-key-value-single-line/__tests__/index.js
@@ -8,42 +8,146 @@ testRule({
   accept: [
     {
       code: `
-      $font-weights: ("regular": 400, "medium": 500, "bold": 700);
-      @each $key, $value in $font-weights {}
+        $font-weights: ("regular": 400, "medium": 500, "bold": 700);
+        @each $key, $value in $font-weights {}
       `,
       description: "Proper map loop that gets both keys + values"
     },
     {
       code: `
-      $font-weights: ("regular": 400, "medium": 500, "bold": 700);
-      @each $key in map-keys($font-weights) {}
+        $font-weights: ("regular": 400, "medium": 500, "bold": 700);
+        @each $key in map-keys($font-weights) {}
       `,
-      description: "Loop that just gets keys + has no need for values"
+      description:
+        "Loop that just gets keys + has no need for values when using global function"
     },
     {
       code: `
-       $font-weights: ("regular": 400, "medium": 500, "bold": 700);
-       $other-weights: ("regular": 400, "medium": 500, "bold": 700);
-
-       @each $key, $value in map-keys($font-weights) {
-         $value: map-get($other-weights, $key);
-       }
+        @use "sass:map";
+        $font-weights: ("regular": 400, "medium": 500, "bold": 700);
+        @each $key in map.keys($font-weights) {}
       `,
-      description: "map-get pattern used with different hash than loop"
+      description:
+        "Loop that just gets keys + has no need for values when using sass module with default namespace"
+    },
+    {
+      code: `
+        @use "sass:map" as *;
+        $font-weights: ("regular": 400, "medium": 500, "bold": 700);
+        @each $key in keys($font-weights) {}
+      `,
+      description:
+        "Loop that just gets keys + has no need for values when using sass module with no namespace"
+    },
+    {
+      code: `
+        @use "sass:map" as ns;
+        $font-weights: ("regular": 400, "medium": 500, "bold": 700);
+        @each $key in ns.keys($font-weights) {}
+      `,
+      description:
+        "Loop that just gets keys + has no need for values when using sass module with custom namespace"
+    },
+    {
+      code: `
+        $font-weights: ("regular": 400, "medium": 500, "bold": 700);
+        $other-weights: ("regular": 400, "medium": 500, "bold": 700);
+        @each $key, $value in map-keys($font-weights) {
+         $value: map-get($other-weights, $key);
+        }
+      `,
+      description:
+        "map-get pattern used with different hash than loop when using global function"
+    },
+    {
+      code: `
+        @use "sass:map";
+        $font-weights: ("regular": 400, "medium": 500, "bold": 700);
+        $other-weights: ("regular": 400, "medium": 500, "bold": 700);
+        @each $key, $value in map.keys($font-weights) {
+         $value: map.get($other-weights, $key);
+        }
+      `,
+      description:
+        "map.get pattern used with different hash than loop when using sass module with default namespace"
+    },
+    {
+      code: `
+        @use "sass:map" as *;
+        $font-weights: ("regular": 400, "medium": 500, "bold": 700);
+        $other-weights: ("regular": 400, "medium": 500, "bold": 700);
+        @each $key, $value in keys($font-weights) {
+         $value: get($other-weights, $key);
+        }
+      `,
+      description:
+        "map.get pattern used with different hash than loop when using sass module with no namespace"
+    },
+    {
+      code: `
+        @use "sass:map" as ns;
+        $font-weights: ("regular": 400, "medium": 500, "bold": 700);
+        $other-weights: ("regular": 400, "medium": 500, "bold": 700);
+        @each $key, $value in ns.keys($font-weights) {
+         $value: ns.get($other-weights, $key);
+        }
+      `,
+      description:
+        "map.get pattern used with different hash than loop when using sass module with custom namespace"
     }
   ],
 
   reject: [
     {
       code: `
-      $font-weights: ("regular": 400, "medium": 500, "bold": 700);
-      @each $key in map-keys($font-weights) {
-        $value: map-get($font-weights, $key);
-      }
+        $font-weights: ("regular": 400, "medium": 500, "bold": 700);
+        @each $key in map-keys($font-weights) {
+          $value: map-get($font-weights, $key);
+        }
       `,
-      description: "Loop that gets keys + then grabs values inside the map",
+      description:
+        "Loop that gets keys + then grabs values inside the map when using global function",
       message: messages.expected,
       line: 3
+    },
+    {
+      code: `
+        @use "sass:map";
+        $font-weights: ("regular": 400, "medium": 500, "bold": 700);
+        @each $key in map.keys($font-weights) {
+          $value: map.get($font-weights, $key);
+        }
+      `,
+      description:
+        "Loop that gets keys + then grabs values inside the map when using sass module with default namespace",
+      message: messages.expected,
+      line: 4
+    },
+    {
+      code: `
+        @use "sass:map" as *;
+        $font-weights: ("regular": 400, "medium": 500, "bold": 700);
+        @each $key in keys($font-weights) {
+          $value: get($font-weights, $key);
+        }
+      `,
+      description:
+        "Loop that gets keys + then grabs values inside the map when using sass module with no namespace",
+      message: messages.expected,
+      line: 4
+    },
+    {
+      code: `
+        @use "sass:map" as ns;
+        $font-weights: ("regular": 400, "medium": 500, "bold": 700);
+        @each $key in ns.keys($font-weights) {
+          $value: ns.get($font-weights, $key);
+        }
+      `,
+      description:
+        "Loop that gets keys + then grabs values inside the map when using sass module with custom namespace",
+      message: messages.expected,
+      line: 4
     }
   ]
 });

--- a/src/rules/at-each-key-value-single-line/index.js
+++ b/src/rules/at-each-key-value-single-line/index.js
@@ -77,17 +77,13 @@ function separateEachParams(paramString) {
 }
 
 function didCallMapKeys(mapDecl, mapNamespace) {
-  const pattern = getNamespacedPattern("keys\\(.*\\)", mapNamespace, mapDecl);
+  const pattern = getNamespacedPattern("keys\\(.*\\)", mapNamespace);
 
   return new RegExp(pattern).test(mapDecl);
 }
 
 function didCallMapGet(mapDecl, mapNamespace) {
-  const pattern = getNamespacedPattern(
-    "get\\((.*),(.*)\\)",
-    mapNamespace,
-    mapDecl
-  );
+  const pattern = getNamespacedPattern("get\\((.*),(.*)\\)", mapNamespace);
 
   return new RegExp(pattern).test(mapDecl);
 }
@@ -95,11 +91,7 @@ function didCallMapGet(mapDecl, mapNamespace) {
 // Fetch the name of the map from a map-keys() or map.keys() call.
 function mapName(mapDecl, mapNamespace) {
   if (didCallMapKeys(mapDecl, mapNamespace)) {
-    const pattern = getNamespacedPattern(
-      "keys\\((.*)\\)",
-      mapNamespace,
-      mapDecl
-    );
+    const pattern = getNamespacedPattern("keys\\((.*)\\)", mapNamespace);
 
     return mapDecl.match(new RegExp(pattern))[1];
   }
@@ -110,26 +102,12 @@ function mapName(mapDecl, mapNamespace) {
 // Returns the parameters of a map-get or map.get call
 // Returns [map variable, key_variable]
 function mapGetParameters(mapGetDecl, mapNamespace) {
-  const pattern = getNamespacedPattern(
-    "get\\((.*), ?(.*)\\)",
-    mapNamespace,
-    mapGetDecl
-  );
+  const pattern = getNamespacedPattern("get\\((.*), ?(.*)\\)", mapNamespace);
   const parts = mapGetDecl.match(new RegExp(pattern));
 
   return [parts[1], parts[2]];
 }
 
-function getNamespacedPattern(pattern, namespace, decl) {
-  if (namespace === null) {
-    return `map[-.]${pattern}`;
-  }
-
-  if (namespace === "*") {
-    return pattern;
-  }
-
-  return new RegExp(`${namespace}.${pattern}`).test(decl)
-    ? `${namespace}.${pattern}`
-    : `map-${pattern}`;
+function getNamespacedPattern(pattern, namespace) {
+  return namespace !== null ? `(?:${namespace}\\.|map-)${pattern}` : pattern;
 }

--- a/src/rules/at-each-key-value-single-line/index.js
+++ b/src/rules/at-each-key-value-single-line/index.js
@@ -1,5 +1,5 @@
 import { utils } from "stylelint";
-import { namespace } from "../../utils";
+import { namespace, moduleNamespace } from "../../utils";
 
 export const ruleName = namespace("at-each-key-value-single-line");
 
@@ -18,6 +18,8 @@ export default function(primary) {
       return;
     }
 
+    const mapNamespace = moduleNamespace(root, "sass:map");
+
     root.walkAtRules("each", rule => {
       const parts = separateEachParams(rule.params);
 
@@ -27,7 +29,7 @@ export default function(primary) {
       }
 
       // If didn't call map-keys, return.
-      if (!didCallMapKeys(parts[1])) {
+      if (!didCallMapKeys(parts[1], mapNamespace)) {
         return;
       }
 
@@ -38,15 +40,15 @@ export default function(primary) {
           return;
         }
 
-        if (!didCallMapGet(innerDecl.value)) {
+        if (!didCallMapGet(innerDecl.value, mapNamespace)) {
           return;
         }
 
         // Check map_name + key_name match.
-        const map_get_parts = mapGetParameters(innerDecl.value);
+        const map_get_parts = mapGetParameters(innerDecl.value, mapNamespace);
 
         // Check map names match.
-        if (map_get_parts[0] !== mapName(parts[1])) {
+        if (map_get_parts[0] !== mapName(parts[1], mapNamespace)) {
           return;
         }
 
@@ -74,27 +76,45 @@ function separateEachParams(paramString) {
   return [parts[0].split(",").map(s => s.trim()), parts[1].trim()];
 }
 
-function didCallMapKeys(map_decl) {
-  return map_decl.match(/map-keys\(.*\)/);
+function didCallMapKeys(mapDecl, mapNamespace) {
+  const pattern = getNamespacedPattern("keys\\(.*\\)", mapNamespace);
+
+  return new RegExp(pattern).test(mapDecl);
 }
 
-function didCallMapGet(map_decl) {
-  return map_decl.match(/map-get\((.*),(.*)\)/);
+function didCallMapGet(mapDecl, mapNamespace) {
+  const pattern = getNamespacedPattern("get\\((.*),(.*)\\)", mapNamespace);
+
+  return new RegExp(pattern).test(mapDecl);
 }
 
-// Fetch the name of the map from a map-keys() call.
-function mapName(map_decl) {
-  if (didCallMapKeys(map_decl)) {
-    return map_decl.match(/map-keys\((.*)\)/)[1];
-  } else {
-    return map_decl;
+// Fetch the name of the map from a map-keys() or map.keys() call.
+function mapName(mapDecl, mapNamespace) {
+  if (didCallMapKeys(mapDecl, mapNamespace)) {
+    const pattern = getNamespacedPattern("keys\\((.*)\\)", mapNamespace);
+
+    return mapDecl.match(new RegExp(pattern))[1];
   }
+
+  return mapDecl;
 }
 
-// Returns the parameters of a map-get call
+// Returns the parameters of a map-get or map.get call
 // Returns [map variable, key_variable]
-function mapGetParameters(mapGetDecl) {
-  const parts = mapGetDecl.match(/map-get\((.*), ?(.*)\)/);
+function mapGetParameters(mapGetDecl, mapNamespace) {
+  const pattern = getNamespacedPattern("get\\((.*), ?(.*)\\)", mapNamespace);
+  const parts = mapGetDecl.match(new RegExp(pattern));
 
   return [parts[1], parts[2]];
+}
+
+function getNamespacedPattern(pattern, mapNamespace) {
+  switch (mapNamespace) {
+    case "*":
+      return pattern;
+    case null:
+      return `map[-.]${pattern}`;
+  }
+
+  return `${mapNamespace}[-.]${pattern}`;
 }

--- a/src/utils/__tests__/moduleNamespace.test.js
+++ b/src/utils/__tests__/moduleNamespace.test.js
@@ -1,0 +1,26 @@
+import postcss from "postcss";
+import { moduleNamespace } from "../moduleNamespace";
+
+describe("moduleNamespace", () => {
+  it("should return null when module import was not found", () => {
+    expect(getModuleNamespace("@use 'sass:color';", "sass:map")).toBeNull();
+  });
+
+  it("should return null on default namespace", () => {
+    expect(getModuleNamespace("@use 'sass:map';", "sass:map")).toBeNull();
+  });
+
+  it("should return '*' on no namespace", () => {
+    expect(getModuleNamespace("@use 'sass:map' as *;", "sass:map")).toBe("*");
+  });
+
+  it("should return 'ns' on custom namespace", () => {
+    expect(getModuleNamespace("@use 'sass:map' as ns;", "sass:map")).toBe("ns");
+  });
+});
+
+function getModuleNamespace(css, module) {
+  const root = postcss.parse(css);
+
+  return moduleNamespace(root, module);
+}

--- a/src/utils/__tests__/moduleNamespace.test.js
+++ b/src/utils/__tests__/moduleNamespace.test.js
@@ -2,40 +2,61 @@ import postcss from "postcss";
 import { moduleNamespace } from "../moduleNamespace";
 
 describe("moduleNamespace", () => {
-  it("should return null when module import was not found", () => {
-    expect(getModuleNamespace("@use 'sass:color';", "sass:map")).toBeNull();
+  it("should return 'map' when module import was not found", () => {
+    expect(getModuleNamespace("@use 'sass:color';", "sass:map")).toBe("map");
   });
 
-  it("should return null on default namespace", () => {
-    expect(getModuleNamespace("@use 'sass:map';", "sass:map")).toBeNull();
+  it("should return 'map' on default namespace", () => {
+    expect(getModuleNamespace("@use 'sass:map';", "sass:map")).toBe("map");
   });
 
-  it("should return null on default namespace using 'with'", () => {
-    expect(
-      getModuleNamespace("@use 'sass:map' with ();", "sass:map")
-    ).toBeNull();
+  it("should return 'map' on default namespace using 'with'", () => {
+    expect(getModuleNamespace("@use 'sass:map' with ();", "sass:map")).toBe(
+      "map"
+    );
   });
 
-  it("should return null on default namespace using 'with' and multiple spaces", () => {
-    expect(
-      getModuleNamespace("@use  'sass:map'  with  ();", "sass:map")
-    ).toBeNull();
+  it("should return 'map' on default namespace using 'with' (with multiple spaces)", () => {
+    expect(getModuleNamespace("@use  'sass:map'  with  ();", "sass:map")).toBe(
+      "map"
+    );
   });
 
-  it("should return '*' on no namespace", () => {
-    expect(getModuleNamespace("@use 'sass:map' as *;", "sass:map")).toBe("*");
+  it("should return null on no namespace", () => {
+    expect(getModuleNamespace("@use 'sass:map' as *;", "sass:map")).toBeNull();
   });
 
-  it("should return '*' on no namespace using 'with'", () => {
+  it("should return null on no namespace using 'with'", () => {
     expect(
       getModuleNamespace("@use 'sass:map' as * with ();", "sass:map")
-    ).toBe("*");
+    ).toBeNull();
   });
 
-  it("should return '*' on no namespace using 'with' and multiple spaces", () => {
+  it("should return null on no namespace using 'with' (with multiple spaces)", () => {
     expect(
       getModuleNamespace("@use  'sass:map'  as  *  with  ();", "sass:map")
-    ).toBe("*");
+    ).toBeNull();
+  });
+
+  it("should return null on no namespace using 'with' (without spaces)", () => {
+    expect(
+      getModuleNamespace("@use 'sass:map'as*with ();", "sass:map")
+    ).toBeNull();
+  });
+
+  it("should return null on no namespace using 'with' (without spaces, with line breaks)", () => {
+    expect(
+      getModuleNamespace("@use\n'sass:map'\nas\n*\nwith\n();", "sass:map")
+    ).toBeNull();
+  });
+
+  it("should return null on no namespace using 'with' (with multiple spaces, with line breaks)", () => {
+    expect(
+      getModuleNamespace(
+        "@use  \n  'sass:map'  \n  as  \n  *  \n  with  \n  ();",
+        "sass:map"
+      )
+    ).toBeNull();
   });
 
   it("should return 'ns' on custom namespace", () => {
@@ -48,9 +69,105 @@ describe("moduleNamespace", () => {
     ).toBe("ns");
   });
 
-  it("should return 'ns' on custom namespace using 'with' and multiple spaces", () => {
+  it("should return 'ns' on custom namespace using 'with' (with multiple spaces)", () => {
     expect(
       getModuleNamespace("@use  'sass:map'  as  ns  with  ();", "sass:map")
+    ).toBe("ns");
+  });
+
+  it("should return 'ns' on custom namespace using 'with' (with multiple spaces, with line breaks)", () => {
+    expect(
+      getModuleNamespace(
+        "@use  \n \n  'sass:map'  \n \n  as  \n \n  ns  \n \n  with  \n \n  ();",
+        "sass:map"
+      )
+    ).toBe("ns");
+  });
+
+  it("should return 'custom-module' when module import is 'custom-module'", () => {
+    expect(getModuleNamespace("@use 'custom-module';", "custom-module")).toBe(
+      "custom-module"
+    );
+  });
+
+  it("should return 'custom-module' when module import is 'custom-module' using 'with'", () => {
+    expect(
+      getModuleNamespace("@use 'custom-module' with ();", "custom-module")
+    ).toBe("custom-module");
+  });
+
+  it("should return 'custom-module' when module import is 'custom-module.scss'", () => {
+    expect(
+      getModuleNamespace("@use 'custom-module.scss';", "custom-module.scss")
+    ).toBe("custom-module");
+  });
+
+  it("should return 'custom-module' when module import is 'custom-module.scss' using 'with'", () => {
+    expect(
+      getModuleNamespace(
+        "@use 'custom-module.scss' with ();",
+        "custom-module.scss"
+      )
+    ).toBe("custom-module");
+  });
+
+  it("should return 'custom-module' when module import is 'path/to/custom-module'", () => {
+    expect(
+      getModuleNamespace(
+        "@use 'path/to/custom-module';",
+        "path/to/custom-module"
+      )
+    ).toBe("custom-module");
+  });
+
+  it("should return 'custom-module' when module import is 'path/to/custom-module' using with ()", () => {
+    expect(
+      getModuleNamespace(
+        "@use 'path/to/custom-module' with ();",
+        "path/to/custom-module"
+      )
+    ).toBe("custom-module");
+  });
+
+  it("should return 'custom-module' when module import is 'path/to/custom-module.scss'", () => {
+    expect(
+      getModuleNamespace(
+        "@use 'path/to/custom-module.scss';",
+        "path/to/custom-module.scss"
+      )
+    ).toBe("custom-module");
+  });
+
+  it("should return 'custom-module' when module import is 'path/to/custom-module.scss' using 'with'", () => {
+    expect(
+      getModuleNamespace(
+        "@use 'path/to/custom-module.scss' with ();",
+        "path/to/custom-module.scss"
+      )
+    ).toBe("custom-module");
+  });
+
+  it("should return `null` on no namespace when module import is 'custom-module'", () => {
+    expect(
+      getModuleNamespace("@use 'custom-module' as *;", "custom-module")
+    ).toBeNull();
+  });
+
+  it("should return `null` on no namespace when module import is 'custom-module' using 'with'", () => {
+    expect(
+      getModuleNamespace("@use 'custom-module' as * with ();", "custom-module")
+    ).toBeNull();
+  });
+
+  it("should return 'ns' on custom namespace when module import is 'custom-module'", () => {
+    expect(
+      getModuleNamespace("@use 'custom-module' as ns;", "custom-module")
+    ).toBe("ns");
+  });
+
+  it("should return 'ns' on custom namespace when module import is 'custom-module' using 'with'", () => {
+    expect(
+      getModuleNamespace("@use 'custom-module' as ns with ();", "custom-module")
     ).toBe("ns");
   });
 });

--- a/src/utils/__tests__/moduleNamespace.test.js
+++ b/src/utils/__tests__/moduleNamespace.test.js
@@ -10,12 +10,48 @@ describe("moduleNamespace", () => {
     expect(getModuleNamespace("@use 'sass:map';", "sass:map")).toBeNull();
   });
 
+  it("should return null on default namespace using 'with'", () => {
+    expect(
+      getModuleNamespace("@use 'sass:map' with ();", "sass:map")
+    ).toBeNull();
+  });
+
+  it("should return null on default namespace using 'with' and multiple spaces", () => {
+    expect(
+      getModuleNamespace("@use  'sass:map'  with  ();", "sass:map")
+    ).toBeNull();
+  });
+
   it("should return '*' on no namespace", () => {
     expect(getModuleNamespace("@use 'sass:map' as *;", "sass:map")).toBe("*");
   });
 
+  it("should return '*' on no namespace using 'with'", () => {
+    expect(
+      getModuleNamespace("@use 'sass:map' as * with ();", "sass:map")
+    ).toBe("*");
+  });
+
+  it("should return '*' on no namespace using 'with' and multiple spaces", () => {
+    expect(
+      getModuleNamespace("@use  'sass:map'  as  *  with  ();", "sass:map")
+    ).toBe("*");
+  });
+
   it("should return 'ns' on custom namespace", () => {
     expect(getModuleNamespace("@use 'sass:map' as ns;", "sass:map")).toBe("ns");
+  });
+
+  it("should return 'ns' on custom namespace using 'with'", () => {
+    expect(
+      getModuleNamespace("@use 'sass:map' as ns with ();", "sass:map")
+    ).toBe("ns");
+  });
+
+  it("should return 'ns' on custom namespace using 'with' and multiple spaces", () => {
+    expect(
+      getModuleNamespace("@use  'sass:map'  as  ns  with  ();", "sass:map")
+    ).toBe("ns");
   });
 });
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -29,3 +29,4 @@ export { default as findOperators } from "./sassValueParser";
 export { default as whitespaceChecker } from "./whitespaceChecker";
 export { default as hasNestedSibling } from "./hasNestedSibling";
 export { default as isType } from "./isType";
+export { moduleNamespace } from "./moduleNamespace";

--- a/src/utils/moduleNamespace.js
+++ b/src/utils/moduleNamespace.js
@@ -1,0 +1,39 @@
+/**
+ * Returns the namespace of an imported module or `null` if missing.
+ *
+ * Example: no import found, possibly using global function
+ * `@use "sass:color";`
+ * `moduleNamespace(root, 'sass:map')` returns `null`
+ *
+ * Example: default namespace
+ * `@use "sass:map";`
+ * `moduleNamespace(root, 'sass:map')` returns `null`
+ *
+ * Example: no namespace
+ * `@use "sass:map" as *;`
+ * `moduleNamespace(root, 'sass:map')` returns '*'
+ *
+ * Example: custom namespace
+ * `@use "sass:map" as ns;`
+ * `moduleNamespace(root, 'sass:map')` returns 'ns'
+ */
+export function moduleNamespace(root, module) {
+  const regExp = new RegExp(`["']${module}["']`);
+  let moduleNamespace = null;
+
+  root.walkAtRules("use", rule => {
+    if (!regExp.test(rule.params)) {
+      return;
+    }
+
+    const parts = rule.params.split(" as ");
+
+    if (parts.length < 2) {
+      return;
+    }
+
+    moduleNamespace = parts[1].trim();
+  });
+
+  return moduleNamespace;
+}

--- a/src/utils/moduleNamespace.js
+++ b/src/utils/moduleNamespace.js
@@ -1,42 +1,60 @@
 /**
- * Returns the namespace of an imported module or `null` if missing.
+ * Returns the namespace of an imported module or `null` if the namespace is removed.
  *
  * Example: no import found, possibly using global function
  * `@use "sass:color";`
- * `moduleNamespace(root, 'sass:map')` returns `null`
+ * `moduleNamespace(root, 'sass:map')` returns 'map'
  *
  * Example: default namespace
  * `@use "sass:map";`
- * `moduleNamespace(root, 'sass:map')` returns `null`
- *
- * Example: no namespace
- * `@use "sass:map" as *;`
- * `moduleNamespace(root, 'sass:map')` returns '*'
+ * `moduleNamespace(root, 'sass:map')` returns `map`
  *
  * Example: custom namespace
  * `@use "sass:map" as ns;`
  * `moduleNamespace(root, 'sass:map')` returns 'ns'
+ *
+ * Example: no namespace
+ * `@use "sass:map" as *;`
+ * `moduleNamespace(root, 'sass:map')` returns `null`
+ *
+ * Have a look at the tests for more examples.
  */
 export function moduleNamespace(root, module) {
-  const regExp = new RegExp(`["']${module}["']`);
-  let moduleNamespace = null;
+  let moduleNamespace = getDefaultNamespace(module);
 
   root.walkAtRules("use", rule => {
-    if (!regExp.test(rule.params)) {
-      return;
+    const customNamespace = getCustomNamespace(module, rule);
+
+    switch (customNamespace) {
+      case null:
+        return;
+      case "*":
+        moduleNamespace = null;
+        return;
+      default:
+        moduleNamespace = customNamespace;
     }
-
-    const parts = rule.params.split(" as ");
-
-    if (parts.length < 2) {
-      return;
-    }
-
-    moduleNamespace = parts[1]
-      .trim()
-      .split(" ")[0]
-      .trim();
   });
 
   return moduleNamespace;
+}
+
+function getDefaultNamespace(module) {
+  return module.match(/([^/:]+)$/)[1].replace(/\.[^.]+$/, "");
+}
+
+function getCustomNamespace(module, rule) {
+  const ruleParamsParts = rule.params.split(
+    new RegExp(`["']${module}['"][ \n]*as`)
+  );
+
+  if (ruleParamsParts.length < 2) {
+    return null;
+  }
+
+  const secondRuleParamsPart = ruleParamsParts[1].trim();
+
+  return !secondRuleParamsPart.startsWith("*")
+    ? secondRuleParamsPart.split(" ")[0]
+    : "*";
 }

--- a/src/utils/moduleNamespace.js
+++ b/src/utils/moduleNamespace.js
@@ -32,7 +32,10 @@ export function moduleNamespace(root, module) {
       return;
     }
 
-    moduleNamespace = parts[1].trim();
+    moduleNamespace = parts[1]
+      .trim()
+      .split(" ")[0]
+      .trim();
   });
 
   return moduleNamespace;


### PR DESCRIPTION
The `at-each-key-value-single-line` rule does not report an error when set to `true` and using sass modules.

This should fail but it doesn't:
```scss
@use 'sass:map';

$font-weights: ("regular": 400, "medium": 500, "bold": 700);
@each $key in map.keys($font-weights) {
  $value: map.get($font-weights, $key);
}
```

This pull request changes the rule to take the use of sass modules into account.