### PR TITLE
Add options ignore: "after-dollar-variable" to dollar-variable-empty-…

### DIFF
--- a/src/rules/dollar-variable-empty-line-before/__tests__/index.js
+++ b/src/rules/dollar-variable-empty-line-before/__tests__/index.js
@@ -346,6 +346,101 @@ testRule({
   ]
 });
 
+// Ignore: after-dollar-variable
+// --------------------------------------------------------------------------
+
+testRule({
+  ruleName,
+  config: ["always", { ignore: "after-dollar-variable" }],
+  customSyntax: "postcss-scss",
+  fix: true,
+
+  accept: [
+    {
+      code: `
+      $var1: 100px;
+      $var2: 200px;
+    `,
+      description:
+        "always, { ignore: after-dollar-variable }. $var after $var, no empty line."
+    },
+    {
+      code: `
+      $var1: 100px;
+
+      $var2: 200px;
+    `,
+      description:
+        "always, { ignore: after-dollar-variable }. $var after $var, has empty line."
+    }
+  ],
+
+  reject: [
+    {
+      code: `
+      width: 1;
+      $var2: 2;
+    `,
+      fixed: `
+      width: 1;
+
+      $var2: 2;
+    `,
+      description:
+        "always, { ignore: after-dollar-variable }. No $var directly before $var, no empty line.",
+      message: messages.expected,
+      line: 3,
+      column: 7
+    }
+  ]
+});
+
+testRule({
+  ruleName,
+  config: ["never", { ignore: "after-dollar-variable" }],
+  customSyntax: "postcss-scss",
+  fix: true,
+
+  accept: [
+    {
+      code: `
+      $var1: 100px;
+      $var2: 200px;
+    `,
+      description:
+        "never, { ignore: after-dollar-variable }. $var after $var, no empty line."
+    },
+    {
+      code: `
+      $var1: 100px;
+
+      $var2: 200px;
+    `,
+      description:
+        "never, { ignore: after-dollar-variable }. $var after $var, has empty line."
+    }
+  ],
+
+  reject: [
+    {
+      code: `
+      width: 1;
+
+      $var2: 2;
+    `,
+      fixed: `
+      width: 1;
+      $var2: 2;
+    `,
+      description:
+        "never, { ignore: after-dollar-variable }. No $var directly before $var, has empty line.",
+      message: messages.rejected,
+      line: 4,
+      column: 7
+    }
+  ]
+});
+
 // Except: first-nested
 // --------------------------------------------------------------------------
 

--- a/src/rules/dollar-variable-empty-line-before/index.js
+++ b/src/rules/dollar-variable-empty-line-before/index.js
@@ -29,7 +29,11 @@ export default function(expectation, options, context) {
         actual: options,
         possible: {
           except: ["first-nested", "after-comment", "after-dollar-variable"],
-          ignore: ["after-comment", "inside-single-line-block"],
+          ignore: [
+            "after-comment",
+            "inside-single-line-block",
+            "after-dollar-variable"
+          ],
           disableFix: isBoolean
         },
         optional: true
@@ -73,6 +77,15 @@ export default function(expectation, options, context) {
         optionsHaveIgnored(options, "inside-single-line-block") &&
         decl.parent.type !== "root" &&
         isSingleLineString(blockString(decl.parent))
+      ) {
+        return;
+      }
+
+      // if ignoring after another $-variable
+      if (
+        optionsHaveIgnored(options, "after-dollar-variable") &&
+        decl.prev() &&
+        isDollarVar(decl.prev())
       ) {
         return;
       }


### PR DESCRIPTION
This PR fix #603 to support:

```scss
$vxp-color-primary: #339af0;
$vxp-color-info: #3bc9db;

$vxp-border-radius; 4px;
$vxp-border-radius-large: 6px;
```