### PR TITLE
Make `scss/comment-no-empty` treat multiline double-slash comments as blocks

### DIFF
--- a/src/rules/comment-no-empty/__tests__/index.js
+++ b/src/rules/comment-no-empty/__tests__/index.js
@@ -17,6 +17,33 @@ testRule({
     {
       code: "/* comment */",
       description: "Single line block comment"
+    },
+    {
+      code: `
+        // comment
+        //
+        // comment
+      `,
+      description: "Multiline double slash comment with paragraph break"
+    },
+    {
+      code: `
+        //
+        //
+        // comment
+        //
+        //
+      `,
+      description:
+        "Multiline double slash comment with leading and trailing empty lines"
+    },
+    {
+      code: `
+        /* comment
+
+           comment */
+      `,
+      description: "Multiline block comment with paragraph break"
     }
   ],
   reject: [
@@ -38,6 +65,34 @@ testRule({
       message: messages.rejected,
       line: 2,
       column: 9
+    },
+    {
+      code: `
+        //
+        //
+        //
+      `,
+      description: "Empty multiline double slash comment",
+      message: messages.rejected,
+      line: 2 // note, should be just one error at first line
+    },
+    {
+      code: `
+        //
+        width: 100px; // comment
+      `,
+      description: "Empty double slash comment with trailing inline comment",
+      message: messages.rejected,
+      line: 2
+    },
+    {
+      code: `
+        width: 100px; // comment
+        //
+      `,
+      description: "Empty double slash comment with preceding inline comment",
+      message: messages.rejected,
+      line: 3
     },
     {
       code: `

--- a/src/rules/comment-no-empty/index.js
+++ b/src/rules/comment-no-empty/index.js
@@ -69,7 +69,6 @@ function rule(primary) {
 
 function isStandaloneDoubleSlashComment(node) {
   return (
-    // Must be a comment
     node &&
     node.type === "comment" &&
     // Must be a double-slash comment

--- a/src/rules/comment-no-empty/index.js
+++ b/src/rules/comment-no-empty/index.js
@@ -1,5 +1,5 @@
 import { rules, utils } from "stylelint";
-import { namespace } from "../../utils";
+import { isInlineComment, namespace } from "../../utils";
 
 const coreRuleName = "comment-no-empty";
 
@@ -22,17 +22,61 @@ function rule(primary) {
       return;
     }
 
+    let doubleSlashCommentBlockState = null;
+
     root.walkComments(comment => {
-      if (isEmptyComment(comment)) {
-        utils.report({
-          message: messages.rejected,
-          node: comment,
-          result,
-          ruleName
-        });
+      const isEmpty = isEmptyComment(comment);
+
+      // postcss considers multiple double-slash comments in a row to be separate comments,
+      // but for this rule's purposes we want to track them as one combined comment block.
+      if (isStandaloneDoubleSlashComment(comment)) {
+        doubleSlashCommentBlockState = {
+          firstCommentInBlock: doubleSlashCommentBlockState
+            ? doubleSlashCommentBlockState.firstCommentInBlock
+            : comment,
+          isBlockEmptySoFar:
+            isEmpty &&
+            (!doubleSlashCommentBlockState ||
+              doubleSlashCommentBlockState.isBlockEmptySoFar)
+        };
+
+        if (!isStandaloneDoubleSlashComment(comment.next())) {
+          if (doubleSlashCommentBlockState.isBlockEmptySoFar) {
+            utils.report({
+              message: messages.rejected,
+              node: doubleSlashCommentBlockState.firstCommentInBlock,
+              result,
+              ruleName
+            });
+          }
+          doubleSlashCommentBlockState = null;
+          return;
+        }
+      } else {
+        doubleSlashCommentBlockState = null;
+        if (isEmptyComment(comment)) {
+          utils.report({
+            message: messages.rejected,
+            node: comment,
+            result,
+            ruleName
+          });
+        }
       }
     });
   };
+}
+
+function isStandaloneDoubleSlashComment(node) {
+  return (
+    // Must be a comment
+    node &&
+    node.type === "comment" &&
+    // Must be a double-slash comment
+    (node.raws.inline || node.inline) &&
+    // Must be standalone
+    !isInlineComment(node)
+  );
 }
 
 function isEmptyComment(comment) {


### PR DESCRIPTION
Proposed fix for #606

I've never contributed to a stylelint rule before, so apologies if I've made any structural mistakes here. In particular, I felt a bit uncertain about adding state that persists between different calls to the `walkComments` callback, since I didn't see other examples of rules doing that, but it seemed like the most straightforward way to solve the problem.

The logic for determining whether a given comment is double-slash vs not and standalone vs not is taken from the examples on L44-51 of `src/rules/double-slash-comment-empty-line-before/index.js`.