### PR TITLE
Add `at-import-partial-extension` autofix only when `"never"`

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Please also see the [example configs](./docs/examples/) for special cases.
 ### `@`-import
 
 - [`at-import-no-partial-leading-underscore`](./src/rules/at-import-no-partial-leading-underscore/README.md): Disallow leading underscore in partial names in `@import`.
-- [`at-import-partial-extension`](./src/rules/at-import-partial-extension/README.md): Require or disallow extension in `@import` commands.
+- [`at-import-partial-extension`](./src/rules/at-import-partial-extension/README.md): Require or disallow extension in `@import` commands (Autofixable).
 - [`at-import-partial-extension-blacklist`](./src/rules/at-import-partial-extension-blacklist/README.md): Specify blacklist of disallowed file extensions for partial names in `@import` commands.
 - [`at-import-partial-extension-whitelist`](./src/rules/at-import-partial-extension-whitelist/README.md): Specify whitelist of allowed file extensions for partial names in `@import` commands.
 

--- a/src/rules/at-import-partial-extension/README.md
+++ b/src/rules/at-import-partial-extension/README.md
@@ -8,6 +8,8 @@ Require or disallow extension in `@import` commands.
  * This extension */
 ```
 
+The [`fix` option](https://stylelint.io/user-guide/usage/options#fix) can automatically fix all of the problems reported by this rule only when `"never"` is given.
+
 The rule ignores [cases](https://sass-lang.com/documentation/at-rules/import) when Sass considers an `@import` command just a plain CSS import:
 
 - If the file’s extension is `.css`.

--- a/src/rules/at-import-partial-extension/__tests__/index.js
+++ b/src/rules/at-import-partial-extension/__tests__/index.js
@@ -182,6 +182,7 @@ testRule({
   ruleName,
   config: ["never"],
   customSyntax: "postcss-scss",
+  fix: true,
 
   accept: [
     {
@@ -300,7 +301,10 @@ testRule({
     {
       code: `
       @import "fff.scss";
-    `,
+     `,
+      fixed: `
+      @import "fff";
+     `,
       line: 2,
       column: 20,
       message: messages.rejected("scss"),
@@ -309,6 +313,9 @@ testRule({
     {
       code: `
       @import "screen.scss";
+    `,
+      fixed: `
+      @import "screen";
     `,
       line: 2,
       column: 23,
@@ -319,6 +326,9 @@ testRule({
       code: `
       @import "fff.scss ";
     `,
+      fixed: `
+      @import "fff ";
+    `,
       line: 2,
       column: 20,
       message: messages.rejected("scss"),
@@ -327,6 +337,9 @@ testRule({
     {
       code: `
       @import " fff.scss ";
+    `,
+      fixed: `
+      @import " fff ";
     `,
       line: 2,
       column: 21,
@@ -337,6 +350,9 @@ testRule({
       code: `
       @import "df/fff.scss";
     `,
+      fixed: `
+      @import "df/fff";
+    `,
       line: 2,
       column: 23,
       message: messages.rejected("scss"),
@@ -345,6 +361,9 @@ testRule({
     {
       code: `
       @import "df\\fff.scss";
+    `,
+      fixed: `
+      @import "df\\fff";
     `,
       line: 2,
       column: 23,
@@ -355,6 +374,9 @@ testRule({
     {
       code: `
       @import "df/fff", '_1.scss';
+    `,
+      fixed: `
+      @import "df/fff", '_1';
     `,
       line: 2,
       column: 29,

--- a/src/rules/at-import-partial-extension/index.js
+++ b/src/rules/at-import-partial-extension/index.js
@@ -28,7 +28,7 @@ const mediaQueryTypesRE = new RegExp(`(${mediaQueryTypes.join("|")})$`, "i");
 const stripPath = path =>
   path.replace(/^\s*(["'])\s*/, "").replace(/\s*(["'])\s*$/, "");
 
-export default function(expectation) {
+export default function(expectation, _, context) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: expectation,
@@ -72,6 +72,13 @@ export default function(expectation) {
         }
 
         if (extension && expectation === "never") {
+          if (context.fix) {
+            const extPattern = new RegExp(`\\.${extension}(['" ]*)`, "g");
+            decl.params = decl.params.replace(extPattern, "$1");
+
+            return;
+          }
+
           utils.report({
             message: messages.rejected(extension),
             node: decl,


### PR DESCRIPTION
This PR adds the *autofix* support to the `scss/at-import-partial-extension` rule only when the `"never"` option is given.

I believe we cannot support autofix when `"always"` is given because it's impossible to determine file extensions to be added.