### PR TITLE
Fix `--fix` option link on each rule doc

### DIFF
--- a/src/rules/at-else-closing-brace-newline-after/README.md
+++ b/src/rules/at-else-closing-brace-newline-after/README.md
@@ -11,7 +11,7 @@ Require or disallow a newline after the closing brace of `@else` statements.
  * The newline after these braces */
 ```
 
-The `--fix` option on the [command line](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://stylelint.io/user-guide/usage/options#fix) can automatically fix all of the problems reported by this rule.
 
 This rule might have conflicts with stylelint's core rule [`block-closing-brace-newline-after`](https://stylelint.io/user-guide/rules/block-closing-brace-newline-after) if it doesn't have `"ignoreAtRules": ["else"]` in a `.stylelintrc` config file.  That's because an `@else { ... }` statement can be successfully parsed as an at-rule with a block. You might also want to set `"ignoreAtRules": ["else"]` for another stylelint's core rule - [`at-rule-empty-line-before`](https://stylelint.io/user-guide/rules/at-rule-empty-line-before) that could be forcing empty lines before at-rules (including `@else`s that follow `@if`s or other `@else`s).
 

--- a/src/rules/at-else-closing-brace-space-after/README.md
+++ b/src/rules/at-else-closing-brace-space-after/README.md
@@ -10,7 +10,7 @@ Require a single space or disallow whitespace after the closing brace of `@else`
  * The space after this brace */
 ```
 
-The `--fix` option on the [command line](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://stylelint.io/user-guide/usage/options#fix) can automatically fix all of the problems reported by this rule.
 
 This rule might have conflicts with stylelint's core [`block-closing-brace-space-after`](https://stylelint.io/user-guide/rules/block-closing-brace-space-after) rule if the latter is set up in your `.stylelintrc` config file.
 
@@ -43,7 +43,7 @@ The following patterns are considered warnings:
   // ...
 } @else if ($x == 2) {
   // ...
-} 
+}
 @else { }
 
 @if ($x == 1) {
@@ -61,7 +61,7 @@ The following patterns are *not* considered warnings:
 } @else if ($x == 2) {
   // ...
 } @else {}
-      
+
 a {
   @if ($x == 1) {
     // ...
@@ -71,7 +71,7 @@ a {
   width: 10px;
 }
 
-@if ($x == 1) { } @else if ($x == 2) { 
+@if ($x == 1) { } @else if ($x == 2) {
   // ...
 } @include x;
 

--- a/src/rules/at-else-empty-line-before/README.md
+++ b/src/rules/at-else-empty-line-before/README.md
@@ -11,7 +11,7 @@ Require an empty line or disallow empty lines before `@`-else.
  * This empty line */
 ```
 
-The `--fix` option on the [command line](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://stylelint.io/user-guide/usage/options#fix) can automatically fix all of the problems reported by this rule.
 
 `@if` and `@else` statements might need to have different behavior than all the other at-rules. For that you might need to set `"ignoreAtRules": ["else"]` for stylelint's core rule [`at-rule-empty-line-before`](https://stylelint.io/user-guide/rules/at-rule-empty-line-before). But that would make you unable to disallow empty lines before `@else` while forcing it to be on a new line. This rule is designed to solve exactly that.
 
@@ -53,7 +53,7 @@ The following patterns are *not* considered warnings:
 } @else if ($x == 2) {
   // ...
 } @else {}
-      
+
 a {
   @if ($x == 1) {
     // ...

--- a/src/rules/at-else-if-parentheses-space-before/README.md
+++ b/src/rules/at-else-if-parentheses-space-before/README.md
@@ -8,7 +8,7 @@ Require or disallow a space before `@else if` parentheses.
  * The space before this parenthesis */
 ```
 
-The `--fix` option on the [command line](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://stylelint.io/user-guide/usage/options#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/rules/at-function-parentheses-space-before/README.md
+++ b/src/rules/at-function-parentheses-space-before/README.md
@@ -8,7 +8,7 @@ Require or disallow a space before `@function` parentheses.
  * The space before this parenthesis */
 ```
 
-The `--fix` option on the [command line](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://stylelint.io/user-guide/usage/options#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/rules/at-if-closing-brace-newline-after/README.md
+++ b/src/rules/at-if-closing-brace-newline-after/README.md
@@ -9,7 +9,7 @@ Require or disallow a newline after the closing brace of `@if` statements.
  * The newline after this brace */
 ```
 
-The `--fix` option on the [command line](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://stylelint.io/user-guide/usage/options#fix) can automatically fix all of the problems reported by this rule.
 
 This rule might have conflicts with stylelint's core rule [`block-closing-brace-newline-after`](https://stylelint.io/user-guide/rules/block-closing-brace-newline-after) if it doesn't have `"ignoreAtRules": ["if"]` in a `.stylelintrc` config file. That's because an `@if { ... }` statement can be successfully parsed as an at-rule with a block. You might also want to set `"ignoreAtRules": ["else"]` for another stylelint's core rule - [`at-rule-empty-line-before`](https://stylelint.io/user-guide/rules/at-rule-empty-line-before) that could be forcing empty lines before at-rules (including `@else`s that follow `@if`s or other `@else`s).
 

--- a/src/rules/at-if-closing-brace-space-after/README.md
+++ b/src/rules/at-if-closing-brace-space-after/README.md
@@ -9,7 +9,7 @@ Require a single space or disallow whitespace after the closing brace of `@if` s
  * The space after this brace */
 ```
 
-The `--fix` option on the [command line](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://stylelint.io/user-guide/usage/options#fix) can automatically fix all of the problems reported by this rule.
 
 This rule might have conflicts with stylelint's core [`block-closing-brace-space-after`](https://stylelint.io/user-guide/rules/block-closing-brace-space-after) rule if the latter is set up in your `.stylelintrc` config file.
 
@@ -36,7 +36,7 @@ The following patterns are considered warnings:
 // `@if` has a space and a newline after the closing brace
 @if ($x == 1) {
   // ...
-} 
+}
 @else { }
 
 @if ($x == 1) {
@@ -86,7 +86,7 @@ The following patterns are *not* considered warnings:
 @if ($x == 1) {
   // ...
 }@else {}
-      
+
 a {
   @if ($x == 1) {}
   width: 10px;

--- a/src/rules/at-mixin-argumentless-call-parentheses/README.md
+++ b/src/rules/at-mixin-argumentless-call-parentheses/README.md
@@ -8,7 +8,7 @@ Require or disallow parentheses in argumentless `@mixin` calls.
  *                 Such mixin calls */
 ```
 
-The `--fix` option on the [command line](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://stylelint.io/user-guide/usage/options#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/rules/at-mixin-parentheses-space-before/README.md
+++ b/src/rules/at-mixin-parentheses-space-before/README.md
@@ -8,7 +8,7 @@ Require or disallow a space before `@mixin` parentheses.
  * The space before this parenthesis */
 ```
 
-The `--fix` option on the [command line](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://stylelint.io/user-guide/usage/options#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 
@@ -16,7 +16,7 @@ The `--fix` option on the [command line](https://github.com/stylelint/stylelint/
 
 ### `"always"`
 
-There *must always* be exactly one space between the mixin name and the opening parenthesis. 
+There *must always* be exactly one space between the mixin name and the opening parenthesis.
 
 *Note: This rule does not enforce parentheses to be present in a declaration without arguments.*
 

--- a/src/rules/at-rule-conditional-no-parentheses/README.md
+++ b/src/rules/at-rule-conditional-no-parentheses/README.md
@@ -8,7 +8,7 @@ Disallow parentheses in conditional @ rules (if, elsif, while)
  * Get rid of parentheses like this. */
 ```
 
-The `--fix` option on the [command line](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://stylelint.io/user-guide/usage/options#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/rules/dollar-variable-colon-newline-after/README.md
+++ b/src/rules/dollar-variable-colon-newline-after/README.md
@@ -11,7 +11,7 @@ $box-shadow:
  * The newline after this colon */
 ```
 
-The `--fix` option on the [command line](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://stylelint.io/user-guide/usage/options#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/rules/dollar-variable-colon-space-after/README.md
+++ b/src/rules/dollar-variable-colon-space-after/README.md
@@ -8,7 +8,7 @@ $variable: 10px;
  * The space after this colon */
 ```
 
-The `--fix` option on the [command line](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://stylelint.io/user-guide/usage/options#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/rules/dollar-variable-colon-space-before/README.md
+++ b/src/rules/dollar-variable-colon-space-before/README.md
@@ -8,7 +8,7 @@ $variable: 10px;
  * The space before this colon */
 ```
 
-The `--fix` option on the [command line](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://stylelint.io/user-guide/usage/options#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/rules/dollar-variable-empty-line-after/README.md
+++ b/src/rules/dollar-variable-empty-line-after/README.md
@@ -4,7 +4,7 @@ Require an empty line or disallow empty lines after `$`-variable declarations.
 
 If the `$`-variable declaration is the last declaration in a file, it's ignored.
 
-The `--fix` option on the [command line](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://stylelint.io/user-guide/usage/options#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 
@@ -143,7 +143,7 @@ The following patterns are *not* considered warnings:
 a {
   $var: 1;
   $var1: 2;
-  
+
   b {
     width: 100%;
   }

--- a/src/rules/dollar-variable-empty-line-before/README.md
+++ b/src/rules/dollar-variable-empty-line-before/README.md
@@ -11,7 +11,7 @@ $width: 10px;   ↑
  * This empty line */
 ```
 
-The `--fix` option on the [command line](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://stylelint.io/user-guide/usage/options#fix) can automatically fix all of the problems reported by this rule.
 
 ## Options
 

--- a/src/rules/double-slash-comment-empty-line-before/README.md
+++ b/src/rules/double-slash-comment-empty-line-before/README.md
@@ -10,7 +10,7 @@ a {}
 *     This line */
 ```
 
-The `--fix` option on the [command line](https://github.com/stylelint/stylelint/blob/master/docs/user-guide/cli.md#autofixing-errors) can automatically fix all of the problems reported by this rule.
+The [`fix` option](https://stylelint.io/user-guide/usage/options#fix) can automatically fix all of the problems reported by this rule.
 
 This rule only works with SCSS-like [single-line comments](https://sass-lang.com/documentation/syntax/comments) and ignores:
 * comments that are the very first nodes in a file;


### PR DESCRIPTION
For example, the doc of a core rule `alpha-value-notation` is helpful.
See https://stylelint.io/user-guide/rules/list/alpha-value-notation
