### PR TITLE
Bug fix: Make filenames with dots work with at-import-partial-extension rule

### DIFF
--- a/src/rules/at-import-partial-extension/__tests__/index.js
+++ b/src/rules/at-import-partial-extension/__tests__/index.js
@@ -134,6 +134,12 @@ testRule({
       @import "screen.scss";
     `,
       description: "Import with a name that matches a media query type."
+    },
+    {
+      code: `
+      @import "colors.variables.scss";
+    `,
+      description: "Import a filename with a dot."
     }
   ],
 
@@ -294,6 +300,12 @@ testRule({
       @import _file.scss tv,screen;
     `,
       description: "Import CSS (with media queries - multiple, no spaces)."
+    },
+    {
+      code: `
+      @import "colors.variables";
+    `,
+      description: "Import a style file with a dot in the name."
     }
   ],
 
@@ -382,6 +394,18 @@ testRule({
       column: 29,
       message: messages.rejected("scss"),
       description: "Two files, path with dir, has extension."
+    },
+    {
+      code: `
+      @import "colors.variables.scss";
+    `,
+      fixed: `
+      @import "colors.variables";
+    `,
+      line: 2,
+      column: 33,
+      message: messages.rejected("scss"),
+      description: "Single file, has .scss extension and a dot in the name."
     }
   ]
 });

--- a/src/rules/at-import-partial-extension/index.js
+++ b/src/rules/at-import-partial-extension/index.js
@@ -75,7 +75,8 @@ export default function rule(expectation, _, context) {
           return;
         }
 
-        if (extension && expectation === "never") {
+        const isScssPartial = extension === "scss";
+        if (extension && isScssPartial && expectation === "never") {
           if (context.fix) {
             const extPattern = new RegExp(`\\.${extension}(['" ]*)`, "g");
             decl.params = decl.params.replace(extPattern, "$1");


### PR DESCRIPTION
### Bug
- Related issue: https://github.com/stylelint-scss/stylelint-scss/issues/587#issuecomment-1025651087
- Fixing an issue when using `@import` with scss files that contain `.` symbol.
<img width="992" alt="image" src="https://user-images.githubusercontent.com/621330/176472664-59516983-d13f-42c7-8066-6c597be04a0c.png">

**Before (didn't work)**
```scss
@import "colors.variables"; // <--- Stylelint: Unexpected extension ".utility" in @import (scss/at-import-partial-extension)
@import "defaultOutlineStyle.mixin"; // <--- Stylelint: Unexpected extension ".utility" in @import (scss/at-import-partial-extension)

// ...
```

**After (works now)**
```scss
@import "colors.variables"; // OK
@import "defaultOutlineStyle.mixin"; // OK

// ...
```