### PR TITLE
New Rule: `at-extend-disallow`

### DIFF
--- a/src/rules/at-extend-disallow/README.md
+++ b/src/rules/at-extend-disallow/README.md
@@ -1,0 +1,3 @@
+# at-extend-disallow
+
+Disallow `@extend` declarations of any type.

--- a/src/rules/at-extend-disallow/__tests__/index.js
+++ b/src/rules/at-extend-disallow/__tests__/index.js
@@ -1,0 +1,82 @@
+import { ruleName, messages } from "..";
+
+testRule({
+  ruleName,
+  config: [true],
+  customSyntax: "postcss-scss",
+  accept: [],
+  reject: [
+    {
+      code: `
+      p {
+        @extend span;
+      }
+    `,
+      line: 3,
+      message: messages.rejected,
+      description: "when extending with an element"
+    },
+    {
+      code: `
+      p {
+        @extend #some-identifier;
+      }
+    `,
+      line: 3,
+      message: messages.rejected,
+      description: "when extending with an id"
+    },
+    {
+      code: `
+      p {
+        @extend .some-class;
+      }
+    `,
+      line: 3,
+      message: messages.rejected,
+      description: "when extending with a class"
+    },
+    {
+      code: `
+      p {
+        @extend .blah-#{$dynamically_generated_name};
+      }
+    `,
+      line: 3,
+      message: messages.rejected,
+      description:
+        "when extending with a dynamic selector whose prefix is not a placeholder"
+    },
+    {
+      code: `
+        p {
+          @extend %placeholder;
+        }
+      `,
+      line: 3,
+      message: messages.rejected,
+      description: "when extending with a placeholder"
+    },
+    {
+      code: `
+        p {
+          @extend #{$dynamically_generated_placeholder_name};
+        }
+      `,
+      line: 3,
+      message: messages.rejected,
+      description: "when extending with a dynamic selector"
+    },
+    {
+      code: `
+        p {
+          @extend %foo-#{$dynamically_generated_placeholder_name};
+        }
+      `,
+      line: 3,
+      message: messages.rejected,
+      description:
+        "when extending with a dynamic selector whose prefix is a placeholder"
+    }
+  ]
+});

--- a/src/rules/at-extend-disallow/index.js
+++ b/src/rules/at-extend-disallow/index.js
@@ -1,0 +1,35 @@
+import { utils } from "stylelint";
+import { namespace, ruleUrl } from "../../utils";
+
+export const ruleName = namespace("at-extend-disallow");
+
+export const messages = utils.ruleMessages(ruleName, {
+  rejected: "@extend declarations are not permitted"
+});
+
+export const meta = {
+  url: ruleUrl(ruleName)
+};
+
+export default function rule(actual) {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, { actual });
+
+    if (!validOptions) {
+      return;
+    }
+
+    root.walkAtRules("extend", atrule => {
+      utils.report({
+        ruleName,
+        result,
+        node: atrule,
+        message: messages.rejected
+      });
+    });
+  };
+}
+
+rule.ruleName = ruleName;
+rule.messages = messages;
+rule.meta = meta;

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -4,6 +4,7 @@ import atElseClosingBraceSpaceAfter from "./at-else-closing-brace-space-after";
 import atElseEmptyLineBefore from "./at-else-empty-line-before";
 import atElseIfParenthesesSpaceBefore from "./at-else-if-parentheses-space-before";
 import atExtendNoMissingPlaceholder from "./at-extend-no-missing-placeholder";
+import atExtendDisallow from "./at-extend-disallow";
 import atFunctionNamedArguments from "./at-function-named-arguments";
 import atFunctionParenthesesSpaceBefore from "./at-function-parentheses-space-before";
 import atFunctionPattern from "./at-function-pattern";
@@ -60,6 +61,7 @@ import selectorNoUnionClassName from "./selector-no-union-class-name";
 
 export default {
   "at-extend-no-missing-placeholder": atExtendNoMissingPlaceholder,
+  "at-extend-disallow": atExtendDisallow,
   "at-else-closing-brace-newline-after": atElseClosingBraceNewlineAfter,
   "at-else-closing-brace-space-after": atElseClosingBraceSpaceAfter,
   "at-else-empty-line-before": atElseEmptyLineBefore,


### PR DESCRIPTION
I would like to introduce a new rule,`at-extend-disallow`, which would allow developers to lint against the use of `@extend` altogether. We see several issues with `@extend` in practice:

1. `@extend` [obfuscates the meaning](https://pressupinc.com/blog/2014/11/dont-overextend-yourself-in-sass/) of a particular rule.
2. `@extend` leads to [specificity and inheritance problems](https://webinista.com/updates/dont-use-extend-sass/), which are hard to troubleshoot.
3. `@extend` behaves differently across [versions of Sass](https://sass-lang.com/documentation/breaking-changes/extend-compound).

Instead, we encourage developers to use Mixins, which offer similar functionality without some of these drawbacks. 

It seems that `sass-lint` currently offers a similar [`no-extends`](https://github.com/sasstools/sass-lint/blob/develop/docs/rules/no-extends.md) rule, so I would like to propose we support one in `stylelint-scss` as well.