### PR TITLE
Fix at-rule pattern warnings to range only one line

### DIFF
--- a/src/rules/at-function-pattern/__tests__/index.js
+++ b/src/rules/at-function-pattern/__tests__/index.js
@@ -77,6 +77,9 @@ testRule({
       }
     `,
       line: 2,
+      column: 7,
+      endLine: 3,
+      endColumn: 0,
       message: messages.expected,
       description: "Regexp: sequence part. Example: symbol in between."
     }
@@ -120,6 +123,9 @@ testRule({
       }
     `,
       line: 2,
+      column: 7,
+      endLine: 3,
+      endColumn: 0,
       message: messages.expected,
       description: "String: sequence part. Example: symbol in between."
     },
@@ -129,6 +135,9 @@ testRule({
       }
     `,
       line: 2,
+      column: 7,
+      endLine: 3,
+      endColumn: 0,
       message: messages.expected,
       description: "String: sequence part. Example: not a full sequence."
     }
@@ -191,6 +200,9 @@ testRule({
       }
     `,
       line: 2,
+      column: 7,
+      endLine: 3,
+      endColumn: 0,
       message: messages.expected,
       description: "Regexp: strict match. Example: matches at the end."
     },
@@ -200,6 +212,9 @@ testRule({
       }
     `,
       line: 2,
+      column: 7,
+      endLine: 3,
+      endColumn: 0,
       message: messages.expected,
       description: "Regexp: strict match. Example: matches at the beginning."
     },
@@ -209,6 +224,9 @@ testRule({
       }
     `,
       line: 2,
+      column: 7,
+      endLine: 3,
+      endColumn: 0,
       message: messages.expected,
       description: "Regexp: strict match. Example: symbol in between."
     },
@@ -220,6 +238,9 @@ testRule({
       }
     `,
       line: 2,
+      column: 7,
+      endLine: 3,
+      endColumn: 0,
       message: messages.expected,
       description:
         "Regexp: strict match. Example: function name divided by newlines."
@@ -258,6 +279,9 @@ testRule({
       }
     `,
       line: 2,
+      column: 7,
+      endLine: 3,
+      endColumn: 0,
       message: messages.expected,
       description:
         "Regexp: pattern at the beginning. Example: matches at the end."
@@ -268,6 +292,9 @@ testRule({
       }
     `,
       line: 2,
+      column: 7,
+      endLine: 3,
+      endColumn: 0,
       message: messages.expected,
       description:
         "Regexp: pattern at the beginning. Example: symbol in between."
@@ -296,6 +323,9 @@ testRule({
     {
       code: "@function boo-Foo-bar ( $p) {}",
       line: 1,
+      column: 1,
+      endLine: 2,
+      endColumn: 0,
       message: messages.expected,
       description:
         "Regexp: SUIT component. Example: starts with lowercase, two elements"
@@ -303,12 +333,18 @@ testRule({
     {
       code: "@function foo-bar ($p) {}",
       line: 1,
+      column: 1,
+      endLine: 2,
+      endColumn: 0,
       message: messages.expected,
       description: "Regexp: SUIT component. Example: starts with lowercase"
     },
     {
       code: "@function Foo-Bar ($p) {}",
       line: 1,
+      column: 1,
+      endLine: 2,
+      endColumn: 0,
       message: messages.expected,
       description:
         "Regexp: SUIT component. Example: element starts with uppercase"

--- a/src/rules/at-function-pattern/index.js
+++ b/src/rules/at-function-pattern/index.js
@@ -37,11 +37,16 @@ export default function rule(pattern) {
         return;
       }
 
+      const funcTopLine = Object.assign({}, decl.source.start);
+      funcTopLine.line += 1;
+      funcTopLine.column = 0;
+
       utils.report({
         message: messages.expected,
         node: decl,
         result,
-        ruleName
+        ruleName,
+        end: funcTopLine
       });
     });
   };

--- a/src/rules/at-mixin-pattern/__tests__/index.js
+++ b/src/rules/at-mixin-pattern/__tests__/index.js
@@ -75,6 +75,9 @@ testRule({
       }
     `,
       line: 2,
+      column: 7,
+      endLine: 3,
+      endColumn: 0,
       message: messages.expected,
       description: "Regexp: sequence part. Example: symbol in between."
     }
@@ -118,6 +121,9 @@ testRule({
       }
     `,
       line: 2,
+      column: 7,
+      endLine: 3,
+      endColumn: 0,
       message: messages.expected,
       description: "String: sequence part. Example: symbol in between."
     },
@@ -127,6 +133,9 @@ testRule({
       }
     `,
       line: 2,
+      column: 7,
+      endLine: 3,
+      endColumn: 0,
       message: messages.expected,
       description: "String: sequence part. Example: not a full sequence."
     }
@@ -198,6 +207,9 @@ testRule({
       }
     `,
       line: 2,
+      column: 7,
+      endLine: 3,
+      endColumn: 0,
       message: messages.expected,
       description: "Regexp: strict match. Example: matches at the end."
     },
@@ -207,6 +219,9 @@ testRule({
       }
     `,
       line: 2,
+      column: 7,
+      endLine: 3,
+      endColumn: 0,
       message: messages.expected,
       description: "Regexp: strict match. Example: matches at the beginning."
     },
@@ -216,6 +231,9 @@ testRule({
       }
     `,
       line: 2,
+      column: 7,
+      endLine: 3,
+      endColumn: 0,
       message: messages.expected,
       description: "Regexp: strict match. Example: symbol in between."
     },
@@ -227,6 +245,9 @@ testRule({
       }
     `,
       line: 2,
+      column: 7,
+      endLine: 3,
+      endColumn: 0,
       message: messages.expected,
       description:
         "Regexp: strict match. Example: mixin name divided by newlines."
@@ -265,6 +286,9 @@ testRule({
       }
     `,
       line: 2,
+      column: 7,
+      endLine: 3,
+      endColumn: 0,
       message: messages.expected,
       description:
         "Regexp: pattern at the beginning. Example: matches at the end."
@@ -275,6 +299,9 @@ testRule({
       }
     `,
       line: 2,
+      column: 7,
+      endLine: 3,
+      endColumn: 0,
       message: messages.expected,
       description:
         "Regexp: pattern at the beginning. Example: symbol in between."
@@ -303,6 +330,9 @@ testRule({
     {
       code: "@mixin boo-Foo-bar ( $p) {}",
       line: 1,
+      column: 1,
+      endLine: 2,
+      endColumn: 0,
       message: messages.expected,
       description:
         "Regexp: SUIT component. Example: starts with lowercase, two elements"
@@ -310,12 +340,18 @@ testRule({
     {
       code: "@mixin foo-bar ($p) {}",
       line: 1,
+      column: 1,
+      endLine: 2,
+      endColumn: 0,
       message: messages.expected,
       description: "Regexp: SUIT component. Example: starts with lowercase"
     },
     {
       code: "@mixin Foo-Bar ($p) {}",
       line: 1,
+      column: 1,
+      endLine: 2,
+      endColumn: 0,
       message: messages.expected,
       description:
         "Regexp: SUIT component. Example: element starts with uppercase"

--- a/src/rules/at-mixin-pattern/index.js
+++ b/src/rules/at-mixin-pattern/index.js
@@ -37,11 +37,16 @@ export default function rule(pattern) {
         return;
       }
 
+      const mixinTopLine = Object.assign({}, decl.source.start);
+      mixinTopLine.line += 1;
+      mixinTopLine.column = 0;
+
       utils.report({
         message: messages.expected,
         node: decl,
         result,
-        ruleName
+        ruleName,
+        end: mixinTopLine
       });
     });
   };


### PR DESCRIPTION
Hi, first contrib here.

I noticed the `at-function-pattern` and `at-mixin-pattern` rules spit out warnings with a range over the *entire* at-rule block as the "problem area", which of course doesn't make sense when it's just the name that's the issue.

Not at all familiar with the codebase and I just wanted to slap a quick fix on it if I could, best I was able to do was limiting it to one line only.

Before:
<img width="566" alt="before" src="https://user-images.githubusercontent.com/39429628/179681677-6440d451-348a-48f8-940f-f021a70929f3.png">

After:
<img width="566" alt="after" src="https://user-images.githubusercontent.com/39429628/179681147-3c88ffa2-d1a3-40e8-b0da-a3823257aeb7.png">