### PR TITLE
bugfix(at-import-partial-extension): fixer incorrectly replaces filename

### DIFF
--- a/src/rules/at-import-partial-extension/__tests__/index.js
+++ b/src/rules/at-import-partial-extension/__tests__/index.js
@@ -406,6 +406,18 @@ testRule({
       column: 33,
       message: messages.rejected("scss"),
       description: "Single file, has .scss extension and a dot in the name."
+    },
+    {
+      code: `
+      @import "component.scss-theme.scss";
+    `,
+      fixed: `
+      @import "component.scss-theme";
+    `,
+      line: 2,
+      column: 26,
+      message: messages.rejected("scss"),
+      description: "Single file, has .scss extension and a .scss in the filename."
     }
   ]
 });

--- a/src/rules/at-import-partial-extension/index.js
+++ b/src/rules/at-import-partial-extension/index.js
@@ -78,7 +78,7 @@ export default function rule(expectation, _, context) {
         const isScssPartial = extension === "scss";
         if (extension && isScssPartial && expectation === "never") {
           if (context.fix) {
-            const extPattern = new RegExp(`\\.${extension}(['" ]*)`, "g");
+            const extPattern = new RegExp(`\\.${extension}(['" ]*)$`, "g");
             decl.params = decl.params.replace(extPattern, "$1");
 
             return;


### PR DESCRIPTION
Hi, my first contrib here. 👋

While fixing a large codebase I noticed the `at-import-partial-extension` fixer incorrectly fixed certain files when they have `.scss` in their filename. (example: `component.scss-theme.scss`)

---

**currently**:
`at-import-partial-extension`'s fixer incorrectly replaced all `.scss` occurences in a filename.

```diff
- @import "component.scss-theme.scss";
+ @import "component-theme";
```

**expected**:
`at-import-partial-extension`'s fixer should only replace the `.scss` extension (not when `.scss` is used in the filename itself)

```diff
- @import "component.scss-theme.scss";
+ @import "component.scss-theme";
```
