### PR TITLE
ci(husky): fix husky v8

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx --no lint-staged

--- a/package.json
+++ b/package.json
@@ -148,10 +148,5 @@
     "**/*.{js,json}": [
       "prettier --write"
     ]
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
   }
 }


### PR DESCRIPTION
Bumping husky from v4 to v8 broke husky.

Introduced in change: https://github.com/stylelint-scss/stylelint-scss/pull/627

Followed migration guide: https://github.com/typicode/husky-4-to-8


Side note: Prettier2 upgrade (https://github.com/stylelint-scss/stylelint-scss/pull/625) will format files slightly differently.
