### PR TITLE
refactor: fix prettier code style

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@ import { createPlugin } from "stylelint";
 import { namespace } from "./utils";
 import rules from "./rules";
 
-const rulesPlugins = Object.keys(rules).map(ruleName => {
+const rulesPlugins = Object.keys(rules).map((ruleName) => {
   return createPlugin(namespace(ruleName), rules[ruleName]);
 });
 

--- a/src/rules/at-each-key-value-single-line/__tests__/index.js
+++ b/src/rules/at-each-key-value-single-line/__tests__/index.js
@@ -11,7 +11,7 @@ testRule({
         $font-weights: ("regular": 400, "medium": 500, "bold": 700);
         @each $key, $value in $font-weights {}
       `,
-      description: "Proper map loop that gets both keys + values"
+      description: "Proper map loop that gets both keys + values",
     },
     {
       code: `
@@ -19,7 +19,7 @@ testRule({
         @each $key in map-keys($font-weights) {}
       `,
       description:
-        "Loop that just gets keys + has no need for values when using global function"
+        "Loop that just gets keys + has no need for values when using global function",
     },
     {
       code: `
@@ -28,7 +28,7 @@ testRule({
         @each $key in map.keys($font-weights) {}
       `,
       description:
-        "Loop that just gets keys + has no need for values when loading sass module with default namespace"
+        "Loop that just gets keys + has no need for values when loading sass module with default namespace",
     },
     {
       code: `
@@ -37,7 +37,7 @@ testRule({
         @each $key in map-keys($font-weights) {}
       `,
       description:
-        "Loop that just gets keys + has no need for values when loading sass module with default namespace but using global function"
+        "Loop that just gets keys + has no need for values when loading sass module with default namespace but using global function",
     },
     {
       code: `
@@ -46,7 +46,7 @@ testRule({
         @each $key in keys($font-weights) {}
       `,
       description:
-        "Loop that just gets keys + has no need for values when loading sass module with no namespace"
+        "Loop that just gets keys + has no need for values when loading sass module with no namespace",
     },
     {
       code: `
@@ -55,7 +55,7 @@ testRule({
         @each $key in map-keys($font-weights) {}
       `,
       description:
-        "Loop that just gets keys + has no need for values when loading sass module with no namespace but using global function"
+        "Loop that just gets keys + has no need for values when loading sass module with no namespace but using global function",
     },
     {
       code: `
@@ -64,7 +64,7 @@ testRule({
         @each $key in ns.keys($font-weights) {}
       `,
       description:
-        "Loop that just gets keys + has no need for values when loading sass module with custom namespace"
+        "Loop that just gets keys + has no need for values when loading sass module with custom namespace",
     },
     {
       code: `
@@ -73,7 +73,7 @@ testRule({
         @each $key in map-keys($font-weights) {}
       `,
       description:
-        "Loop that just gets keys + has no need for values when loading sass module with custom namespace but using global function"
+        "Loop that just gets keys + has no need for values when loading sass module with custom namespace but using global function",
     },
     {
       code: `
@@ -84,7 +84,7 @@ testRule({
         }
       `,
       description:
-        "map-get pattern used with different hash than loop when using global function"
+        "map-get pattern used with different hash than loop when using global function",
     },
     {
       code: `
@@ -96,7 +96,7 @@ testRule({
         }
       `,
       description:
-        "map.get pattern used with different hash than loop when loading sass module with default namespace"
+        "map.get pattern used with different hash than loop when loading sass module with default namespace",
     },
     {
       code: `
@@ -108,7 +108,7 @@ testRule({
         }
       `,
       description:
-        "map.get pattern used with different hash than loop when loading sass module with default namespace but using global function"
+        "map.get pattern used with different hash than loop when loading sass module with default namespace but using global function",
     },
     {
       code: `
@@ -120,7 +120,7 @@ testRule({
         }
       `,
       description:
-        "map.get pattern used with different hash than loop when loading sass module with no namespace"
+        "map.get pattern used with different hash than loop when loading sass module with no namespace",
     },
     {
       code: `
@@ -132,7 +132,7 @@ testRule({
         }
       `,
       description:
-        "map.get pattern used with different hash than loop when loading sass module with no namespace but using global function"
+        "map.get pattern used with different hash than loop when loading sass module with no namespace but using global function",
     },
     {
       code: `
@@ -144,7 +144,7 @@ testRule({
         }
       `,
       description:
-        "map.get pattern used with different hash than loop when loading sass module with custom namespace"
+        "map.get pattern used with different hash than loop when loading sass module with custom namespace",
     },
     {
       code: `
@@ -156,8 +156,8 @@ testRule({
         }
       `,
       description:
-        "map.get pattern used with different hash than loop when loading sass module with custom namespace but using global function"
-    }
+        "map.get pattern used with different hash than loop when loading sass module with custom namespace but using global function",
+    },
   ],
 
   reject: [
@@ -171,7 +171,7 @@ testRule({
       description:
         "Loop that gets keys + then grabs values inside the map when using global function",
       message: messages.expected,
-      line: 3
+      line: 3,
     },
     {
       code: `
@@ -184,7 +184,7 @@ testRule({
       description:
         "Loop that gets keys + then grabs values inside the map when loading sass module with default namespace",
       message: messages.expected,
-      line: 4
+      line: 4,
     },
     {
       code: `
@@ -197,7 +197,7 @@ testRule({
       description:
         "Loop that gets keys + then grabs values inside the map when loading sass module with default namespace but using global function",
       message: messages.expected,
-      line: 4
+      line: 4,
     },
     {
       code: `
@@ -210,7 +210,7 @@ testRule({
       description:
         "Loop that gets keys + then grabs values inside the map when loading sass module with no namespace",
       message: messages.expected,
-      line: 4
+      line: 4,
     },
     {
       code: `
@@ -223,7 +223,7 @@ testRule({
       description:
         "Loop that gets keys + then grabs values inside the map when loading sass module with no namespace but using global function",
       message: messages.expected,
-      line: 4
+      line: 4,
     },
     {
       code: `
@@ -236,7 +236,7 @@ testRule({
       description:
         "Loop that gets keys + then grabs values inside the map when loading sass module with custom namespace",
       message: messages.expected,
-      line: 4
+      line: 4,
     },
     {
       code: `
@@ -249,7 +249,7 @@ testRule({
       description:
         "Loop that gets keys + then grabs values inside the map when loading sass module with custom namespace but using global function",
       message: messages.expected,
-      line: 4
-    }
-  ]
+      line: 4,
+    },
+  ],
 });

--- a/src/rules/at-each-key-value-single-line/index.js
+++ b/src/rules/at-each-key-value-single-line/index.js
@@ -5,17 +5,17 @@ export const ruleName = namespace("at-each-key-value-single-line");
 
 export const messages = utils.ruleMessages(ruleName, {
   expected:
-    "Use @each $key, $value in $map syntax instead of $value: map-get($map, $key)"
+    "Use @each $key, $value in $map syntax instead of $value: map-get($map, $key)",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(primary) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
-      actual: primary
+      actual: primary,
     });
 
     if (!validOptions) {
@@ -24,7 +24,7 @@ export default function rule(primary) {
 
     const mapNamespace = moduleNamespace(root, "sass:map");
 
-    root.walkAtRules("each", rule => {
+    root.walkAtRules("each", (rule) => {
       const parts = separateEachParams(rule.params);
 
       // If loop is fetching both key + value, return
@@ -38,7 +38,7 @@ export default function rule(primary) {
       }
 
       // Loop over decls inside of each statement and loop for variable assignments.
-      rule.walkDecls(innerDecl => {
+      rule.walkDecls((innerDecl) => {
         // Check that this decl is a map-get call
         if (innerDecl.prop[0] !== "$") {
           return;
@@ -65,7 +65,7 @@ export default function rule(primary) {
           message: messages.expected,
           node: rule,
           result,
-          ruleName
+          ruleName,
         });
       });
     });
@@ -81,7 +81,7 @@ rule.meta = meta;
 function separateEachParams(paramString) {
   const parts = paramString.split("in");
 
-  return [parts[0].split(",").map(s => s.trim()), parts[1].trim()];
+  return [parts[0].split(",").map((s) => s.trim()), parts[1].trim()];
 }
 
 function didCallMapKeys(mapDecl, mapNamespace) {

--- a/src/rules/at-else-closing-brace-newline-after/__tests__/index.js
+++ b/src/rules/at-else-closing-brace-newline-after/__tests__/index.js
@@ -13,7 +13,7 @@ testRule({
       width: 10px;
     }`,
       description:
-        "always-last-in-chain (no following @else, has newline after)."
+        "always-last-in-chain (no following @else, has newline after).",
     },
     {
       code: `a {
@@ -22,7 +22,7 @@ testRule({
       width: 10px;
     }`,
       description:
-        "always-last-in-chain (no following @else, has blank line after)."
+        "always-last-in-chain (no following @else, has blank line after).",
     },
     {
       code: `a {
@@ -35,7 +35,7 @@ testRule({
       width: 10px;
     }`,
       description:
-        "always-last-in-chain (has following @else, this one with no newline after, the following has it)."
+        "always-last-in-chain (has following @else, this one with no newline after, the following has it).",
     },
     {
       code: `a {
@@ -44,7 +44,7 @@ testRule({
       width: 10px;
     }`,
       description:
-        "always-last-in-chain (has following @else, single-line, this one with no newline after, the following has it)."
+        "always-last-in-chain (has following @else, single-line, this one with no newline after, the following has it).",
     },
     {
       code: `a {
@@ -53,12 +53,12 @@ testRule({
       @include x;
     }`,
       description:
-        "always-last-in-chain (followed by non-@else at-rule, single-line, empty line after)."
+        "always-last-in-chain (followed by non-@else at-rule, single-line, empty line after).",
     },
     {
       code: "@if ($x == 1) {} @else { }",
-      description: "always-last-in-chain (single line, nothing after)."
-    }
+      description: "always-last-in-chain (single line, nothing after).",
+    },
   ],
 
   reject: [
@@ -81,7 +81,7 @@ width: 10px;
       description:
         "always-last-in-chain (has decl on the same line as its closing brace).",
       message: messages.expected,
-      line: 6
+      line: 6,
     },
     {
       code: `a {
@@ -97,7 +97,7 @@ width: 10px;
     }`,
       description: "always-last-in-chain (has following @else, newline after).",
       message: messages.rejected,
-      line: 4
+      line: 4,
     },
     {
       code: `a {
@@ -115,7 +115,7 @@ width: 10px;
       description:
         "always-last-in-chain (has following @else, empty line after).",
       message: messages.rejected,
-      line: 4
+      line: 4,
     },
     {
       code: `a {
@@ -132,9 +132,9 @@ width: 10px;
       description:
         "always-last-in-chain (followed by non-@else at-rule, no newline after).",
       message: messages.expected,
-      line: 4
-    }
-  ]
+      line: 4,
+    },
+  ],
 });
 
 testRule({
@@ -142,8 +142,8 @@ testRule({
   config: [
     "always-last-in-chain",
     {
-      disableFix: true
-    }
+      disableFix: true,
+    },
   ],
   customSyntax: "postcss-scss",
   unfixable: true,
@@ -155,7 +155,7 @@ testRule({
       width: 10px;
     }`,
       description:
-        "always-last-in-chain (no following @else, has newline after)."
+        "always-last-in-chain (no following @else, has newline after).",
     },
     {
       code: `a {
@@ -164,7 +164,7 @@ testRule({
       width: 10px;
     }`,
       description:
-        "always-last-in-chain (no following @else, has blank line after)."
+        "always-last-in-chain (no following @else, has blank line after).",
     },
     {
       code: `a {
@@ -177,7 +177,7 @@ testRule({
       width: 10px;
     }`,
       description:
-        "always-last-in-chain (has following @else, this one with no newline after, the following has it)."
+        "always-last-in-chain (has following @else, this one with no newline after, the following has it).",
     },
     {
       code: `a {
@@ -186,7 +186,7 @@ testRule({
       width: 10px;
     }`,
       description:
-        "always-last-in-chain (has following @else, single-line, this one with no newline after, the following has it)."
+        "always-last-in-chain (has following @else, single-line, this one with no newline after, the following has it).",
     },
     {
       code: `a {
@@ -195,12 +195,12 @@ testRule({
       @include x;
     }`,
       description:
-        "always-last-in-chain (followed by non-@else at-rule, single-line, empty line after)."
+        "always-last-in-chain (followed by non-@else at-rule, single-line, empty line after).",
     },
     {
       code: "@if ($x == 1) {} @else { }",
-      description: "always-last-in-chain (single line, nothing after)."
-    }
+      description: "always-last-in-chain (single line, nothing after).",
+    },
   ],
 
   reject: [
@@ -215,7 +215,7 @@ testRule({
       description:
         "always-last-in-chain (has decl on the same line as its closing brace).",
       message: messages.expected,
-      line: 6
+      line: 6,
     },
     {
       code: `a {
@@ -226,7 +226,7 @@ testRule({
     }`,
       description: "always-last-in-chain (has following @else, newline after).",
       message: messages.rejected,
-      line: 4
+      line: 4,
     },
     {
       code: `a {
@@ -239,7 +239,7 @@ testRule({
       description:
         "always-last-in-chain (has following @else, empty line after).",
       message: messages.rejected,
-      line: 4
+      line: 4,
     },
     {
       code: `a {
@@ -250,7 +250,7 @@ testRule({
       description:
         "always-last-in-chain (followed by non-@else at-rule, no newline after).",
       message: messages.expected,
-      line: 4
-    }
-  ]
+      line: 4,
+    },
+  ],
 });

--- a/src/rules/at-else-closing-brace-newline-after/index.js
+++ b/src/rules/at-else-closing-brace-newline-after/index.js
@@ -7,11 +7,11 @@ export const ruleName = namespace("at-else-closing-brace-newline-after");
 
 export const messages = utils.ruleMessages(ruleName, {
   expected: 'Expected newline after "}" of @else statement',
-  rejected: 'Unexpected newline after "}" of @else statement'
+  rejected: 'Unexpected newline after "}" of @else statement',
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(expectation, options, context) {
@@ -21,14 +21,14 @@ export default function rule(expectation, options, context) {
       ruleName,
       {
         actual: expectation,
-        possible: ["always-last-in-chain"]
+        possible: ["always-last-in-chain"],
       },
       {
         actual: options,
         possible: {
-          disableFix: isBoolean
+          disableFix: isBoolean,
         },
-        optional: true
+        optional: true,
       }
     );
 
@@ -44,7 +44,7 @@ export default function rule(expectation, options, context) {
       expectation,
       messages,
       context,
-      options
+      options,
     });
   };
 }

--- a/src/rules/at-else-closing-brace-space-after/__tests__/index.js
+++ b/src/rules/at-else-closing-brace-space-after/__tests__/index.js
@@ -13,7 +13,7 @@ testRule({
       @if ($x == 1) {}
       width: 10px;
     }`,
-      description: "always-intermediate (no @else at all)."
+      description: "always-intermediate (no @else at all).",
     },
     {
       code: `a {
@@ -22,14 +22,14 @@ testRule({
       width: 10px;
     }`,
       description:
-        "always-intermediate (not an intermediate @else, newline after)."
+        "always-intermediate (not an intermediate @else, newline after).",
     },
     {
       code: `a {
       @if ($x == 1) {} @else {}width: 10px;
     }`,
       description:
-        "always-intermediate (not an intermediate @else, no whitespace after)."
+        "always-intermediate (not an intermediate @else, no whitespace after).",
     },
     {
       code: `a {
@@ -40,7 +40,7 @@ testRule({
       width: 10px;
     }`,
       description:
-        "always-intermediate (an intermediate @else, has space after)."
+        "always-intermediate (an intermediate @else, has space after).",
     },
     {
       code: `a {
@@ -49,18 +49,18 @@ testRule({
       width: 10px;
     }`,
       description:
-        "always-intermediate (an intermediate @else, single-line, has space after)."
+        "always-intermediate (an intermediate @else, single-line, has space after).",
     },
     {
       code: `a {
       @if ($x == 1) { } @else ($x ==2) {}@include x;
     }`,
       description:
-        "always-intermediate (@else followed by non-@else at-rule, no space after)."
+        "always-intermediate (@else followed by non-@else at-rule, no space after).",
     },
     {
       code: "@if ($x == 1) {} @else ($x ==2) {}",
-      description: "always-intermediate (single line, nothing after)."
+      description: "always-intermediate (single line, nothing after).",
     },
     {
       // TODO: should warn on this?
@@ -70,8 +70,8 @@ testRule({
       } @include x;
     }`,
       description:
-        "always-intermediate (followed by non-@else at-rule, has space after)."
-    }
+        "always-intermediate (followed by non-@else at-rule, has space after).",
+    },
   ],
 
   reject: [
@@ -89,7 +89,7 @@ testRule({
       description:
         "always-intermediate (an intermediate @else, no space after).",
       message: messages.expected,
-      line: 4
+      line: 4,
     },
     {
       code: `a {
@@ -106,7 +106,7 @@ testRule({
       description:
         "always-intermediate (an intermediate @else, newline after).",
       message: messages.expected,
-      line: 4
+      line: 4,
     },
     {
       code: `a {
@@ -123,7 +123,7 @@ testRule({
       description:
         "always-intermediate (an intermediate @else, a space and an newline after).",
       message: messages.expected,
-      line: 4
+      line: 4,
     },
     {
       code: `a {
@@ -139,9 +139,9 @@ testRule({
       description:
         "always-intermediate (an intermediate @else, multiple spaces after).",
       message: messages.expected,
-      line: 4
-    }
-  ]
+      line: 4,
+    },
+  ],
 });
 
 // never-intermediate
@@ -158,21 +158,21 @@ testRule({
       width: 10px;
     }`,
       description:
-        "never-intermediate (not an intermediate @else, has newline after)."
+        "never-intermediate (not an intermediate @else, has newline after).",
     },
     {
       code: `a {
       @if ($x == 1) {} @else ($x ==2) {}width: 10px;
     }`,
       description:
-        "never-intermediate (not an intermediate @else, no whitespace after)."
+        "never-intermediate (not an intermediate @else, no whitespace after).",
     },
     {
       code: `a {
       @if ($x == 1) {} @else ($x ==2) {} width: 10px;
     }`,
       description:
-        "never-intermediate (not an intermediate @else, has a space after)."
+        "never-intermediate (not an intermediate @else, has a space after).",
     },
     {
       code: `a {
@@ -182,7 +182,8 @@ testRule({
 
       width: 10px;
     }`,
-      description: "never-intermediate (an intermediate @else, no space after)."
+      description:
+        "never-intermediate (an intermediate @else, no space after).",
     },
     {
       code: `a {
@@ -191,11 +192,11 @@ testRule({
       width: 10px;
     }`,
       description:
-        "never-intermediate (an intermediate @else, single-line, no space after)."
+        "never-intermediate (an intermediate @else, single-line, no space after).",
     },
     {
       code: "@if ($x == 1) {} @else ($x ==2) {}",
-      description: "never-intermediate (single line, nothing after)."
+      description: "never-intermediate (single line, nothing after).",
     },
     {
       // TODO: should warn on this?
@@ -205,8 +206,8 @@ testRule({
       } @else ($x ==2) {} @include x;
     }`,
       description:
-        "never-intermediate (followed by non-@else at-rule, has space after)."
-    }
+        "never-intermediate (followed by non-@else at-rule, has space after).",
+    },
   ],
 
   reject: [
@@ -224,7 +225,7 @@ testRule({
       description:
         "never-intermediate (an intermediate @else, has space after).",
       message: messages.rejected,
-      line: 4
+      line: 4,
     },
     {
       code: `a {
@@ -240,7 +241,7 @@ testRule({
     }`,
       description: "never-intermediate (an intermediate @else, newline after).",
       message: messages.rejected,
-      line: 4
+      line: 4,
     },
     {
       code: `a {
@@ -257,7 +258,7 @@ testRule({
       description:
         "never-intermediate (an intermediate @else, a space and a newline after).",
       message: messages.rejected,
-      line: 4
+      line: 4,
     },
     {
       code: `a {
@@ -273,7 +274,7 @@ testRule({
       description:
         "never-intermediate (an intermediate @else, multiple spaces after).",
       message: messages.rejected,
-      line: 4
-    }
-  ]
+      line: 4,
+    },
+  ],
 });

--- a/src/rules/at-else-closing-brace-space-after/index.js
+++ b/src/rules/at-else-closing-brace-space-after/index.js
@@ -6,18 +6,18 @@ export const ruleName = namespace("at-else-closing-brace-space-after");
 
 export const messages = utils.ruleMessages(ruleName, {
   expected: 'Expected single space after "}" of @else statement',
-  rejected: 'Unexpected space after "}" of @else statement'
+  rejected: 'Unexpected space after "}" of @else statement',
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(expectation, _, context) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: expectation,
-      possible: ["always-intermediate", "never-intermediate"]
+      possible: ["always-intermediate", "never-intermediate"],
     });
 
     if (!validOptions) {
@@ -31,7 +31,7 @@ export default function rule(expectation, _, context) {
       atRuleName: "else",
       expectation,
       messages,
-      context
+      context,
     });
   };
 }

--- a/src/rules/at-else-empty-line-before/__tests__/index.js
+++ b/src/rules/at-else-empty-line-before/__tests__/index.js
@@ -16,7 +16,7 @@ testRule({
         // ...
       } @else {}
     }`,
-      description: "never (no newline for @else)."
+      description: "never (no newline for @else).",
     },
     {
       code: `a {
@@ -27,8 +27,8 @@ testRule({
         // ...
       }
     }`,
-      description: "never (no empty line for @else)."
-    }
+      description: "never (no empty line for @else).",
+    },
   ],
 
   reject: [
@@ -47,14 +47,14 @@ testRule({
     }`,
       description: "never (one empty line before @else)",
       message: messages.rejected,
-      line: 6
+      line: 6,
     },
     {
       code: "a { @if ($x == 1) { } \n\n @else if ($x == 2) { } \n @else { } }",
       fixed: "a { @if ($x == 1) { } @else if ($x == 2) { } \n @else { } }",
       description: "never (two empty lines before @else if)",
       message: messages.rejected,
-      line: 3
-    }
-  ]
+      line: 3,
+    },
+  ],
 });

--- a/src/rules/at-else-empty-line-before/index.js
+++ b/src/rules/at-else-empty-line-before/index.js
@@ -4,25 +4,25 @@ import { utils } from "stylelint";
 export const ruleName = namespace("at-else-empty-line-before");
 
 export const messages = utils.ruleMessages(ruleName, {
-  rejected: "Unexpected empty line before @else"
+  rejected: "Unexpected empty line before @else",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(expectation, _, context) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: expectation,
-      possible: ["never"]
+      possible: ["never"],
     });
 
     if (!validOptions) {
       return;
     }
 
-    root.walkAtRules(atrule => {
+    root.walkAtRules((atrule) => {
       if (atrule.name !== "else") {
         return;
       }
@@ -44,7 +44,7 @@ export default function rule(expectation, _, context) {
         message: messages.rejected,
         node: atrule,
         result,
-        ruleName
+        ruleName,
       });
     });
   };

--- a/src/rules/at-else-if-parentheses-space-before/__tests__/index.js
+++ b/src/rules/at-else-if-parentheses-space-before/__tests__/index.js
@@ -12,50 +12,50 @@ testRule({
       @else if ($bar) {
       }
     `,
-      description: "With parentheses. Single condition"
+      description: "With parentheses. Single condition",
     },
     {
       code: `
       @else if $bar {
       }
     `,
-      description: "Without parentheses. Single condition"
+      description: "Without parentheses. Single condition",
     },
     {
       code: `
       @else if ($bar == 0 or ($bar > 5 and $bar < 10)) {
       }
     `,
-      description: "With parentheses. Complex condition"
+      description: "With parentheses. Complex condition",
     },
     {
       code: `
       @else if ($bar == 0 or($bar > 5 and $bar < 10)) {
       }
     `,
-      description: "With parentheses. Complex condition"
+      description: "With parentheses. Complex condition",
     },
     {
       code: `
       @else if $bar == 0 or ($bar > 5 and $bar < 10) {
       }
     `,
-      description: "Without parentheses. Complex condition"
+      description: "Without parentheses. Complex condition",
     },
     {
       code: `
       @else if $bar == 0 or($bar > 5 and $bar < 10) {
       }
     `,
-      description: "Without parentheses. Complex condition"
+      description: "Without parentheses. Complex condition",
     },
     {
       code: `
       @bar foo ($n) {
       }
     `,
-      description: "Not an SCSS else statement, skipping."
-    }
+      description: "Not an SCSS else statement, skipping.",
+    },
   ],
 
   reject: [
@@ -73,7 +73,7 @@ testRule({
     `,
       line: 2,
       message: messages.expectedBefore(),
-      description: "Newline after if"
+      description: "Newline after if",
     },
     {
       code: `
@@ -86,7 +86,7 @@ testRule({
     `,
       line: 2,
       message: messages.expectedBefore(),
-      description: "No space before parentheses. Simple condition."
+      description: "No space before parentheses. Simple condition.",
     },
     {
       code: `
@@ -99,7 +99,7 @@ testRule({
     `,
       line: 2,
       message: messages.expectedBefore(),
-      description: "Extra spaces after if."
+      description: "Extra spaces after if.",
     },
     {
       code: `
@@ -112,9 +112,9 @@ testRule({
     `,
       line: 2,
       message: messages.expectedBefore(),
-      description: "No space before parentheses. Complex condition."
-    }
-  ]
+      description: "No space before parentheses. Complex condition.",
+    },
+  ],
 });
 
 testRule({
@@ -129,50 +129,50 @@ testRule({
       @else if($bar) {
       }
     `,
-      description: "With parentheses. Single condition"
+      description: "With parentheses. Single condition",
     },
     {
       code: `
       @else if $bar {
       }
     `,
-      description: "Without parentheses. Single condition"
+      description: "Without parentheses. Single condition",
     },
     {
       code: `
       @else if($bar == 0 or ($bar > 5 and $bar < 10)) {
       }
     `,
-      description: "With parentheses. Complex condition"
+      description: "With parentheses. Complex condition",
     },
     {
       code: `
       @else if($bar == 0 or($bar > 5 and $bar < 10)) {
       }
     `,
-      description: "With parentheses. Complex condition"
+      description: "With parentheses. Complex condition",
     },
     {
       code: `
       @else if $bar == 0 or ($bar > 5 and $bar < 10) {
       }
     `,
-      description: "Without parentheses. Complex condition"
+      description: "Without parentheses. Complex condition",
     },
     {
       code: `
       @else if $bar == 0 or($bar > 5 and $bar < 10) {
       }
     `,
-      description: "Without parentheses. Complex condition"
+      description: "Without parentheses. Complex condition",
     },
     {
       code: `
       @bar foo($n) {
       }
     `,
-      description: "Not an SCSS else statement, skipping."
-    }
+      description: "Not an SCSS else statement, skipping.",
+    },
   ],
 
   reject: [
@@ -190,7 +190,7 @@ testRule({
     `,
       line: 2,
       message: messages.rejectedBefore(),
-      description: "Newline after if"
+      description: "Newline after if",
     },
     {
       code: `
@@ -203,7 +203,7 @@ testRule({
     `,
       line: 2,
       message: messages.rejectedBefore(),
-      description: "Single space before parentheses. Simple condition."
+      description: "Single space before parentheses. Simple condition.",
     },
     {
       code: `
@@ -216,7 +216,7 @@ testRule({
     `,
       line: 2,
       message: messages.rejectedBefore(),
-      description: "Single space before parentheses. Complex condition."
+      description: "Single space before parentheses. Complex condition.",
     },
     {
       code: `
@@ -229,7 +229,7 @@ testRule({
     `,
       line: 2,
       message: messages.rejectedBefore(),
-      description: "Multiple spaces before parentheses. Simple condition."
+      description: "Multiple spaces before parentheses. Simple condition.",
     },
     {
       code: `
@@ -242,7 +242,7 @@ testRule({
     `,
       line: 2,
       message: messages.rejectedBefore(),
-      description: "Multiple spaces before parentheses. Complex condition."
-    }
-  ]
+      description: "Multiple spaces before parentheses. Complex condition.",
+    },
+  ],
 });

--- a/src/rules/at-else-if-parentheses-space-before/index.js
+++ b/src/rules/at-else-if-parentheses-space-before/index.js
@@ -7,18 +7,18 @@ export const messages = utils.ruleMessages(ruleName, {
   rejectedBefore: () =>
     "Unexpected whitespace before parentheses in else-if declaration",
   expectedBefore: () =>
-    "Expected a single space before parentheses in else-if declaration"
+    "Expected a single space before parentheses in else-if declaration",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(value, _, context) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: value,
-      possible: ["always", "never"]
+      possible: ["always", "never"],
     });
 
     if (!validOptions) {
@@ -30,7 +30,7 @@ export default function rule(value, _, context) {
 
     const checker = whitespaceChecker("space", value, messages).before;
 
-    root.walkAtRules("else", decl => {
+    root.walkAtRules("else", (decl) => {
       // return early if the else-if statement is not surrounded by parentheses
       if (!match.test(decl.params)) {
         return;
@@ -43,7 +43,8 @@ export default function rule(value, _, context) {
       checker({
         source: decl.params,
         index: decl.params.indexOf("("),
-        err: message => utils.report({ message, node: decl, result, ruleName })
+        err: (message) =>
+          utils.report({ message, node: decl, result, ruleName }),
       });
     });
   };

--- a/src/rules/at-extend-no-missing-placeholder/__tests__/index.js
+++ b/src/rules/at-extend-no-missing-placeholder/__tests__/index.js
@@ -12,7 +12,7 @@ testRule({
         @extend %placeholder;
       }
     `,
-      description: "when extending with a placeholder"
+      description: "when extending with a placeholder",
     },
     {
       code: `
@@ -20,7 +20,7 @@ testRule({
         @extend #{$dynamically_generated_placeholder_name};
       }
     `,
-      description: "when extending with a dynamic selector"
+      description: "when extending with a dynamic selector",
     },
     {
       code: `
@@ -29,8 +29,8 @@ testRule({
       }
     `,
       description:
-        "when extending with a dynamic selector whose prefix is a placeholder"
-    }
+        "when extending with a dynamic selector whose prefix is a placeholder",
+    },
   ],
 
   reject: [
@@ -42,7 +42,7 @@ testRule({
     `,
       line: 3,
       message: messages.rejected,
-      description: "when extending with an element"
+      description: "when extending with an element",
     },
     {
       code: `
@@ -52,7 +52,7 @@ testRule({
     `,
       line: 3,
       message: messages.rejected,
-      description: "when extending with an id"
+      description: "when extending with an id",
     },
     {
       code: `
@@ -62,7 +62,7 @@ testRule({
     `,
       line: 3,
       message: messages.rejected,
-      description: "when extending with a class"
+      description: "when extending with a class",
     },
     {
       code: `
@@ -73,7 +73,7 @@ testRule({
       line: 3,
       message: messages.rejected,
       description:
-        "when extending with a dynamic selector whose prefix is not a placeholder"
-    }
-  ]
+        "when extending with a dynamic selector whose prefix is not a placeholder",
+    },
+  ],
 });

--- a/src/rules/at-extend-no-missing-placeholder/index.js
+++ b/src/rules/at-extend-no-missing-placeholder/index.js
@@ -5,11 +5,11 @@ export const ruleName = namespace("at-extend-no-missing-placeholder");
 
 export const messages = utils.ruleMessages(ruleName, {
   rejected:
-    "Expected a placeholder selector (e.g. %placeholder) to be used in @extend"
+    "Expected a placeholder selector (e.g. %placeholder) to be used in @extend",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(actual) {
@@ -20,7 +20,7 @@ export default function rule(actual) {
       return;
     }
 
-    root.walkAtRules("extend", atrule => {
+    root.walkAtRules("extend", (atrule) => {
       const isPlaceholder = atrule.params.trim()[0] === "%";
       const isInterpolation = /^#{.+}/.test(atrule.params.trim());
 
@@ -29,7 +29,7 @@ export default function rule(actual) {
           ruleName,
           result,
           node: atrule,
-          message: messages.rejected
+          message: messages.rejected,
         });
       }
     });

--- a/src/rules/at-function-named-arguments/__tests__/index.js
+++ b/src/rules/at-function-named-arguments/__tests__/index.js
@@ -13,7 +13,7 @@ testRule({
         border: reset();
       }
       `,
-      description: "Always. Example: no arguments with parenthesis."
+      description: "Always. Example: no arguments with parenthesis.",
     },
     {
       code: `
@@ -22,7 +22,7 @@ testRule({
         text-align: center;
       }
       `,
-      description: "Always. Example: no arguments with other declarations."
+      description: "Always. Example: no arguments with other declarations.",
     },
     {
       code: `
@@ -30,7 +30,7 @@ testRule({
         background-image: linear-gradient(0deg, blue, green 40%, red);
       }
       `,
-      description: "Always. Example: native CSS function is ignored."
+      description: "Always. Example: native CSS function is ignored.",
     },
     {
       code: `
@@ -39,7 +39,7 @@ testRule({
       }
       `,
       description:
-        "Always. Example: native CSS function is ignored inside a function call."
+        "Always. Example: native CSS function is ignored inside a function call.",
     },
     {
       code: `
@@ -48,7 +48,7 @@ testRule({
       }
       `,
       description:
-        "Always. Example: native CSS camel-casing function is ignored."
+        "Always. Example: native CSS camel-casing function is ignored.",
     },
     {
       code: `
@@ -56,7 +56,7 @@ testRule({
         border: reset($value: 40px);
       }
       `,
-      description: "Always. Example: single argument is named."
+      description: "Always. Example: single argument is named.",
     },
     {
       code: `
@@ -67,7 +67,7 @@ testRule({
       }
       `,
       description:
-        "Always. Example: single argument is named in multiline function call."
+        "Always. Example: single argument is named in multiline function call.",
     },
     {
       code: `
@@ -77,7 +77,7 @@ testRule({
         );
       }
       `,
-      description: "Always. Example: trailing comma after last argument."
+      description: "Always. Example: trailing comma after last argument.",
     },
     {
       code: `
@@ -85,7 +85,7 @@ testRule({
         border: reset($value: 40px, $second-value: 10px, $color: 'black');
       }
       `,
-      description: "Always. Example: all arguments are named."
+      description: "Always. Example: all arguments are named.",
     },
     {
       code: `
@@ -98,7 +98,7 @@ testRule({
       }
       `,
       description:
-        "Always. Example: all arguments are named in multiline function call."
+        "Always. Example: all arguments are named in multiline function call.",
     },
     {
       code: `
@@ -106,7 +106,7 @@ testRule({
         border: reset($value: $other-value);
       }
       `,
-      description: "Always. Example: single argument is a variable."
+      description: "Always. Example: single argument is a variable.",
     },
     {
       code: `
@@ -114,7 +114,7 @@ testRule({
         border: reset($value: #{$other-value});
       }
       `,
-      description: "Always. Example: single argument is an interpolated value."
+      description: "Always. Example: single argument is an interpolated value.",
     },
     {
       code: `
@@ -122,7 +122,7 @@ testRule({
         animation: anim($duration: 30 * 25ms);
       }
       `,
-      description: "Always. Example: single argument is a calculated value."
+      description: "Always. Example: single argument is a calculated value.",
     },
     {
       code: `
@@ -130,7 +130,7 @@ testRule({
         animation: anim($iteration: infinite);
       }
       `,
-      description: "Always. Example: single argument is an unquoted string."
+      description: "Always. Example: single argument is an unquoted string.",
     },
     {
       code: `
@@ -138,7 +138,7 @@ testRule({
         font-size: calc(10px * 2em);
       }
       `,
-      description: "Always. Example: single argument is an unquoted string."
+      description: "Always. Example: single argument is an unquoted string.",
     },
     {
       code: `
@@ -150,7 +150,7 @@ testRule({
         huge: $horizontal-list-spacing-huge
       );
       `,
-      description: "Always. Should ignore Sass maps."
+      description: "Always. Should ignore Sass maps.",
     },
     {
       code: `
@@ -162,7 +162,7 @@ testRule({
         huge: $horizontal-list-spacing-huge
       ) !default;
       `,
-      description: "Always. Should ignore Sass maps with default."
+      description: "Always. Should ignore Sass maps with default.",
     },
     {
       code: `
@@ -174,8 +174,8 @@ testRule({
         "b": blue($blue: $color)
       );
       `,
-      description: "Always. function call inside a map."
-    }
+      description: "Always. function call inside a map.",
+    },
   ],
 
   reject: [
@@ -188,7 +188,7 @@ testRule({
       line: 3,
       column: 9,
       message: messages.expected,
-      description: "Always. Example: single argument that is not named."
+      description: "Always. Example: single argument that is not named.",
     },
     {
       code: `
@@ -200,15 +200,15 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.expected
+          message: messages.expected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.expected
-        }
+          message: messages.expected,
+        },
       ],
-      description: "Always. Example: first argument is not named."
+      description: "Always. Example: first argument is not named.",
     },
     {
       code: `
@@ -223,16 +223,16 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.expected
+          message: messages.expected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.expected
-        }
+          message: messages.expected,
+        },
       ],
       description:
-        "Always. Example: first argument is not named in multiline function call."
+        "Always. Example: first argument is not named in multiline function call.",
     },
     {
       code: `
@@ -244,7 +244,7 @@ testRule({
       column: 9,
       message: messages.expected,
       description:
-        "Always. Example: single argument is a variable but is not named."
+        "Always. Example: single argument is a variable but is not named.",
     },
     {
       code: `
@@ -256,7 +256,7 @@ testRule({
       column: 9,
       message: messages.expected,
       description:
-        "Always. Example: single argument is a calculated value but is not named."
+        "Always. Example: single argument is a calculated value but is not named.",
     },
     {
       code: `
@@ -268,16 +268,16 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.expected
+          message: messages.expected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.expected
-        }
+          message: messages.expected,
+        },
       ],
       description:
-        "Always. Example: first argument is named but remaining are not."
+        "Always. Example: first argument is named but remaining are not.",
     },
     {
       code: `
@@ -289,15 +289,15 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.expected
+          message: messages.expected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.expected
-        }
+          message: messages.expected,
+        },
       ],
-      description: "Always. Example: mixed named arguments."
+      description: "Always. Example: mixed named arguments.",
     },
     {
       code: `
@@ -309,7 +309,7 @@ testRule({
       column: 9,
       message: messages.expected,
       description:
-        "Always. Example: native CSS function inside a function call."
+        "Always. Example: native CSS function inside a function call.",
     },
     {
       code: `
@@ -325,22 +325,22 @@ testRule({
         {
           line: 4,
           column: 7,
-          message: messages.expected
+          message: messages.expected,
         },
         {
           line: 4,
           column: 7,
-          message: messages.expected
+          message: messages.expected,
         },
         {
           line: 4,
           column: 7,
-          message: messages.expected
-        }
+          message: messages.expected,
+        },
       ],
-      description: "Always. function call inside a map."
-    }
-  ]
+      description: "Always. function call inside a map.",
+    },
+  ],
 });
 
 // Not allowed ("never")
@@ -356,7 +356,7 @@ testRule({
         background-image: linear-gradient(0deg, blue, green 40%, red);
       }
       `,
-      description: "Never. Example: native CSS function is ignored."
+      description: "Never. Example: native CSS function is ignored.",
     },
     {
       code: `
@@ -365,7 +365,7 @@ testRule({
       }
       `,
       description:
-        "Never. Example: native CSS camel-casing function is ignored."
+        "Never. Example: native CSS camel-casing function is ignored.",
     },
     {
       code: `
@@ -373,7 +373,7 @@ testRule({
         border: reset();
       }
       `,
-      description: "Never. Example: no arguments with parenthesis."
+      description: "Never. Example: no arguments with parenthesis.",
     },
     {
       code: `
@@ -381,7 +381,7 @@ testRule({
         border: reset(40px);
       }
     `,
-      description: "Never. Example: single argument that is not named."
+      description: "Never. Example: single argument that is not named.",
     },
     {
       code: `
@@ -389,7 +389,7 @@ testRule({
         border: reset(40px, 10px);
       }
     `,
-      description: "Never. Example: multiple arguments that are not named."
+      description: "Never. Example: multiple arguments that are not named.",
     },
     {
       code: `
@@ -401,7 +401,7 @@ testRule({
       }
     `,
       description:
-        "Never. Example: multiple arguments that are not named in multiline function call."
+        "Never. Example: multiple arguments that are not named in multiline function call.",
     },
     {
       code: `
@@ -410,7 +410,7 @@ testRule({
       }
     `,
       description:
-        "Never. Example: single argument is a variable and are not named."
+        "Never. Example: single argument is a variable and are not named.",
     },
     {
       code: `
@@ -419,7 +419,7 @@ testRule({
       }
     `,
       description:
-        "Never. Example: single argument is a calculated value and not named."
+        "Never. Example: single argument is a calculated value and not named.",
     },
     {
       code: `
@@ -428,7 +428,7 @@ testRule({
       }
     `,
       description:
-        "Never. Example: single argument is a quoted string and not named."
+        "Never. Example: single argument is a quoted string and not named.",
     },
     {
       code: `
@@ -437,7 +437,7 @@ testRule({
       }
     `,
       description:
-        "Never. Example: single argument is an unquoted string and not named."
+        "Never. Example: single argument is an unquoted string and not named.",
     },
     {
       code: `
@@ -446,7 +446,7 @@ testRule({
       }
     `,
       description:
-        "Never. Example: single argument is an interpolated value and not named."
+        "Never. Example: single argument is an interpolated value and not named.",
     },
     {
       code: `
@@ -455,7 +455,7 @@ testRule({
       }
       `,
       description:
-        "Never. Example: native CSS function is ignored inside a function call."
+        "Never. Example: native CSS function is ignored inside a function call.",
     },
     {
       code: `
@@ -467,8 +467,8 @@ testRule({
         "b": blue($color)
       );
       `,
-      description: "Never. function call inside a map."
-    }
+      description: "Never. function call inside a map.",
+    },
   ],
 
   reject: [
@@ -481,7 +481,7 @@ testRule({
       line: 3,
       column: 9,
       message: messages.rejected,
-      description: "Never. Example: single argument is named."
+      description: "Never. Example: single argument is named.",
     },
     {
       code: `
@@ -492,7 +492,7 @@ testRule({
       line: 3,
       column: 9,
       message: messages.rejected,
-      description: "Never. Example: single argument is a variable."
+      description: "Never. Example: single argument is a variable.",
     },
     {
       code: `
@@ -503,7 +503,7 @@ testRule({
       line: 3,
       column: 9,
       message: messages.rejected,
-      description: "Never. Example: single argument is an interpolated value."
+      description: "Never. Example: single argument is an interpolated value.",
     },
     {
       code: `
@@ -514,7 +514,7 @@ testRule({
       line: 3,
       column: 9,
       message: messages.rejected,
-      description: "Never. Example: single argument is a calculated value."
+      description: "Never. Example: single argument is a calculated value.",
     },
     {
       code: `
@@ -525,7 +525,7 @@ testRule({
       line: 3,
       column: 9,
       message: messages.rejected,
-      description: "Never. Example: single argument is a quoted string."
+      description: "Never. Example: single argument is a quoted string.",
     },
     {
       code: `
@@ -536,7 +536,7 @@ testRule({
       line: 3,
       column: 9,
       message: messages.rejected,
-      description: "Never. Example: single argument is an unquoted string."
+      description: "Never. Example: single argument is an unquoted string.",
     },
     {
       code: `
@@ -548,20 +548,20 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.rejected
+          message: messages.rejected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.rejected
+          message: messages.rejected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.rejected
-        }
+          message: messages.rejected,
+        },
       ],
-      description: "Never. Example: all arguments are named."
+      description: "Never. Example: all arguments are named.",
     },
     {
       code: `
@@ -577,21 +577,21 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.rejected
+          message: messages.rejected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.rejected
+          message: messages.rejected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.rejected
-        }
+          message: messages.rejected,
+        },
       ],
       description:
-        "Never. Example: all arguments are named in multiline function call."
+        "Never. Example: all arguments are named in multiline function call.",
     },
     {
       code: `
@@ -603,7 +603,7 @@ testRule({
       column: 9,
       message: messages.rejected,
       description:
-        "Never. Example: first argument is named but remaining are not."
+        "Never. Example: first argument is named but remaining are not.",
     },
     {
       code: `
@@ -614,7 +614,7 @@ testRule({
       line: 3,
       column: 9,
       message: messages.rejected,
-      description: "Never. Example: mixed named arguments."
+      description: "Never. Example: mixed named arguments.",
     },
     {
       code: `
@@ -625,7 +625,8 @@ testRule({
       line: 3,
       column: 9,
       message: messages.rejected,
-      description: "Never. Example: native CSS function inside a function call."
+      description:
+        "Never. Example: native CSS function inside a function call.",
     },
     {
       code: `
@@ -641,22 +642,22 @@ testRule({
         {
           line: 4,
           column: 7,
-          message: messages.rejected
+          message: messages.rejected,
         },
         {
           line: 4,
           column: 7,
-          message: messages.rejected
+          message: messages.rejected,
         },
         {
           line: 4,
           column: 7,
-          message: messages.rejected
-        }
+          message: messages.rejected,
+        },
       ],
-      description: "Never. function call inside a map."
-    }
-  ]
+      description: "Never. function call inside a map.",
+    },
+  ],
 });
 
 testRule({
@@ -672,7 +673,7 @@ testRule({
       }
       `,
       description:
-        "Always and ignore single argument. Example: native CSS function is ignored."
+        "Always and ignore single argument. Example: native CSS function is ignored.",
     },
     {
       code: `
@@ -681,7 +682,7 @@ testRule({
       }
       `,
       description:
-        "Always and ignore single argument. Example: native CSS camel-casing function is ignored."
+        "Always and ignore single argument. Example: native CSS camel-casing function is ignored.",
     },
     {
       code: `
@@ -690,7 +691,7 @@ testRule({
       }
       `,
       description:
-        "Always and ignore single argument. Example: no arguments with parenthesis."
+        "Always and ignore single argument. Example: no arguments with parenthesis.",
     },
     {
       code: `
@@ -699,7 +700,7 @@ testRule({
       }
     `,
       description:
-        "Always and ignore single argument. Example: single argument that is not named."
+        "Always and ignore single argument. Example: single argument that is not named.",
     },
     {
       code: `
@@ -708,7 +709,7 @@ testRule({
       }
     `,
       description:
-        "Always and ignore single argument. Example: single argument is a variable and is not named."
+        "Always and ignore single argument. Example: single argument is a variable and is not named.",
     },
     {
       code: `
@@ -717,7 +718,7 @@ testRule({
       }
     `,
       description:
-        "Always and ignore single argument. Example: single argument is a calculated value and is not named."
+        "Always and ignore single argument. Example: single argument is a calculated value and is not named.",
     },
     {
       code: `
@@ -726,7 +727,7 @@ testRule({
       }
       `,
       description:
-        "Always and ignore single argument. Example: all arguments are named."
+        "Always and ignore single argument. Example: all arguments are named.",
     },
     {
       code: `
@@ -735,7 +736,7 @@ testRule({
       }
       `,
       description:
-        "Always and ignore single argument. Example: single argument is named."
+        "Always and ignore single argument. Example: single argument is named.",
     },
     {
       code: `
@@ -744,7 +745,7 @@ testRule({
       }
       `,
       description:
-        "Always and ignore single argument. Example: single named argument is a variable."
+        "Always and ignore single argument. Example: single named argument is a variable.",
     },
     {
       code: `
@@ -753,7 +754,7 @@ testRule({
       }
       `,
       description:
-        "Always and ignore single argument. Example: single named argument is an interpolated value."
+        "Always and ignore single argument. Example: single named argument is an interpolated value.",
     },
     {
       code: `
@@ -762,7 +763,7 @@ testRule({
       }
       `,
       description:
-        "Always and ignore single argument. Example: single named argument is a calculated value."
+        "Always and ignore single argument. Example: single named argument is a calculated value.",
     },
     {
       code: `
@@ -771,7 +772,7 @@ testRule({
       }
       `,
       description:
-        "Always and ignore single argument. Example: single named argument is a quoted string."
+        "Always and ignore single argument. Example: single named argument is a quoted string.",
     },
     {
       code: `
@@ -780,7 +781,7 @@ testRule({
       }
       `,
       description:
-        "Always and ignore single argument. Example: single argument is an unquoted string."
+        "Always and ignore single argument. Example: single argument is an unquoted string.",
     },
     {
       code: `
@@ -793,8 +794,8 @@ testRule({
       }
       `,
       description:
-        "Always and ignore single argument. Example: all arguments are named in multiline function call."
-    }
+        "Always and ignore single argument. Example: all arguments are named in multiline function call.",
+    },
   ],
 
   reject: [
@@ -811,7 +812,7 @@ testRule({
       column: 9,
       message: messages.expected,
       description:
-        "Always and ignore single argument. Example: first argument is named but remaining are not in multiline function call."
+        "Always and ignore single argument. Example: first argument is named but remaining are not in multiline function call.",
     },
     {
       code: `
@@ -823,16 +824,16 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.expected
+          message: messages.expected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.expected
-        }
+          message: messages.expected,
+        },
       ],
       description:
-        "Always and ignore single argument. Example: mixed named arguments."
+        "Always and ignore single argument. Example: mixed named arguments.",
     },
     {
       code: `
@@ -844,16 +845,16 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.expected
+          message: messages.expected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.expected
-        }
+          message: messages.expected,
+        },
       ],
       description:
-        "Always and ignore single argument. Example: first argument is named but remaining are not."
+        "Always and ignore single argument. Example: first argument is named but remaining are not.",
     },
     {
       code: `
@@ -865,18 +866,18 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.expected
+          message: messages.expected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.expected
-        }
+          message: messages.expected,
+        },
       ],
       description:
-        "Always and ignore single argument. Example: mixed named arguments."
-    }
-  ]
+        "Always and ignore single argument. Example: mixed named arguments.",
+    },
+  ],
 });
 
 testRule({
@@ -892,7 +893,7 @@ testRule({
       }
       `,
       description:
-        "Never and ignore single argument. Example: native CSS function is ignored."
+        "Never and ignore single argument. Example: native CSS function is ignored.",
     },
     {
       code: `
@@ -901,7 +902,7 @@ testRule({
       }
       `,
       description:
-        "Never and ignore single argument. Example: native CSS camel-casing function is ignored."
+        "Never and ignore single argument. Example: native CSS camel-casing function is ignored.",
     },
     {
       code: `
@@ -910,7 +911,7 @@ testRule({
       }
       `,
       description:
-        "Never and ignore single argument. Example: no arguments with parenthesis."
+        "Never and ignore single argument. Example: no arguments with parenthesis.",
     },
     {
       code: `
@@ -919,7 +920,7 @@ testRule({
       }
     `,
       description:
-        "Never and ignore single argument. Example: single argument that is not named."
+        "Never and ignore single argument. Example: single argument that is not named.",
     },
     {
       code: `
@@ -928,7 +929,7 @@ testRule({
       }
     `,
       description:
-        "Never and ignore single argument. Example: multiple arguments that are not named."
+        "Never and ignore single argument. Example: multiple arguments that are not named.",
     },
     {
       code: `
@@ -940,7 +941,7 @@ testRule({
       }
     `,
       description:
-        "Never and ignore single argument. Example: multiple arguments that are not named in multiline function call."
+        "Never and ignore single argument. Example: multiple arguments that are not named in multiline function call.",
     },
     {
       code: `
@@ -949,7 +950,7 @@ testRule({
       }
     `,
       description:
-        "Never and ignore single argument. Example: single argument is a variable and are not named."
+        "Never and ignore single argument. Example: single argument is a variable and are not named.",
     },
     {
       code: `
@@ -958,7 +959,7 @@ testRule({
       }
     `,
       description:
-        "Never and ignore single argument. Example: single argument is a calculated value and not named."
+        "Never and ignore single argument. Example: single argument is a calculated value and not named.",
     },
     {
       code: `
@@ -967,7 +968,7 @@ testRule({
       }
     `,
       description:
-        "Never and ignore single argument. Example: single argument is a quoted string and not named."
+        "Never and ignore single argument. Example: single argument is a quoted string and not named.",
     },
     {
       code: `
@@ -976,7 +977,7 @@ testRule({
       }
     `,
       description:
-        "Never and ignore single argument. Example: single argument is an unquoted string and not named."
+        "Never and ignore single argument. Example: single argument is an unquoted string and not named.",
     },
     {
       code: `
@@ -985,7 +986,7 @@ testRule({
       }
     `,
       description:
-        "Never and ignore single argument. Example: single argument is an interpolated value and not named."
+        "Never and ignore single argument. Example: single argument is an interpolated value and not named.",
     },
     {
       code: `
@@ -994,7 +995,7 @@ testRule({
       }
       `,
       description:
-        "Never and ignore single argument. Example: single argument is named."
+        "Never and ignore single argument. Example: single argument is named.",
     },
     {
       code: `
@@ -1003,7 +1004,7 @@ testRule({
       }
       `,
       description:
-        "Never and ignore single argument. Example: single argument is a variable."
+        "Never and ignore single argument. Example: single argument is a variable.",
     },
     {
       code: `
@@ -1012,7 +1013,7 @@ testRule({
       }
       `,
       description:
-        "Never and ignore single argument. Example: single argument is an interpolated value."
+        "Never and ignore single argument. Example: single argument is an interpolated value.",
     },
     {
       code: `
@@ -1021,7 +1022,7 @@ testRule({
       }
       `,
       description:
-        "Never and ignore single argument. Example: single argument is a calculated value."
+        "Never and ignore single argument. Example: single argument is a calculated value.",
     },
     {
       code: `
@@ -1030,7 +1031,7 @@ testRule({
       }
       `,
       description:
-        "Never and ignore single argument. Example: single argument is a quoted string."
+        "Never and ignore single argument. Example: single argument is a quoted string.",
     },
     {
       code: `
@@ -1039,8 +1040,8 @@ testRule({
       }
       `,
       description:
-        "Never and ignore single argument. Example: single argument is an unquoted string."
-    }
+        "Never and ignore single argument. Example: single argument is an unquoted string.",
+    },
   ],
 
   reject: [
@@ -1054,21 +1055,21 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.rejected
+          message: messages.rejected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.rejected
+          message: messages.rejected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.rejected
-        }
+          message: messages.rejected,
+        },
       ],
       description:
-        "Never and ignore single argument. Example: all arguments are named."
+        "Never and ignore single argument. Example: all arguments are named.",
     },
     {
       code: `
@@ -1084,21 +1085,21 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.rejected
+          message: messages.rejected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.rejected
+          message: messages.rejected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.rejected
-        }
+          message: messages.rejected,
+        },
       ],
       description:
-        "Never and ignore single argument. Example: all arguments are named in multiline function call."
+        "Never and ignore single argument. Example: all arguments are named in multiline function call.",
     },
     {
       code: `
@@ -1110,7 +1111,7 @@ testRule({
       column: 9,
       message: messages.rejected,
       description:
-        "Never and ignore single argument. Example: first argument is named but remaining are not."
+        "Never and ignore single argument. Example: first argument is named but remaining are not.",
     },
     {
       code: `
@@ -1122,9 +1123,9 @@ testRule({
       column: 9,
       message: messages.rejected,
       description:
-        "Never and ignore single argument. Example: mixed named arguments."
-    }
-  ]
+        "Never and ignore single argument. Example: mixed named arguments.",
+    },
+  ],
 });
 
 testRule({
@@ -1140,7 +1141,7 @@ testRule({
       }
       `,
       description:
-        "Always and ignore function. Example: single argument is named."
+        "Always and ignore function. Example: single argument is named.",
     },
     {
       code: `
@@ -1148,7 +1149,7 @@ testRule({
         content: map-get($map, key);
       }
       `,
-      description: "Always and ignore function: ignored function."
+      description: "Always and ignore function: ignored function.",
     },
     {
       code: `
@@ -1156,7 +1157,7 @@ testRule({
         content: my-func($map, key);
       }
       `,
-      description: "Always and ignore function: ignored function."
+      description: "Always and ignore function: ignored function.",
     },
     {
       code: `
@@ -1164,7 +1165,7 @@ testRule({
         content: MY-FUNC($map, key);
       }
       `,
-      description: "Always and ignore function: ignored function."
+      description: "Always and ignore function: ignored function.",
     },
     {
       code: `
@@ -1172,8 +1173,8 @@ testRule({
         content: ffunct($map, key);
       }
       `,
-      description: "Always and ignore function: ignored function."
-    }
+      description: "Always and ignore function: ignored function.",
+    },
   ],
 
   reject: [
@@ -1187,7 +1188,7 @@ testRule({
       column: 9,
       message: messages.expected,
       description:
-        "Always and ignore function. Example: single argument that is not named."
+        "Always and ignore function. Example: single argument that is not named.",
     },
     {
       code: `
@@ -1199,16 +1200,16 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.expected
+          message: messages.expected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.expected
-        }
+          message: messages.expected,
+        },
       ],
       description:
-        "Always and ignore function. Example: function name's case does not match regex."
+        "Always and ignore function. Example: function name's case does not match regex.",
     },
     {
       code: `
@@ -1220,18 +1221,18 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.expected
+          message: messages.expected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.expected
-        }
+          message: messages.expected,
+        },
       ],
       description:
-        "Always and ignore function. Example: function name does not match string or regex."
-    }
-  ]
+        "Always and ignore function. Example: function name does not match string or regex.",
+    },
+  ],
 });
 
 testRule({
@@ -1246,7 +1247,7 @@ testRule({
         border: reset(40px);
       }
     `,
-      description: "Never. Example: single argument that is not named."
+      description: "Never. Example: single argument that is not named.",
     },
     {
       code: `
@@ -1254,7 +1255,7 @@ testRule({
         border: reset(40px, 10px);
       }
     `,
-      description: "Never. Example: multiple arguments that are not named."
+      description: "Never. Example: multiple arguments that are not named.",
     },
     {
       code: `
@@ -1262,7 +1263,7 @@ testRule({
         content: somefunc($key: 1, $key2: 2);
       }
       `,
-      description: "Never and ignore function: ignored function."
+      description: "Never and ignore function: ignored function.",
     },
     {
       code: `
@@ -1270,7 +1271,7 @@ testRule({
         content: my-func($key: 1, $key2: 2);
       }
       `,
-      description: "Never and ignore function: ignored function."
+      description: "Never and ignore function: ignored function.",
     },
     {
       code: `
@@ -1278,8 +1279,8 @@ testRule({
         content: ffunct($key: 1, $key2: 2);
       }
       `,
-      description: "Never and ignore function: ignored function."
-    }
+      description: "Never and ignore function: ignored function.",
+    },
   ],
 
   reject: [
@@ -1292,7 +1293,7 @@ testRule({
       line: 3,
       column: 9,
       message: messages.rejected,
-      description: "Never. Example: single argument is named."
-    }
-  ]
+      description: "Never. Example: single argument is named.",
+    },
+  ],
 });

--- a/src/rules/at-function-named-arguments/index.js
+++ b/src/rules/at-function-named-arguments/index.js
@@ -6,18 +6,18 @@ import {
   namespace,
   optionsHaveIgnored,
   parseFunctionArguments,
-  ruleUrl
+  ruleUrl,
 } from "../../utils";
 
 export const ruleName = namespace("at-function-named-arguments");
 
 export const messages = utils.ruleMessages(ruleName, {
   expected: "Expected a named parameter to be used in function call",
-  rejected: "Unexpected a named parameter in function call"
+  rejected: "Unexpected a named parameter in function call",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 const isScssVarRegExp = /^\$\S*/;
@@ -29,15 +29,15 @@ export default function rule(expectation, options) {
       ruleName,
       {
         actual: expectation,
-        possible: ["always", "never"]
+        possible: ["always", "never"],
       },
       {
         actual: options,
         possible: {
           ignore: ["single-argument"],
-          ignoreFunctions: [isString]
+          ignoreFunctions: [isString],
         },
-        optional: true
+        optional: true,
       }
     );
 
@@ -50,8 +50,8 @@ export default function rule(expectation, options) {
       "single-argument"
     );
 
-    root.walkDecls(decl => {
-      valueParser(decl.value).walk(node => {
+    root.walkDecls((decl) => {
+      valueParser(decl.value).walk((node) => {
         if (
           node.type !== "function" ||
           isNativeCssFunction(node.value) ||
@@ -63,7 +63,7 @@ export default function rule(expectation, options) {
         const hasFuncIgnored =
           options &&
           options.ignoreFunctions &&
-          options.ignoreFunctions.some(f => {
+          options.ignoreFunctions.some((f) => {
             const isRegex = /^\/.*\//.test(f);
 
             if (!isRegex) {
@@ -86,7 +86,7 @@ export default function rule(expectation, options) {
           return;
         }
 
-        args.forEach(arg => {
+        args.forEach((arg) => {
           switch (expectation) {
             case "never": {
               if (!arg.key) {
@@ -97,7 +97,7 @@ export default function rule(expectation, options) {
                 message: messages.rejected,
                 node: decl,
                 result,
-                ruleName
+                ruleName,
               });
               break;
             }
@@ -111,7 +111,7 @@ export default function rule(expectation, options) {
                 message: messages.expected,
                 node: decl,
                 result,
-                ruleName
+                ruleName,
               });
               break;
             }

--- a/src/rules/at-function-parentheses-space-before/__tests__/index.js
+++ b/src/rules/at-function-parentheses-space-before/__tests__/index.js
@@ -12,43 +12,43 @@ testRule({
       @function foo () {
       }
     `,
-      description: "No params."
+      description: "No params.",
     },
     {
       code: `
       @function foo ($links: 10){
       }
     `,
-      description: "With default params."
+      description: "With default params.",
     },
     {
       code: `
       @function foo ($n) {
       }
     `,
-      description: "With params."
+      description: "With params.",
     },
     {
       code: `
       @function  foo ($n) {
       }
     `,
-      description: "Extra spaces after @function."
+      description: "Extra spaces after @function.",
     },
     {
       code: `
       @functio1n foo ($n) {
       }
     `,
-      description: "Not a SCSS function, skipping."
+      description: "Not a SCSS function, skipping.",
     },
     {
       code: `
       @function foo-bar () {
       }
     `,
-      description: "No params, hyphenated name."
-    }
+      description: "No params, hyphenated name.",
+    },
   ],
 
   reject: [
@@ -66,7 +66,7 @@ testRule({
     `,
       line: 2,
       message: messages.expectedBefore(),
-      description: "Newline after function name"
+      description: "Newline after function name",
     },
     {
       code: `
@@ -79,7 +79,7 @@ testRule({
     `,
       line: 2,
       message: messages.expectedBefore(),
-      description: "No space before parentheses."
+      description: "No space before parentheses.",
     },
     {
       code: `
@@ -92,7 +92,7 @@ testRule({
     `,
       line: 2,
       message: messages.expectedBefore(),
-      description: "Extra spaces after @function."
+      description: "Extra spaces after @function.",
     },
     {
       code: `
@@ -105,9 +105,9 @@ testRule({
     `,
       line: 2,
       message: messages.expectedBefore(),
-      description: "No space before parentheses, hyphenated name."
-    }
-  ]
+      description: "No space before parentheses, hyphenated name.",
+    },
+  ],
 });
 
 testRule({
@@ -122,43 +122,43 @@ testRule({
       @function foo() {
       }
     `,
-      description: "No params."
+      description: "No params.",
     },
     {
       code: `
       @function foo($links: 10){
       }
     `,
-      description: "With default params."
+      description: "With default params.",
     },
     {
       code: `
       @function foo($n) {
       }
     `,
-      description: "With params."
+      description: "With params.",
     },
     {
       code: `
       @function  foo($n) {
       }
     `,
-      description: "Extra spaces after @function."
+      description: "Extra spaces after @function.",
     },
     {
       code: `
       @functio1n foo($n) {
       }
     `,
-      description: "Not a SCSS function, skipping."
+      description: "Not a SCSS function, skipping.",
     },
     {
       code: `
       @function foo-bar() {
       }
     `,
-      description: "No params, hyphenated name."
-    }
+      description: "No params, hyphenated name.",
+    },
   ],
 
   reject: [
@@ -176,7 +176,7 @@ testRule({
     `,
       line: 2,
       message: messages.rejectedBefore(),
-      description: "Newline after function name"
+      description: "Newline after function name",
     },
     {
       code: `
@@ -189,7 +189,7 @@ testRule({
     `,
       line: 2,
       message: messages.rejectedBefore(),
-      description: "Single space before parentheses."
+      description: "Single space before parentheses.",
     },
     {
       code: `
@@ -202,7 +202,7 @@ testRule({
     `,
       line: 2,
       message: messages.rejectedBefore(),
-      description: "Multiple spaces before parentheses."
+      description: "Multiple spaces before parentheses.",
     },
     {
       code: `
@@ -215,7 +215,7 @@ testRule({
     `,
       line: 2,
       message: messages.rejectedBefore(),
-      description: "Single space before parentheses, hyphenated name."
-    }
-  ]
+      description: "Single space before parentheses, hyphenated name.",
+    },
+  ],
 });

--- a/src/rules/at-function-parentheses-space-before/index.js
+++ b/src/rules/at-function-parentheses-space-before/index.js
@@ -7,18 +7,18 @@ export const messages = utils.ruleMessages(ruleName, {
   rejectedBefore: () =>
     "Unexpected whitespace before parentheses in function declaration",
   expectedBefore: () =>
-    "Expected a single space before parentheses in function declaration"
+    "Expected a single space before parentheses in function declaration",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(value, _, context) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: value,
-      possible: ["always", "never"]
+      possible: ["always", "never"],
     });
 
     if (!validOptions) {
@@ -30,7 +30,7 @@ export default function rule(value, _, context) {
 
     const checker = whitespaceChecker("space", value, messages).before;
 
-    root.walkAtRules("function", decl => {
+    root.walkAtRules("function", (decl) => {
       if (context.fix) {
         decl.params = decl.params.replace(match, replacement);
 
@@ -40,7 +40,8 @@ export default function rule(value, _, context) {
       checker({
         source: decl.params,
         index: decl.params.indexOf("("),
-        err: message => utils.report({ message, node: decl, result, ruleName })
+        err: (message) =>
+          utils.report({ message, node: decl, result, ruleName }),
       });
     });
   };

--- a/src/rules/at-function-pattern/__tests__/index.js
+++ b/src/rules/at-function-pattern/__tests__/index.js
@@ -12,42 +12,42 @@ testRule({
       @function foo () {
       }
     `,
-      description: "Regexp: sequence part. Example: full match."
+      description: "Regexp: sequence part. Example: full match.",
     },
     {
       code: `
       @function foo ($links: 10){
       }
     `,
-      description: "Regexp: sequence part. Example: full match, with params."
+      description: "Regexp: sequence part. Example: full match, with params.",
     },
     {
       code: `
       @function _foo ($n) {
       }
     `,
-      description: "Regexp: sequence part. Example: matches at the end."
+      description: "Regexp: sequence part. Example: matches at the end.",
     },
     {
       code: `
       @function food ($n) {
       }
     `,
-      description: "Regexp: sequence part. Example: matches at the beginning."
+      description: "Regexp: sequence part. Example: matches at the beginning.",
     },
     {
       code: `
       @function  foo ($n) {
       }
     `,
-      description: "Regexp: sequence part. Example: space after @function."
+      description: "Regexp: sequence part. Example: space after @function.",
     },
     {
       code: `
       @functio1n fowdo ($n) {
       }
     `,
-      description: "Any pattern. Example: not a SCSS function, skipping."
+      description: "Any pattern. Example: not a SCSS function, skipping.",
     },
     {
       code: `
@@ -57,7 +57,7 @@ testRule({
       }
     `,
       description:
-        "Regexp: sequence part. Example: newlines around a function name."
+        "Regexp: sequence part. Example: newlines around a function name.",
     },
     {
       code: `
@@ -66,8 +66,8 @@ testRule({
         $n
       ) {}
     `,
-      description: "Regexp: sequence part. Example: newline after a brace."
-    }
+      description: "Regexp: sequence part. Example: newline after a brace.",
+    },
   ],
 
   reject: [
@@ -81,9 +81,9 @@ testRule({
       endLine: 3,
       endColumn: 0,
       message: messages.expected,
-      description: "Regexp: sequence part. Example: symbol in between."
-    }
-  ]
+      description: "Regexp: sequence part. Example: symbol in between.",
+    },
+  ],
 });
 
 // Testing against a string, sequence part
@@ -98,22 +98,22 @@ testRule({
       @function foo ($p) {
       }
     `,
-      description: "String: sequence part. Example: full match."
+      description: "String: sequence part. Example: full match.",
     },
     {
       code: `
       @function _foo ($p) {
       }
     `,
-      description: "String: sequence part. Example: matches at the end."
+      description: "String: sequence part. Example: matches at the end.",
     },
     {
       code: `
       @function food ($p) {
       }
     `,
-      description: "String: sequence part. Example: matches at the beginning."
-    }
+      description: "String: sequence part. Example: matches at the beginning.",
+    },
   ],
 
   reject: [
@@ -127,7 +127,7 @@ testRule({
       endLine: 3,
       endColumn: 0,
       message: messages.expected,
-      description: "String: sequence part. Example: symbol in between."
+      description: "String: sequence part. Example: symbol in between.",
     },
     {
       code: `
@@ -139,9 +139,9 @@ testRule({
       endLine: 3,
       endColumn: 0,
       message: messages.expected,
-      description: "String: sequence part. Example: not a full sequence."
-    }
-  ]
+      description: "String: sequence part. Example: not a full sequence.",
+    },
+  ],
 });
 
 // Testing against a regex, full match
@@ -156,14 +156,14 @@ testRule({
       @function foo ($options: ()) {}
     `,
       description:
-        "Regexp: strict match. Example: function with params that have parens INSIDE."
+        "Regexp: strict match. Example: function with params that have parens INSIDE.",
     },
     {
       code: `
       @function foo ($options: (), $lol: ()) {}
     `,
       description:
-        "Regexp: strict match. Example: function with params that have parens INSIDE #2."
+        "Regexp: strict match. Example: function with params that have parens INSIDE #2.",
     },
     {
       code: `
@@ -172,14 +172,14 @@ testRule({
       }
     `,
       description:
-        "Regexp: strict match. Example: function with params that have parens INSIDE #3."
+        "Regexp: strict match. Example: function with params that have parens INSIDE #3.",
     },
     {
       code: `
       @function foo ($p) {
       }
     `,
-      description: "Regexp: strict match. Example: matches."
+      description: "Regexp: strict match. Example: matches.",
     },
     {
       code: `
@@ -189,8 +189,8 @@ testRule({
       }
     `,
       description:
-        "Regexp: strict match. Example: newlines around a function name."
-    }
+        "Regexp: strict match. Example: newlines around a function name.",
+    },
   ],
 
   reject: [
@@ -204,7 +204,7 @@ testRule({
       endLine: 3,
       endColumn: 0,
       message: messages.expected,
-      description: "Regexp: strict match. Example: matches at the end."
+      description: "Regexp: strict match. Example: matches at the end.",
     },
     {
       code: `
@@ -216,7 +216,7 @@ testRule({
       endLine: 3,
       endColumn: 0,
       message: messages.expected,
-      description: "Regexp: strict match. Example: matches at the beginning."
+      description: "Regexp: strict match. Example: matches at the beginning.",
     },
     {
       code: `
@@ -228,7 +228,7 @@ testRule({
       endLine: 3,
       endColumn: 0,
       message: messages.expected,
-      description: "Regexp: strict match. Example: symbol in between."
+      description: "Regexp: strict match. Example: symbol in between.",
     },
     {
       code: `
@@ -243,9 +243,9 @@ testRule({
       endColumn: 0,
       message: messages.expected,
       description:
-        "Regexp: strict match. Example: function name divided by newlines."
-    }
-  ]
+        "Regexp: strict match. Example: function name divided by newlines.",
+    },
+  ],
 });
 
 // Testing against a regex, match at the beginning
@@ -260,7 +260,7 @@ testRule({
       @function foo ($p) {
       }
     `,
-      description: "Regexp: pattern at the beginning. Example: matches."
+      description: "Regexp: pattern at the beginning. Example: matches.",
     },
     {
       code: `
@@ -268,8 +268,8 @@ testRule({
       }
     `,
       description:
-        "Regexp: pattern at the beginning. Example: matches at the beginning."
-    }
+        "Regexp: pattern at the beginning. Example: matches at the beginning.",
+    },
   ],
 
   reject: [
@@ -284,7 +284,7 @@ testRule({
       endColumn: 0,
       message: messages.expected,
       description:
-        "Regexp: pattern at the beginning. Example: matches at the end."
+        "Regexp: pattern at the beginning. Example: matches at the end.",
     },
     {
       code: `
@@ -297,9 +297,9 @@ testRule({
       endColumn: 0,
       message: messages.expected,
       description:
-        "Regexp: pattern at the beginning. Example: symbol in between."
-    }
-  ]
+        "Regexp: pattern at the beginning. Example: symbol in between.",
+    },
+  ],
 });
 
 // Testing against a regex, SUIT naming
@@ -311,12 +311,12 @@ testRule({
   accept: [
     {
       code: "@function Foo-bar  ( $p: 1 ) {}",
-      description: "Regexp: SUIT component. Example: comply"
+      description: "Regexp: SUIT component. Example: comply",
     },
     {
       code: "@function Foo-barBaz {}",
-      description: "Regexp: SUIT component. Example: comply"
-    }
+      description: "Regexp: SUIT component. Example: comply",
+    },
   ],
 
   reject: [
@@ -328,7 +328,7 @@ testRule({
       endColumn: 0,
       message: messages.expected,
       description:
-        "Regexp: SUIT component. Example: starts with lowercase, two elements"
+        "Regexp: SUIT component. Example: starts with lowercase, two elements",
     },
     {
       code: "@function foo-bar ($p) {}",
@@ -337,7 +337,7 @@ testRule({
       endLine: 2,
       endColumn: 0,
       message: messages.expected,
-      description: "Regexp: SUIT component. Example: starts with lowercase"
+      description: "Regexp: SUIT component. Example: starts with lowercase",
     },
     {
       code: "@function Foo-Bar ($p) {}",
@@ -347,7 +347,7 @@ testRule({
       endColumn: 0,
       message: messages.expected,
       description:
-        "Regexp: SUIT component. Example: element starts with uppercase"
-    }
-  ]
+        "Regexp: SUIT component. Example: element starts with uppercase",
+    },
+  ],
 });

--- a/src/rules/at-function-pattern/index.js
+++ b/src/rules/at-function-pattern/index.js
@@ -5,18 +5,18 @@ import { namespace, ruleUrl } from "../../utils";
 export const ruleName = namespace("at-function-pattern");
 
 export const messages = utils.ruleMessages(ruleName, {
-  expected: "Expected @function name to match specified pattern"
+  expected: "Expected @function name to match specified pattern",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(pattern) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: pattern,
-      possible: [isRegExp, isString]
+      possible: [isRegExp, isString],
     });
 
     if (!validOptions) {
@@ -25,7 +25,7 @@ export default function rule(pattern) {
 
     const regexpPattern = isString(pattern) ? new RegExp(pattern) : pattern;
 
-    root.walkAtRules(decl => {
+    root.walkAtRules((decl) => {
       if (decl.name !== "function") {
         return;
       }
@@ -46,7 +46,7 @@ export default function rule(pattern) {
         node: decl,
         result,
         ruleName,
-        end: funcTopLine
+        end: funcTopLine,
       });
     });
   };

--- a/src/rules/at-if-closing-brace-newline-after/__tests__/index.js
+++ b/src/rules/at-if-closing-brace-newline-after/__tests__/index.js
@@ -12,7 +12,7 @@ testRule({
       @if ($x == 1) {}
       width: 10px;
     }`,
-      description: "always-last-in-chain (no @else, has newline after)."
+      description: "always-last-in-chain (no @else, has newline after).",
     },
     {
       code: `a {
@@ -20,7 +20,7 @@ testRule({
 
       width: 10px;
     }`,
-      description: "always-last-in-chain (no @else, has blank line after)."
+      description: "always-last-in-chain (no @else, has blank line after).",
     },
     {
       code: `a {
@@ -30,7 +30,7 @@ testRule({
 
       width: 10px;
     }`,
-      description: "always-last-in-chain (has @else, no newline after)."
+      description: "always-last-in-chain (has @else, no newline after).",
     },
     {
       code: `a {
@@ -43,7 +43,7 @@ testRule({
       width: 10px;
     }`,
       description:
-        "always-last-in-chain (has @else and @elseif, no newline after)."
+        "always-last-in-chain (has @else and @elseif, no newline after).",
     },
     {
       code: `a {
@@ -52,7 +52,7 @@ testRule({
       width: 10px;
     }`,
       description:
-        "always-last-in-chain (has @else, single-line, no newline after)."
+        "always-last-in-chain (has @else, single-line, no newline after).",
     },
     {
       code: `a {
@@ -61,7 +61,7 @@ testRule({
       width: 10px;
     }`,
       description:
-        "always-last-in-chain (has @else and @elseif, single-line, no newline after)."
+        "always-last-in-chain (has @else and @elseif, single-line, no newline after).",
     },
     {
       code: `a {
@@ -70,12 +70,12 @@ testRule({
       @include x;
     }`,
       description:
-        "always-last-in-chain (followed by non-@else at-rule, single-line, empty line after)."
+        "always-last-in-chain (followed by non-@else at-rule, single-line, empty line after).",
     },
     {
       code: "@if ($x == 1) {}",
-      description: "always-last-in-chain (single line, nothing after)."
-    }
+      description: "always-last-in-chain (single line, nothing after).",
+    },
   ],
 
   reject: [
@@ -94,7 +94,7 @@ width: 10px;
       description:
         "always-last-in-chain (has decl on the same line as its closing brace).",
       message: messages.expected,
-      line: 4
+      line: 4,
     },
     {
       code: `a {
@@ -110,7 +110,7 @@ width: 10px;
     }`,
       description: "always-last-in-chain (has @else, newline after).",
       message: messages.rejected,
-      line: 4
+      line: 4,
     },
     {
       code: `a {
@@ -127,7 +127,7 @@ width: 10px;
     }`,
       description: "always-last-in-chain (has @else, empty line after).",
       message: messages.rejected,
-      line: 4
+      line: 4,
     },
     {
       code: `a {
@@ -144,9 +144,9 @@ width: 10px;
       description:
         "always-last-in-chain (followed by non-@else at-rule, no newline after).",
       message: messages.expected,
-      line: 4
-    }
-  ]
+      line: 4,
+    },
+  ],
 });
 
 testRule({
@@ -154,8 +154,8 @@ testRule({
   config: [
     "always-last-in-chain",
     {
-      disableFix: true
-    }
+      disableFix: true,
+    },
   ],
   customSyntax: "postcss-scss",
   unfixable: true,
@@ -166,7 +166,7 @@ testRule({
       @if ($x == 1) {}
       width: 10px;
     }`,
-      description: "always-last-in-chain (no @else, has newline after)."
+      description: "always-last-in-chain (no @else, has newline after).",
     },
     {
       code: `a {
@@ -174,7 +174,7 @@ testRule({
 
       width: 10px;
     }`,
-      description: "always-last-in-chain (no @else, has blank line after)."
+      description: "always-last-in-chain (no @else, has blank line after).",
     },
     {
       code: `a {
@@ -184,7 +184,7 @@ testRule({
 
       width: 10px;
     }`,
-      description: "always-last-in-chain (has @else, no newline after)."
+      description: "always-last-in-chain (has @else, no newline after).",
     },
     {
       code: `a {
@@ -197,7 +197,7 @@ testRule({
       width: 10px;
     }`,
       description:
-        "always-last-in-chain (has @else and @elseif, no newline after)."
+        "always-last-in-chain (has @else and @elseif, no newline after).",
     },
     {
       code: `a {
@@ -206,7 +206,7 @@ testRule({
       width: 10px;
     }`,
       description:
-        "always-last-in-chain (has @else, single-line, no newline after)."
+        "always-last-in-chain (has @else, single-line, no newline after).",
     },
     {
       code: `a {
@@ -215,7 +215,7 @@ testRule({
       width: 10px;
     }`,
       description:
-        "always-last-in-chain (has @else and @elseif, single-line, no newline after)."
+        "always-last-in-chain (has @else and @elseif, single-line, no newline after).",
     },
     {
       code: `a {
@@ -224,12 +224,12 @@ testRule({
       @include x;
     }`,
       description:
-        "always-last-in-chain (followed by non-@else at-rule, single-line, empty line after)."
+        "always-last-in-chain (followed by non-@else at-rule, single-line, empty line after).",
     },
     {
       code: "@if ($x == 1) {}",
-      description: "always-last-in-chain (single line, nothing after)."
-    }
+      description: "always-last-in-chain (single line, nothing after).",
+    },
   ],
 
   reject: [
@@ -242,7 +242,7 @@ testRule({
       description:
         "always-last-in-chain (has decl on the same line as its closing brace).",
       message: messages.expected,
-      line: 4
+      line: 4,
     },
     {
       code: `a {
@@ -253,7 +253,7 @@ testRule({
     }`,
       description: "always-last-in-chain (has @else, newline after).",
       message: messages.rejected,
-      line: 4
+      line: 4,
     },
     {
       code: `a {
@@ -265,7 +265,7 @@ testRule({
     }`,
       description: "always-last-in-chain (has @else, empty line after).",
       message: messages.rejected,
-      line: 4
+      line: 4,
     },
     {
       code: `a {
@@ -276,7 +276,7 @@ testRule({
       description:
         "always-last-in-chain (followed by non-@else at-rule, no newline after).",
       message: messages.expected,
-      line: 4
-    }
-  ]
+      line: 4,
+    },
+  ],
 });

--- a/src/rules/at-if-closing-brace-newline-after/index.js
+++ b/src/rules/at-if-closing-brace-newline-after/index.js
@@ -6,11 +6,11 @@ export const ruleName = namespace("at-if-closing-brace-newline-after");
 
 export const messages = utils.ruleMessages(ruleName, {
   expected: 'Expected newline after "}" of @if statement',
-  rejected: 'Unexpected newline after "}" of @if statement'
+  rejected: 'Unexpected newline after "}" of @if statement',
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(expectation, options, context) {
@@ -20,14 +20,14 @@ export default function rule(expectation, options, context) {
       ruleName,
       {
         actual: expectation,
-        possible: ["always-last-in-chain"]
+        possible: ["always-last-in-chain"],
       },
       {
         actual: options,
         possible: {
-          disableFix: isBoolean
+          disableFix: isBoolean,
         },
-        optional: true
+        optional: true,
       }
     );
 
@@ -43,7 +43,7 @@ export default function rule(expectation, options, context) {
       expectation,
       messages,
       context,
-      options
+      options,
     });
   };
 }
@@ -68,7 +68,7 @@ export function sassConditionalBraceNLAfterChecker({
   expectation,
   messages,
   context,
-  options
+  options,
 }) {
   const shouldFix = context.fix && (!options || options.disableFix !== true);
 
@@ -84,11 +84,11 @@ export function sassConditionalBraceNLAfterChecker({
       ruleName,
       node,
       message,
-      index
+      index,
     });
   }
 
-  root.walkAtRules(atrule => {
+  root.walkAtRules((atrule) => {
     // Do nothing if it's not an @if
     if (atrule.name !== atRuleName) {
       return;

--- a/src/rules/at-if-closing-brace-space-after/__tests__/index.js
+++ b/src/rules/at-if-closing-brace-space-after/__tests__/index.js
@@ -13,13 +13,13 @@ testRule({
       @if ($x == 1) {}
       width: 10px;
     }`,
-      description: "always-intermediate (no @else, has newline after)."
+      description: "always-intermediate (no @else, has newline after).",
     },
     {
       code: `a {
       @if ($x == 1) {}width: 10px;
     }`,
-      description: "always-intermediate (no @else, no whitespace after)."
+      description: "always-intermediate (no @else, no whitespace after).",
     },
     {
       code: `a {
@@ -29,7 +29,7 @@ testRule({
 
       width: 10px;
     }`,
-      description: "always-intermediate (has @else, has space after)."
+      description: "always-intermediate (has @else, has space after).",
     },
     {
       code: `a {
@@ -38,18 +38,18 @@ testRule({
       width: 10px;
     }`,
       description:
-        "always-intermediate (has @else, single-line, has space after)."
+        "always-intermediate (has @else, single-line, has space after).",
     },
     {
       code: `a {
       @if ($x == 1) { }@include x;
     }`,
       description:
-        "always-intermediate (followed by non-@else at-rule, no space after)."
+        "always-intermediate (followed by non-@else at-rule, no space after).",
     },
     {
       code: "@if ($x == 1) {}",
-      description: "always-intermediate (single line, nothing after)."
+      description: "always-intermediate (single line, nothing after).",
     },
     {
       // TODO: should warn on this?
@@ -59,8 +59,8 @@ testRule({
       } @include x;
     }`,
       description:
-        "always-intermediate (followed by non-@else at-rule, has space after)."
-    }
+        "always-intermediate (followed by non-@else at-rule, has space after).",
+    },
   ],
 
   reject: [
@@ -77,7 +77,7 @@ testRule({
     }`,
       description: "always-intermediate (has @else, no space after).",
       message: messages.expected,
-      line: 4
+      line: 4,
     },
     {
       code: `a {
@@ -93,7 +93,7 @@ testRule({
     }`,
       description: "always-intermediate (has @else, newline after).",
       message: messages.expected,
-      line: 4
+      line: 4,
     },
     {
       code: `a {
@@ -110,7 +110,7 @@ testRule({
       description:
         "always-intermediate (has @else, a space and an newline after).",
       message: messages.expected,
-      line: 4
+      line: 4,
     },
     {
       code: `a {
@@ -125,9 +125,9 @@ testRule({
     }`,
       description: "always-intermediate (has @else, multiple spaces after).",
       message: messages.expected,
-      line: 4
-    }
-  ]
+      line: 4,
+    },
+  ],
 });
 
 // never-intermediate
@@ -143,19 +143,19 @@ testRule({
       @if ($x == 1) {}
       width: 10px;
     }`,
-      description: "never-intermediate (no @else, has newline after)."
+      description: "never-intermediate (no @else, has newline after).",
     },
     {
       code: `a {
       @if ($x == 1) {}width: 10px;
     }`,
-      description: "never-intermediate (no @else, no whitespace after)."
+      description: "never-intermediate (no @else, no whitespace after).",
     },
     {
       code: `a {
       @if ($x == 1) {} width: 10px;
     }`,
-      description: "never-intermediate (no @else, has a space after)."
+      description: "never-intermediate (no @else, has a space after).",
     },
     {
       code: `a {
@@ -165,7 +165,7 @@ testRule({
 
       width: 10px;
     }`,
-      description: "never-intermediate (has @else, no space after)."
+      description: "never-intermediate (has @else, no space after).",
     },
     {
       code: `a {
@@ -174,11 +174,11 @@ testRule({
       width: 10px;
     }`,
       description:
-        "never-intermediate (has @else, single-line, no space after)."
+        "never-intermediate (has @else, single-line, no space after).",
     },
     {
       code: "@if ($x == 1) {}",
-      description: "never-intermediate (single line, nothing after)."
+      description: "never-intermediate (single line, nothing after).",
     },
     {
       // TODO: should warn on this?
@@ -188,8 +188,8 @@ testRule({
       } @include x;
     }`,
       description:
-        "never-intermediate (followed by non-@else at-rule, has space after)."
-    }
+        "never-intermediate (followed by non-@else at-rule, has space after).",
+    },
   ],
 
   reject: [
@@ -206,7 +206,7 @@ testRule({
     }`,
       description: "never-intermediate (has @else, has space after).",
       message: messages.rejected,
-      line: 4
+      line: 4,
     },
     {
       code: `a {
@@ -222,7 +222,7 @@ testRule({
     }`,
       description: "never-intermediate (has @else, newline after).",
       message: messages.rejected,
-      line: 4
+      line: 4,
     },
     {
       code: `a {
@@ -239,7 +239,7 @@ testRule({
       description:
         "never-intermediate (has @else, a space and a newline after).",
       message: messages.rejected,
-      line: 4
+      line: 4,
     },
     {
       code: `a {
@@ -254,7 +254,7 @@ testRule({
     }`,
       description: "never-intermediate (has @else, multiple spaces after).",
       message: messages.rejected,
-      line: 4
-    }
-  ]
+      line: 4,
+    },
+  ],
 });

--- a/src/rules/at-if-closing-brace-space-after/index.js
+++ b/src/rules/at-if-closing-brace-space-after/index.js
@@ -5,18 +5,18 @@ export const ruleName = namespace("at-if-closing-brace-space-after");
 
 export const messages = utils.ruleMessages(ruleName, {
   expected: 'Expected single space after "}" of @if statement',
-  rejected: 'Unexpected space after "}" of @if statement'
+  rejected: 'Unexpected space after "}" of @if statement',
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(expectation, _, context) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: expectation,
-      possible: ["always-intermediate", "never-intermediate"]
+      possible: ["always-intermediate", "never-intermediate"],
     });
 
     if (!validOptions) {
@@ -30,7 +30,7 @@ export default function rule(expectation, _, context) {
       atRuleName: "if",
       expectation,
       messages,
-      context
+      context,
     });
   };
 }
@@ -54,7 +54,7 @@ export function sassConditionalBraceSpaceAfterChecker({
   atRuleName,
   expectation,
   messages,
-  context
+  context,
 }) {
   function complain(node, message, index, fixValue) {
     if (context.fix) {
@@ -68,11 +68,11 @@ export function sassConditionalBraceSpaceAfterChecker({
       ruleName,
       node,
       message,
-      index
+      index,
     });
   }
 
-  root.walkAtRules(atrule => {
+  root.walkAtRules((atrule) => {
     // Do nothing if it's not an @if
     if (atrule.name !== atRuleName) {
       return;

--- a/src/rules/at-if-no-null/__tests__/index.js
+++ b/src/rules/at-if-no-null/__tests__/index.js
@@ -10,20 +10,20 @@ testRule({
       code: `a {
       @if $x {}
     }`,
-      description: "does not use the != null format"
+      description: "does not use the != null format",
     },
     {
       code: `a {
       @if not $x {}
     }`,
-      description: "does not use the == null format"
+      description: "does not use the == null format",
     },
     {
       code: `a {
       @if $x != null and $x > 1 {}
     }`,
-      description: "does not use the == null format"
-    }
+      description: "does not use the == null format",
+    },
   ],
 
   reject: [
@@ -33,7 +33,7 @@ testRule({
     }`,
       description: "uses the == null format",
       message: messages.equals_null,
-      line: 2
+      line: 2,
     },
     {
       code: `a {
@@ -41,7 +41,7 @@ testRule({
     }`,
       description: "uses the != null format",
       message: messages.not_equals_null,
-      line: 2
-    }
-  ]
+      line: 2,
+    },
+  ],
 });

--- a/src/rules/at-if-no-null/index.js
+++ b/src/rules/at-if-no-null/index.js
@@ -5,24 +5,24 @@ export const ruleName = namespace("at-if-no-null");
 
 export const messages = utils.ruleMessages(ruleName, {
   equals_null: "Expected @if not statement rather than @if statement == null",
-  not_equals_null: "Expected @if statement rather than @if statement != null"
+  not_equals_null: "Expected @if statement rather than @if statement != null",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(expectation) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
-      actual: expectation
+      actual: expectation,
     });
 
     if (!validOptions) {
       return;
     }
 
-    root.walkAtRules(atrule => {
+    root.walkAtRules((atrule) => {
       // Do nothing if it's not an @if
       if (atrule.name !== "if") {
         return;
@@ -38,14 +38,14 @@ export default function rule(expectation) {
           message: messages.equals_null,
           node: atrule,
           result,
-          ruleName
+          ruleName,
         });
       } else if (atrule.params.match(/.* != null[ \t]*\)?/)) {
         utils.report({
           message: messages.not_equals_null,
           node: atrule,
           result,
-          ruleName
+          ruleName,
         });
       }
     });

--- a/src/rules/at-import-no-partial-leading-underscore/__tests__/index.js
+++ b/src/rules/at-import-no-partial-leading-underscore/__tests__/index.js
@@ -10,120 +10,120 @@ testRule({
       code: `
       @import "fff";
     `,
-      description: "Single file, no underscore, double quotes."
+      description: "Single file, no underscore, double quotes.",
     },
     {
       code: `
       @import 'fff';
     `,
-      description: "Single file, no underscore, single quotes."
+      description: "Single file, no underscore, single quotes.",
     },
     {
       code: `
       @import ' fff ';
     `,
-      description: "Single file, no underscore, trailing spaces inside quotes."
+      description: "Single file, no underscore, trailing spaces inside quotes.",
     },
     {
       code: `
       @import "fff", "score";
     `,
-      description: "Two files, no underscore, double quotes."
+      description: "Two files, no underscore, double quotes.",
     },
     {
       code: `
       @import "ff_f";
     `,
-      description: "One file, underscore in the middle."
+      description: "One file, underscore in the middle.",
     },
     {
       code: `
         @import "fff_",
         "score";
     `,
-      description: "One file, underscore at the end."
+      description: "One file, underscore at the end.",
     },
     {
       code: `
       @import "_path/fff";
     `,
       description:
-        "One file, path with a dir, underscore in dir name, double quotes."
+        "One file, path with a dir, underscore in dir name, double quotes.",
     },
     {
       code: `
       @import url("path/_file.css");
     `,
-      description: "Import CSS with url()."
+      description: "Import CSS with url().",
     },
     {
       code: `
       @import "_file.css";
     `,
-      description: "Import CSS by extension."
+      description: "Import CSS by extension.",
     },
     {
       code: `
       @import "_file.css ";
     `,
-      description: "Import CSS by extension, trailing spaces."
+      description: "Import CSS by extension, trailing spaces.",
     },
     {
       code: `
       @import "http://_file.scss";
     `,
-      description: "Import CSS from the web, http://."
+      description: "Import CSS from the web, http://.",
     },
     {
       code: `
       @import " https://_file.scss ";
     `,
       description:
-        "Import CSS from the web, https://, trailing spaces inside quotes"
+        "Import CSS from the web, https://, trailing spaces inside quotes",
     },
     {
       code: `
       @import "//_file.scss";
     `,
-      description: "Import CSS from the web, no protocol."
+      description: "Import CSS from the web, no protocol.",
     },
     {
       code: `
       @import "_file.scss" screen;
     `,
-      description: "Import CSS (with media queries)."
+      description: "Import CSS (with media queries).",
     },
     {
       code: `
       @import "_file.scss"screen;
     `,
-      description: "Import CSS (with media queries)."
+      description: "Import CSS (with media queries).",
     },
     {
       code: `
       @import "_file.scss "screen;
     `,
       description:
-        "Import CSS (with media queries), trailing space inside quotes."
+        "Import CSS (with media queries), trailing space inside quotes.",
     },
     {
       code: `
       @import url(_lol.scss) screen;
     `,
-      description: "Import CSS (with media queries - url + media)."
+      description: "Import CSS (with media queries - url + media).",
     },
     {
       code: `
       @import _file.scss tv, screen;
     `,
-      description: "Import CSS (with media queries - multiple)."
+      description: "Import CSS (with media queries - multiple).",
     },
     {
       code: `
       @import _file.scss tv,screen;
     `,
-      description: "Import CSS (with media queries - multiple, no spaces)."
-    }
+      description: "Import CSS (with media queries - multiple, no spaces).",
+    },
   ],
 
   reject: [
@@ -133,7 +133,7 @@ testRule({
     `,
       line: 2,
       message: messages.expected,
-      description: "One file, underscore at the start."
+      description: "One file, underscore at the start.",
     },
     {
       code: `
@@ -142,7 +142,7 @@ testRule({
       line: 2,
       message: messages.expected,
       description:
-        "One file, underscore at the start, trailing space at the end."
+        "One file, underscore at the start, trailing space at the end.",
     },
     {
       code: `
@@ -151,7 +151,7 @@ testRule({
       line: 2,
       message: messages.expected,
       description:
-        "One file, underscore at the start, trailing space at the start."
+        "One file, underscore at the start, trailing space at the start.",
     },
     {
       code: `
@@ -159,7 +159,7 @@ testRule({
     `,
       line: 2,
       message: messages.expected,
-      description: "One file, path with dir, underscore at the start."
+      description: "One file, path with dir, underscore at the start.",
     },
     {
       code: `
@@ -167,7 +167,7 @@ testRule({
     `,
       line: 2,
       message: messages.expected,
-      description: "One file, path with dir, windows delimiters."
+      description: "One file, path with dir, windows delimiters.",
     },
     {
       code: `
@@ -175,7 +175,7 @@ testRule({
     `,
       line: 2,
       message: messages.expected,
-      description: "Two files, path with dir, underscore at the start."
-    }
-  ]
+      description: "Two files, path with dir, underscore at the start.",
+    },
+  ],
 });

--- a/src/rules/at-import-no-partial-leading-underscore/index.js
+++ b/src/rules/at-import-no-partial-leading-underscore/index.js
@@ -4,11 +4,11 @@ import { namespace, ruleUrl } from "../../utils";
 export const ruleName = namespace("at-import-no-partial-leading-underscore");
 
 export const messages = utils.ruleMessages(ruleName, {
-  expected: "Unexpected leading underscore in imported partial name"
+  expected: "Unexpected leading underscore in imported partial name",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(actual) {
@@ -44,13 +44,13 @@ export default function rule(actual) {
         message: messages.expected,
         node: decl,
         result,
-        ruleName
+        ruleName,
       });
     }
 
-    root.walkAtRules("import", decl => {
+    root.walkAtRules("import", (decl) => {
       // Processing comma-separated lists of import paths
-      decl.params.split(",").forEach(path => {
+      decl.params.split(",").forEach((path) => {
         checkPathForUnderscore(path, decl);
       });
     });

--- a/src/rules/at-import-partial-extension-blacklist/__tests__/index.js
+++ b/src/rules/at-import-partial-extension-blacklist/__tests__/index.js
@@ -11,94 +11,94 @@ testRule({
       code: `
       @import "fff";
     `,
-      description: "Single file, no extension, double quotes."
+      description: "Single file, no extension, double quotes.",
     },
     {
       code: `
       @import 'fff';
     `,
-      description: "Single file, no extension, single quotes."
+      description: "Single file, no extension, single quotes.",
     },
     {
       code: `
       @import ' fff ';
     `,
-      description: "Single file, no extension, trailing spaces inside quotes."
+      description: "Single file, no extension, trailing spaces inside quotes.",
     },
     {
       code: `
       @import "fff", "score";
     `,
-      description: "Two files, no extension, double quotes."
+      description: "Two files, no extension, double quotes.",
     },
     {
       code: `
       @import url("path/_file.css");
     `,
-      description: "Import CSS with url()."
+      description: "Import CSS with url().",
     },
     {
       code: `
       @import "_file.css";
     `,
-      description: "Import CSS by extension."
+      description: "Import CSS by extension.",
     },
     {
       code: `
       @import "http://_file.scss";
     `,
-      description: "Import CSS from the web, http://."
+      description: "Import CSS from the web, http://.",
     },
     {
       code: `
       @import " https://_file.scss ";
     `,
       description:
-        "Import CSS from the web, https://, trailing spaces inside quotes"
+        "Import CSS from the web, https://, trailing spaces inside quotes",
     },
     {
       code: `
       @import "//_file.scss";
     `,
-      description: "Import CSS from the web, no protocol."
+      description: "Import CSS from the web, no protocol.",
     },
     {
       code: `
       @import "_file.scss" screen;
     `,
-      description: "Import CSS (with media queries)."
+      description: "Import CSS (with media queries).",
     },
     {
       code: `
       @import "_file.scss"screen;
     `,
-      description: "Import CSS (with media queries)."
+      description: "Import CSS (with media queries).",
     },
     {
       code: `
       @import "_file.scss "screen;
     `,
       description:
-        "Import CSS (with media queries), trailing space inside quotes."
+        "Import CSS (with media queries), trailing space inside quotes.",
     },
     {
       code: `
       @import url(_lol.scss) screen;
     `,
-      description: "Import CSS (with media queries - url + media)."
+      description: "Import CSS (with media queries - url + media).",
     },
     {
       code: `
       @import _file.scss tv, screen;
     `,
-      description: "Import CSS (with media queries - multiple)."
+      description: "Import CSS (with media queries - multiple).",
     },
     {
       code: `
       @import _file.scss tv,screen;
     `,
-      description: "Import CSS (with media queries - multiple, no spaces)."
-    }
+      description: "Import CSS (with media queries - multiple, no spaces).",
+    },
   ],
 
   reject: [
@@ -109,7 +109,7 @@ testRule({
       line: 2,
       column: 20,
       message: messages.rejected("scss"),
-      description: "One file, ext is blacklisted."
+      description: "One file, ext is blacklisted.",
     },
     {
       code: `
@@ -118,7 +118,7 @@ testRule({
       line: 2,
       column: 20,
       message: messages.rejected("scss"),
-      description: "One file, has extension, space at the end."
+      description: "One file, has extension, space at the end.",
     },
     {
       code: `
@@ -127,7 +127,7 @@ testRule({
       line: 2,
       column: 21,
       message: messages.rejected("scss"),
-      description: "One file, has extension, trailing spaces."
+      description: "One file, has extension, trailing spaces.",
     },
     {
       code: `
@@ -136,7 +136,7 @@ testRule({
       line: 2,
       column: 23,
       message: messages.rejected("scss"),
-      description: "One file, path with dir, has extension."
+      description: "One file, path with dir, has extension.",
     },
     {
       code: `
@@ -145,7 +145,8 @@ testRule({
       line: 2,
       column: 23,
       message: messages.rejected("scss"),
-      description: "One file, path with dir, has extension, windows delimiters."
+      description:
+        "One file, path with dir, has extension, windows delimiters.",
     },
     {
       code: `
@@ -154,9 +155,9 @@ testRule({
       line: 2,
       column: 29,
       message: messages.rejected("scss"),
-      description: "Two files, path with dir, has extension."
-    }
-  ]
+      description: "Two files, path with dir, has extension.",
+    },
+  ],
 });
 
 // Testing an array
@@ -170,27 +171,27 @@ testRule({
       code: `
       @import "fff";
     `,
-      description: "Single file, no extension."
+      description: "Single file, no extension.",
     },
     {
       code: `
       @import "fff.foo";
     `,
-      description: "Single file, extension not from a blacklist."
+      description: "Single file, extension not from a blacklist.",
     },
     {
       code: `
       @import " fff.scss1 ";
     `,
       description:
-        "Single file, extension not from a blacklist, trailing whitespaces."
+        "Single file, extension not from a blacklist, trailing whitespaces.",
     },
     {
       code: `
       @import "fff", "fff.moi";
     `,
-      description: "Multiple files, ext not from a blacklist."
-    }
+      description: "Multiple files, ext not from a blacklist.",
+    },
   ],
 
   reject: [
@@ -201,7 +202,7 @@ testRule({
       line: 2,
       column: 20,
       message: messages.rejected("scss"),
-      description: "One file, ext from a blacklist array."
+      description: "One file, ext from a blacklist array.",
     },
     {
       code: `
@@ -210,7 +211,7 @@ testRule({
       line: 2,
       column: 20,
       message: messages.rejected("SCsS"),
-      description: "One file, ext from a blacklist array, messed case."
+      description: "One file, ext from a blacklist array, messed case.",
     },
     {
       code: `
@@ -219,7 +220,7 @@ testRule({
       line: 2,
       column: 20,
       message: messages.rejected("less"),
-      description: "One file, ext from a blacklist array #2 (regex)."
+      description: "One file, ext from a blacklist array #2 (regex).",
     },
     {
       code: `
@@ -229,7 +230,7 @@ testRule({
       column: 20,
       message: messages.rejected("LESS"),
       description:
-        "One file, ext from a blacklist array #2 (regex), messed case."
+        "One file, ext from a blacklist array #2 (regex), messed case.",
     },
     {
       code: `
@@ -239,7 +240,7 @@ testRule({
       line: 3,
       column: 16,
       message: messages.rejected("ruthless"),
-      description: "Multiple files, ext from a blacklist array."
-    }
-  ]
+      description: "Multiple files, ext from a blacklist array.",
+    },
+  ],
 });

--- a/src/rules/at-import-partial-extension-blacklist/index.js
+++ b/src/rules/at-import-partial-extension-blacklist/index.js
@@ -6,11 +6,11 @@ import nodeJsPath from "path";
 export const ruleName = namespace("at-import-partial-extension-blacklist");
 
 export const messages = utils.ruleMessages(ruleName, {
-  rejected: ext => `Unexpected extension ".${ext}" in imported partial name`
+  rejected: (ext) => `Unexpected extension ".${ext}" in imported partial name`,
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(blacklistOption) {
@@ -19,7 +19,7 @@ export default function rule(blacklistOption) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: blacklistOption,
-      possible: [isString, isRegExp]
+      possible: [isString, isRegExp],
     });
 
     if (!validOptions) {
@@ -50,7 +50,7 @@ export default function rule(blacklistOption) {
         return;
       }
 
-      blacklist.forEach(ext => {
+      blacklist.forEach((ext) => {
         if (
           (isString(ext) && extensionNormalized === ext) ||
           (isRegExp(ext) && extensionNormalized.search(ext) !== -1)
@@ -60,15 +60,15 @@ export default function rule(blacklistOption) {
             node: decl,
             word: extension,
             result,
-            ruleName
+            ruleName,
           });
         }
       });
     }
 
-    root.walkAtRules("import", atRule => {
+    root.walkAtRules("import", (atRule) => {
       // Processing comma-separated lists of import paths
-      atRule.params.split(",").forEach(path => {
+      atRule.params.split(",").forEach((path) => {
         checkPathForUnderscore(path, atRule);
       });
     });

--- a/src/rules/at-import-partial-extension-whitelist/__tests__/index.js
+++ b/src/rules/at-import-partial-extension-whitelist/__tests__/index.js
@@ -11,57 +11,57 @@ testRule({
       code: `
       @import "fff";
     `,
-      description: "Single file, no extension, double quotes."
+      description: "Single file, no extension, double quotes.",
     },
     {
       code: `
       @import 'fff';
     `,
-      description: "Single file, no extension, single quotes."
+      description: "Single file, no extension, single quotes.",
     },
     {
       code: `
       @import ' fff ';
     `,
-      description: "Single file, no extension, trailing spaces inside quotes."
+      description: "Single file, no extension, trailing spaces inside quotes.",
     },
     {
       code: `
       @import "fff", "score";
     `,
-      description: "Two files, no extension, double quotes."
+      description: "Two files, no extension, double quotes.",
     },
     {
       code: `
       @import "fff.scss ";
     `,
-      description: "One file, whitelisted extension, space at the end."
+      description: "One file, whitelisted extension, space at the end.",
     },
     {
       code: `
       @import " fff.scss ";
     `,
-      description: "One file, whitelisted extension, trailing spaces."
+      description: "One file, whitelisted extension, trailing spaces.",
     },
     {
       code: `
       @import "df/fff.scss";
     `,
-      description: "One file, path with dir, whitelisted extension."
+      description: "One file, path with dir, whitelisted extension.",
     },
     {
       code: `
       @import "df\\fff.scss";
     `,
       description:
-        "One file, path with dir, whitelisted extension, windows delimiters."
+        "One file, path with dir, whitelisted extension, windows delimiters.",
     },
     {
       code: `
       @import "df/fff", '_1.scss';
     `,
-      description: "Two files, path with dir, whitelisted extension."
-    }
+      description: "Two files, path with dir, whitelisted extension.",
+    },
   ],
 
   reject: [
@@ -72,7 +72,7 @@ testRule({
       line: 2,
       column: 20,
       message: messages.rejected("less"),
-      description: "One file, ext not from a whitelist-string."
+      description: "One file, ext not from a whitelist-string.",
     },
     {
       code: `
@@ -82,7 +82,7 @@ testRule({
       column: 20,
       message: messages.rejected("scssy"),
       description:
-        "One file, ext not from a whitelist-string, space at the end."
+        "One file, ext not from a whitelist-string, space at the end.",
     },
     {
       code: `
@@ -91,7 +91,8 @@ testRule({
       line: 2,
       column: 21,
       message: messages.rejected("less"),
-      description: "One file, ext not from a whitelist-string, trailing spaces."
+      description:
+        "One file, ext not from a whitelist-string, trailing spaces.",
     },
     {
       code: `
@@ -100,7 +101,7 @@ testRule({
       line: 2,
       column: 23,
       message: messages.rejected("less"),
-      description: "One file, path with dir, ext not from a whitelist-string."
+      description: "One file, path with dir, ext not from a whitelist-string.",
     },
     {
       code: `
@@ -110,7 +111,7 @@ testRule({
       column: 23,
       message: messages.rejected("less"),
       description:
-        "One file, path with dir, ext not from a whitelist-string, windows delimiters."
+        "One file, path with dir, ext not from a whitelist-string, windows delimiters.",
     },
     {
       code: `
@@ -119,9 +120,9 @@ testRule({
       line: 2,
       column: 29,
       message: messages.rejected("less"),
-      description: "Two files, path with dir, ext not from a whitelist-string."
-    }
-  ]
+      description: "Two files, path with dir, ext not from a whitelist-string.",
+    },
+  ],
 });
 
 // Testing exceptions
@@ -135,71 +136,71 @@ testRule({
       code: `
       @import url("path/_file.css");
     `,
-      description: "Import CSS with url()."
+      description: "Import CSS with url().",
     },
     {
       code: `
       @import "_file.css";
     `,
-      description: "Import CSS by extension."
+      description: "Import CSS by extension.",
     },
     {
       code: `
       @import "http://_file.scss";
     `,
-      description: "Import CSS from the web, http://."
+      description: "Import CSS from the web, http://.",
     },
     {
       code: `
       @import " https://_file.scss ";
     `,
       description:
-        "Import CSS from the web, https://, trailing spaces inside quotes"
+        "Import CSS from the web, https://, trailing spaces inside quotes",
     },
     {
       code: `
       @import "//_file.scss";
     `,
-      description: "Import CSS from the web, no protocol."
+      description: "Import CSS from the web, no protocol.",
     },
     {
       code: `
       @import "_file.scss" screen;
     `,
-      description: "Import CSS (with media queries)."
+      description: "Import CSS (with media queries).",
     },
     {
       code: `
       @import "_file.scss"screen;
     `,
-      description: "Import CSS (with media queries)."
+      description: "Import CSS (with media queries).",
     },
     {
       code: `
       @import "_file.scss "screen;
     `,
       description:
-        "Import CSS (with media queries), trailing space inside quotes."
+        "Import CSS (with media queries), trailing space inside quotes.",
     },
     {
       code: `
       @import url(_lol.scss) screen;
     `,
-      description: "Import CSS (with media queries - url + media)."
+      description: "Import CSS (with media queries - url + media).",
     },
     {
       code: `
       @import _file.scss tv, screen;
     `,
-      description: "Import CSS (with media queries - multiple)."
+      description: "Import CSS (with media queries - multiple).",
     },
     {
       code: `
       @import _file.scss tv,screen;
     `,
-      description: "Import CSS (with media queries - multiple, no spaces)."
-    }
-  ]
+      description: "Import CSS (with media queries - multiple, no spaces).",
+    },
+  ],
 });
 
 // Testing an array
@@ -213,25 +214,26 @@ testRule({
       code: `
       @import "fff.scss";
     `,
-      description: "One file, ext from a whitelist array (string)."
+      description: "One file, ext from a whitelist array (string).",
     },
     {
       code: `
       @import "fff.SCsS";
     `,
-      description: "One file, ext from a whitelist array (string), messed case."
+      description:
+        "One file, ext from a whitelist array (string), messed case.",
     },
     {
       code: `
       @import "fff.less";
     `,
-      description: "One file, ext from a whitelist array (regex)."
+      description: "One file, ext from a whitelist array (regex).",
     },
     {
       code: `
       @import "fff.LESS";
     `,
-      description: "One file, ext from a whitelist array (regex), messed case."
+      description: "One file, ext from a whitelist array (regex), messed case.",
     },
     {
       code: `
@@ -239,8 +241,8 @@ testRule({
           "fff.ruthless";
     `,
       description:
-        "Multiple files, ext from a whitelist array (regex), partial match."
-    }
+        "Multiple files, ext from a whitelist array (regex), partial match.",
+    },
   ],
 
   reject: [
@@ -251,7 +253,7 @@ testRule({
       line: 2,
       column: 20,
       message: messages.rejected("foo"),
-      description: "Single file, extension not from a whitelist."
+      description: "Single file, extension not from a whitelist.",
     },
     {
       code: `
@@ -261,7 +263,7 @@ testRule({
       column: 21,
       message: messages.rejected("scss1"),
       description:
-        "Single file, extension not from a whitelist, trailing whitespaces."
+        "Single file, extension not from a whitelist, trailing whitespaces.",
     },
     {
       code: `
@@ -270,7 +272,7 @@ testRule({
       line: 2,
       column: 27,
       message: messages.rejected("moi"),
-      description: "Multiple files, ext not from a whitelist."
-    }
-  ]
+      description: "Multiple files, ext not from a whitelist.",
+    },
+  ],
 });

--- a/src/rules/at-import-partial-extension-whitelist/index.js
+++ b/src/rules/at-import-partial-extension-whitelist/index.js
@@ -6,11 +6,11 @@ import nodeJsPath from "path";
 export const ruleName = namespace("at-import-partial-extension-whitelist");
 
 export const messages = utils.ruleMessages(ruleName, {
-  rejected: ext => `Unexpected extension ".${ext}" in imported partial name`
+  rejected: (ext) => `Unexpected extension ".${ext}" in imported partial name`,
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(whitelistOption) {
@@ -19,7 +19,7 @@ export default function rule(whitelistOption) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: whitelistOption,
-      possible: [isString, isRegExp]
+      possible: [isString, isRegExp],
     });
 
     if (!validOptions) {
@@ -51,7 +51,7 @@ export default function rule(whitelistOption) {
       }
 
       if (
-        whitelist.some(ext => {
+        whitelist.some((ext) => {
           return (
             (isString(ext) && extensionNormalized === ext) ||
             (isRegExp(ext) && extensionNormalized.search(ext) !== -1)
@@ -66,13 +66,13 @@ export default function rule(whitelistOption) {
         node: decl,
         word: extension,
         result,
-        ruleName
+        ruleName,
       });
     }
 
-    root.walkAtRules("import", atRule => {
+    root.walkAtRules("import", (atRule) => {
       // Processing comma-separated lists of import paths
-      atRule.params.split(",").forEach(path => {
+      atRule.params.split(",").forEach((path) => {
         checkPathForUnderscore(path, atRule);
       });
     });

--- a/src/rules/at-import-partial-extension/__tests__/index.js
+++ b/src/rules/at-import-partial-extension/__tests__/index.js
@@ -10,137 +10,137 @@ testRule({
       code: `
       @import "fff.scss";
     `,
-      description: "Single file, .scss extension"
+      description: "Single file, .scss extension",
     },
     {
       code: `
       @import "path/fff.scss";
     `,
-      description: "Single file, path with dir, .scss extension"
+      description: "Single file, path with dir, .scss extension",
     },
     {
       code: `
       @import "df\\fff.scss";
     `,
       description:
-        "Single file, path with dir, has extension, windows delimiters."
+        "Single file, path with dir, has extension, windows delimiters.",
     },
     {
       code: `
       @import 'fff.scss';
     `,
-      description: "Single file, .scss extension, single quotes."
+      description: "Single file, .scss extension, single quotes.",
     },
     {
       code: `
       @import "fff.foo";
     `,
-      description: "Single file, .foo extension."
+      description: "Single file, .foo extension.",
     },
     {
       code: `
       @import " fff.scss1 ";
     `,
-      description: "Single file, extension, trailing whitespaces."
+      description: "Single file, extension, trailing whitespaces.",
     },
     {
       code: `
       @import "fff.scss", "fff.moi";
     `,
-      description: "Multiple files with extensions."
+      description: "Multiple files with extensions.",
     },
     {
       code: `
       @import url("path/_file.css");
     `,
-      description: "Import CSS with url()."
+      description: "Import CSS with url().",
     },
     {
       code: `
       @import "_file.css";
     `,
-      description: "Import CSS by extension."
+      description: "Import CSS by extension.",
     },
     {
       code: `
       @import "http://_file.scss";
     `,
-      description: "Import CSS from the web, http://."
+      description: "Import CSS from the web, http://.",
     },
     {
       code: `
       @import " https://_file.scss ";
     `,
       description:
-        "Import CSS from the web, https://, trailing spaces inside quotes"
+        "Import CSS from the web, https://, trailing spaces inside quotes",
     },
     {
       code: `
       @import 'https://fonts.googleapis.com/css?family=Montserrat:400,600&display=swap';
     `,
-      description: "Import CSS from the web, https:// with comma"
+      description: "Import CSS from the web, https:// with comma",
     },
     {
       code: `
       @import "//_file.scss";
     `,
-      description: "Import CSS from the web, no protocol."
+      description: "Import CSS from the web, no protocol.",
     },
     {
       code: `
       @import "_file.scss" screen;
     `,
-      description: "Import CSS (with media queries)."
+      description: "Import CSS (with media queries).",
     },
     {
       code: `
       @import "_file.scss"screen;
     `,
-      description: "Import CSS (with media queries)."
+      description: "Import CSS (with media queries).",
     },
     {
       code: `
       @import "_file.scss "screen;
     `,
       description:
-        "Import CSS (with media queries), trailing space inside quotes."
+        "Import CSS (with media queries), trailing space inside quotes.",
     },
     {
       code: `
       @import url(_lol.scss) screen;
     `,
-      description: "Import CSS (with media queries - url + media)."
+      description: "Import CSS (with media queries - url + media).",
     },
     {
       code: `
       @import url('https://fonts.googleapis.com/css?family=Montserrat:400,600&display=swap');
     `,
-      description: "Import CSS from the web, https:// with comma"
+      description: "Import CSS from the web, https:// with comma",
     },
     {
       code: `
       @import _file.scss tv, screen;
     `,
-      description: "Import CSS (with media queries - multiple)."
+      description: "Import CSS (with media queries - multiple).",
     },
     {
       code: `
       @import _file.scss tv,screen;
     `,
-      description: "Import CSS (with media queries - multiple, no spaces)."
+      description: "Import CSS (with media queries - multiple, no spaces).",
     },
     {
       code: `
       @import "screen.scss";
     `,
-      description: "Import with a name that matches a media query type."
+      description: "Import with a name that matches a media query type.",
     },
     {
       code: `
       @import "colors.variables.scss";
     `,
-      description: "Import a filename with a dot."
-    }
+      description: "Import a filename with a dot.",
+    },
   ],
 
   reject: [
@@ -151,7 +151,7 @@ testRule({
       line: 2,
       column: 7,
       message: messages.expected,
-      description: "Single file, no extension."
+      description: "Single file, no extension.",
     },
     {
       code: `
@@ -161,7 +161,7 @@ testRule({
       line: 2,
       column: 7,
       message: messages.expected,
-      description: "Multiple files, one without extension."
+      description: "Multiple files, one without extension.",
     },
     {
       code: `
@@ -171,17 +171,17 @@ testRule({
         {
           line: 2,
           column: 7,
-          message: messages.expected
+          message: messages.expected,
         },
         {
           line: 2,
           column: 7,
-          message: messages.expected
-        }
+          message: messages.expected,
+        },
       ],
-      description: "Two files, no extensions."
-    }
-  ]
+      description: "Two files, no extensions.",
+    },
+  ],
 });
 
 testRule({
@@ -195,118 +195,118 @@ testRule({
       code: `
       @import "fff";
     `,
-      description: "Single file, no extension, double quotes."
+      description: "Single file, no extension, double quotes.",
     },
     {
       code: `
       @import 'fff';
     `,
-      description: "Single file, no extension, single quotes."
+      description: "Single file, no extension, single quotes.",
     },
     {
       code: `
       @import ' fff ';
     `,
-      description: "Single file, no extension, trailing spaces inside quotes."
+      description: "Single file, no extension, trailing spaces inside quotes.",
     },
     {
       code: `
       @import "fff", "score";
     `,
-      description: "Two files, no extension, double quotes."
+      description: "Two files, no extension, double quotes.",
     },
     {
       code: `
       @import "screen";
     `,
-      description: "Import with a name that matches a media query type."
+      description: "Import with a name that matches a media query type.",
     },
     {
       code: `
       @import url("path/_file.css");
     `,
-      description: "Import CSS with url()."
+      description: "Import CSS with url().",
     },
     {
       code: `
       @import "_file.css";
     `,
-      description: "Import CSS by extension."
+      description: "Import CSS by extension.",
     },
     {
       code: `
       @import "http://_file.scss";
     `,
-      description: "Import CSS from the web, http://."
+      description: "Import CSS from the web, http://.",
     },
     {
       code: `
       @import " https://_file.scss ";
     `,
       description:
-        "Import CSS from the web, https://, trailing spaces inside quotes"
+        "Import CSS from the web, https://, trailing spaces inside quotes",
     },
     {
       code: `
       @import 'https://fonts.googleapis.com/css?family=Montserrat:400,600&display=swap';
     `,
-      description: "Import CSS from the web, https:// with comma"
+      description: "Import CSS from the web, https:// with comma",
     },
     {
       code: `
       @import "//_file.scss";
     `,
-      description: "Import CSS from the web, no protocol."
+      description: "Import CSS from the web, no protocol.",
     },
     {
       code: `
       @import "_file.scss" screen;
     `,
-      description: "Import CSS (with media queries)."
+      description: "Import CSS (with media queries).",
     },
     {
       code: `
       @import "_file.scss"screen;
     `,
-      description: "Import CSS (with media queries)."
+      description: "Import CSS (with media queries).",
     },
     {
       code: `
       @import "_file.scss "screen;
     `,
       description:
-        "Import CSS (with media queries), trailing space inside quotes."
+        "Import CSS (with media queries), trailing space inside quotes.",
     },
     {
       code: `
       @import url(_lol.scss) screen;
     `,
-      description: "Import CSS (with media queries - url + media)."
+      description: "Import CSS (with media queries - url + media).",
     },
     {
       code: `
       @import url('https://fonts.googleapis.com/css?family=Montserrat:400,600&display=swap');
     `,
-      description: "Import CSS from the web, https:// with comma"
+      description: "Import CSS from the web, https:// with comma",
     },
     {
       code: `
       @import _file.scss tv, screen;
     `,
-      description: "Import CSS (with media queries - multiple)."
+      description: "Import CSS (with media queries - multiple).",
     },
     {
       code: `
       @import _file.scss tv,screen;
     `,
-      description: "Import CSS (with media queries - multiple, no spaces)."
+      description: "Import CSS (with media queries - multiple, no spaces).",
     },
     {
       code: `
       @import "colors.variables";
     `,
-      description: "Import a style file with a dot in the name."
-    }
+      description: "Import a style file with a dot in the name.",
+    },
   ],
 
   reject: [
@@ -320,7 +320,7 @@ testRule({
       line: 2,
       column: 20,
       message: messages.rejected("scss"),
-      description: "Single file, .scss extension."
+      description: "Single file, .scss extension.",
     },
     {
       code: `
@@ -332,7 +332,8 @@ testRule({
       line: 2,
       column: 23,
       message: messages.rejected("scss"),
-      description: "Single file with media query type as name, .scss extension."
+      description:
+        "Single file with media query type as name, .scss extension.",
     },
     {
       code: `
@@ -344,7 +345,7 @@ testRule({
       line: 2,
       column: 20,
       message: messages.rejected("scss"),
-      description: "Single file, has extension, space at the end."
+      description: "Single file, has extension, space at the end.",
     },
     {
       code: `
@@ -356,7 +357,7 @@ testRule({
       line: 2,
       column: 21,
       message: messages.rejected("scss"),
-      description: "Single file, has extension, trailing spaces."
+      description: "Single file, has extension, trailing spaces.",
     },
     {
       code: `
@@ -368,7 +369,7 @@ testRule({
       line: 2,
       column: 23,
       message: messages.rejected("scss"),
-      description: "Single file, path with dir, has extension."
+      description: "Single file, path with dir, has extension.",
     },
     {
       code: `
@@ -381,7 +382,7 @@ testRule({
       column: 23,
       message: messages.rejected("scss"),
       description:
-        "Single file, path with dir, has extension, windows delimiters."
+        "Single file, path with dir, has extension, windows delimiters.",
     },
     {
       code: `
@@ -393,7 +394,7 @@ testRule({
       line: 2,
       column: 29,
       message: messages.rejected("scss"),
-      description: "Two files, path with dir, has extension."
+      description: "Two files, path with dir, has extension.",
     },
     {
       code: `
@@ -405,7 +406,7 @@ testRule({
       line: 2,
       column: 33,
       message: messages.rejected("scss"),
-      description: "Single file, has .scss extension and a dot in the name."
+      description: "Single file, has .scss extension and a dot in the name.",
     },
     {
       code: `
@@ -417,7 +418,8 @@ testRule({
       line: 2,
       column: 26,
       message: messages.rejected("scss"),
-      description: "Single file, has .scss extension and a .scss in the filename."
-    }
-  ]
+      description:
+        "Single file, has .scss extension and a .scss in the filename.",
+    },
+  ],
 });

--- a/src/rules/at-import-partial-extension/index.js
+++ b/src/rules/at-import-partial-extension/index.js
@@ -6,11 +6,11 @@ export const ruleName = namespace("at-import-partial-extension");
 
 export const messages = utils.ruleMessages(ruleName, {
   expected: "Expected @import to have an extension",
-  rejected: ext => `Unexpected extension ".${ext}" in @import`
+  rejected: (ext) => `Unexpected extension ".${ext}" in @import`,
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 // https://drafts.csswg.org/mediaqueries/#media-types
@@ -25,31 +25,31 @@ const mediaQueryTypes = [
   "handheld",
   "braille",
   "embossed",
-  "aural"
+  "aural",
 ];
 
 const mediaQueryTypesRE = new RegExp(`(${mediaQueryTypes.join("|")})$`, "i");
-const stripPath = path =>
+const stripPath = (path) =>
   path.replace(/^\s*(["'])\s*/, "").replace(/\s*(["'])\s*$/, "");
 
 export default function rule(expectation, _, context) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: expectation,
-      possible: ["always", "never"]
+      possible: ["always", "never"],
     });
 
     if (!validOptions) {
       return;
     }
 
-    root.walkAtRules("import", decl => {
+    root.walkAtRules("import", (decl) => {
       const paths = decl.params
         .split(/["']\s*,/)
-        .filter(path => !mediaQueryTypesRE.test(path.trim()));
+        .filter((path) => !mediaQueryTypesRE.test(path.trim()));
 
       // Processing comma-separated lists of import paths
-      paths.forEach(path => {
+      paths.forEach((path) => {
         // Stripping trailing quotes and whitespaces, if any
         const pathStripped = stripPath(path);
 
@@ -69,7 +69,7 @@ export default function rule(expectation, _, context) {
             message: messages.expected,
             node: decl,
             result,
-            ruleName
+            ruleName,
           });
 
           return;
@@ -89,7 +89,7 @@ export default function rule(expectation, _, context) {
             node: decl,
             word: extension,
             result,
-            ruleName
+            ruleName,
           });
         }
       });

--- a/src/rules/at-mixin-argumentless-call-parentheses/__tests__/index.js
+++ b/src/rules/at-mixin-argumentless-call-parentheses/__tests__/index.js
@@ -11,20 +11,20 @@ testRule({
       code: `
       @include foo ;
     `,
-      description: "No parens; space after mixin name in a call."
+      description: "No parens; space after mixin name in a call.",
     },
     {
       code: `
       @include foo;
     `,
-      description: "No parens; no space after mixin name in a call."
+      description: "No parens; no space after mixin name in a call.",
     },
     {
       code: `
       @include foo ("()") ;
     `,
-      description: "With parens and arguments, '()' as ans argument."
-    }
+      description: "With parens and arguments, '()' as ans argument.",
+    },
   ],
 
   reject: [
@@ -37,7 +37,7 @@ testRule({
     `,
       line: 2,
       message: messages.rejected("foo"),
-      description: "With parens, no space between them."
+      description: "With parens, no space between them.",
     },
     {
       code: `
@@ -48,7 +48,7 @@ testRule({
     `,
       line: 2,
       message: messages.rejected("foo"),
-      description: "With parens, space between them"
+      description: "With parens, space between them",
     },
     {
       code: `
@@ -59,7 +59,7 @@ testRule({
     `,
       line: 2,
       message: messages.rejected("foo"),
-      description: "With parens, no space before and space between them"
+      description: "With parens, no space before and space between them",
     },
     {
       code: `
@@ -71,9 +71,9 @@ testRule({
     `,
       line: 2,
       message: messages.rejected("foo"),
-      description: "With parens, newline between them"
-    }
-  ]
+      description: "With parens, newline between them",
+    },
+  ],
 });
 
 testRule({
@@ -87,27 +87,27 @@ testRule({
       code: `
       @include foo ();
     `,
-      description: "With parens, no space between them."
+      description: "With parens, no space between them.",
     },
     {
       code: `
       @include foo ( );
     `,
-      description: "With parens, space between them"
+      description: "With parens, space between them",
     },
     {
       code: `
       @include foo( 10)
     `,
-      description: "With parens, no space before and space between them"
+      description: "With parens, no space before and space between them",
     },
     {
       code: `
       @include foo
       (10)
     `,
-      description: "With parens, newline between them"
-    }
+      description: "With parens, newline between them",
+    },
   ],
 
   reject: [
@@ -120,7 +120,7 @@ testRule({
     `,
       line: 2,
       message: messages.expected("foo"),
-      description: "No parens."
+      description: "No parens.",
     },
     {
       code: `
@@ -131,7 +131,7 @@ testRule({
     `,
       line: 2,
       message: messages.expected("foo"),
-      description: "No parens; a space after mixin name in a call."
+      description: "No parens; a space after mixin name in a call.",
     },
     {
       code: `
@@ -142,7 +142,7 @@ testRule({
     `,
       line: 2,
       message: messages.expected("foo"),
-      description: "No parens; no trailing semicolon."
-    }
-  ]
+      description: "No parens; no trailing semicolon.",
+    },
+  ],
 });

--- a/src/rules/at-mixin-argumentless-call-parentheses/index.js
+++ b/src/rules/at-mixin-argumentless-call-parentheses/index.js
@@ -4,27 +4,27 @@ import { namespace, ruleUrl } from "../../utils";
 export const ruleName = namespace("at-mixin-argumentless-call-parentheses");
 
 export const messages = utils.ruleMessages(ruleName, {
-  expected: mixin => `Expected parentheses in mixin "${mixin}" call`,
-  rejected: mixin =>
-    `Unexpected parentheses in argumentless mixin "${mixin}" call`
+  expected: (mixin) => `Expected parentheses in mixin "${mixin}" call`,
+  rejected: (mixin) =>
+    `Unexpected parentheses in argumentless mixin "${mixin}" call`,
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(value, _, context) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: value,
-      possible: ["always", "never"]
+      possible: ["always", "never"],
     });
 
     if (!validOptions) {
       return;
     }
 
-    root.walkAtRules("include", mixinCall => {
+    root.walkAtRules("include", (mixinCall) => {
       // If it is "No parens in argumentless calls"
       if (value === "never" && mixinCall.params.search(/\(\s*\)\s*$/) === -1) {
         return;
@@ -48,12 +48,11 @@ export default function rule(value, _, context) {
       const mixinName = /\s*(\S*?)\s*(?:\(|$)/.exec(mixinCall.params)[1];
 
       utils.report({
-        message: messages[value === "never" ? "rejected" : "expected"](
-          mixinName
-        ),
+        message:
+          messages[value === "never" ? "rejected" : "expected"](mixinName),
         node: mixinCall,
         result,
-        ruleName
+        ruleName,
       });
     });
   };

--- a/src/rules/at-mixin-named-arguments/__tests__/index.js
+++ b/src/rules/at-mixin-named-arguments/__tests__/index.js
@@ -13,7 +13,7 @@ testRule({
         @include reset;
       }
       `,
-      description: "Always. Example: no arguments."
+      description: "Always. Example: no arguments.",
     },
     {
       code: `
@@ -21,7 +21,7 @@ testRule({
         @include reset();
       }
       `,
-      description: "Always. Example: no arguments with parenthesis."
+      description: "Always. Example: no arguments with parenthesis.",
     },
     {
       code: `
@@ -29,7 +29,7 @@ testRule({
         @include reset($value: 40px);
       }
       `,
-      description: "Always. Example: single argument is named."
+      description: "Always. Example: single argument is named.",
     },
     {
       code: `
@@ -40,7 +40,7 @@ testRule({
       }
       `,
       description:
-        "Always. Example: single argument is named in multiline mixin call."
+        "Always. Example: single argument is named in multiline mixin call.",
     },
     {
       code: `
@@ -48,7 +48,7 @@ testRule({
         @include reset($value: 40px, $second-value: 10px, $color: 'black');
       }
       `,
-      description: "Always. Example: all arguments are named."
+      description: "Always. Example: all arguments are named.",
     },
     {
       code: `
@@ -61,7 +61,7 @@ testRule({
       }
       `,
       description:
-        "Always. Example: all arguments are named in multiline mixin call."
+        "Always. Example: all arguments are named in multiline mixin call.",
     },
     {
       code: `
@@ -69,7 +69,7 @@ testRule({
         @include reset($value: $other-value);
       }
       `,
-      description: "Always. Example: single argument is a variable."
+      description: "Always. Example: single argument is a variable.",
     },
     {
       code: `
@@ -77,7 +77,7 @@ testRule({
         @include reset($value: #{$other-value});
       }
       `,
-      description: "Always. Example: single argument is an interpolated value."
+      description: "Always. Example: single argument is an interpolated value.",
     },
     {
       code: `
@@ -85,7 +85,7 @@ testRule({
         @include animation($duration: 30 * 25ms);
       }
       `,
-      description: "Always. Example: single argument is a calculated value."
+      description: "Always. Example: single argument is a calculated value.",
     },
     {
       code: `
@@ -93,14 +93,14 @@ testRule({
         @include animation($iteration: infinite);
       }
       `,
-      description: "Always. Example: single argument is an unquoted string."
+      description: "Always. Example: single argument is an unquoted string.",
     },
     {
       code: `
       @include reset($value: 40px);
       `,
-      description: "Always. Example: standalone mixin."
-    }
+      description: "Always. Example: standalone mixin.",
+    },
   ],
 
   reject: [
@@ -113,7 +113,7 @@ testRule({
       line: 3,
       column: 9,
       message: messages.expected,
-      description: "Always. Example: single argument that is not named."
+      description: "Always. Example: single argument that is not named.",
     },
     {
       code: `
@@ -125,15 +125,15 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.expected
+          message: messages.expected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.expected
-        }
+          message: messages.expected,
+        },
       ],
-      description: "Always. Example: first argument is not named."
+      description: "Always. Example: first argument is not named.",
     },
     {
       code: `
@@ -148,16 +148,16 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.expected
+          message: messages.expected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.expected
-        }
+          message: messages.expected,
+        },
       ],
       description:
-        "Always. Example: first argument is not named in multiline mixin call."
+        "Always. Example: first argument is not named in multiline mixin call.",
     },
     {
       code: `
@@ -169,7 +169,7 @@ testRule({
       column: 9,
       message: messages.expected,
       description:
-        "Always. Example: single argument is a variable but is not named."
+        "Always. Example: single argument is a variable but is not named.",
     },
     {
       code: `
@@ -181,7 +181,7 @@ testRule({
       column: 9,
       message: messages.expected,
       description:
-        "Always. Example: single argument is a calculated value but is not named."
+        "Always. Example: single argument is a calculated value but is not named.",
     },
     {
       code: `
@@ -193,16 +193,16 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.expected
+          message: messages.expected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.expected
-        }
+          message: messages.expected,
+        },
       ],
       description:
-        "Always. Example: first argument is named but remaining are not."
+        "Always. Example: first argument is named but remaining are not.",
     },
     {
       code: `
@@ -214,15 +214,15 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.expected
+          message: messages.expected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.expected
-        }
+          message: messages.expected,
+        },
       ],
-      description: "Always. Example: mixed named arguments."
+      description: "Always. Example: mixed named arguments.",
     },
     {
       code: `
@@ -232,7 +232,7 @@ testRule({
       column: 7,
       message: messages.expected,
       description:
-        "Always. Example: single argument is not named in standalone mixin."
+        "Always. Example: single argument is not named in standalone mixin.",
     },
     {
       code: `
@@ -242,18 +242,18 @@ testRule({
         {
           line: 2,
           column: 7,
-          message: messages.expected
+          message: messages.expected,
         },
         {
           line: 2,
           column: 7,
-          message: messages.expected
-        }
+          message: messages.expected,
+        },
       ],
       description:
-        "Always. Example: first argument is not named in standalone mixin."
-    }
-  ]
+        "Always. Example: first argument is not named in standalone mixin.",
+    },
+  ],
 });
 
 // Not allowed ("never")
@@ -269,7 +269,7 @@ testRule({
         @include reset;
       }
       `,
-      description: "Never. Example: no arguments."
+      description: "Never. Example: no arguments.",
     },
     {
       code: `
@@ -277,7 +277,7 @@ testRule({
         @include reset();
       }
       `,
-      description: "Never. Example: no arguments with parenthesis."
+      description: "Never. Example: no arguments with parenthesis.",
     },
     {
       code: `
@@ -285,7 +285,7 @@ testRule({
         @include reset(40px);
       }
     `,
-      description: "Never. Example: single argument that is not named."
+      description: "Never. Example: single argument that is not named.",
     },
     {
       code: `
@@ -293,7 +293,7 @@ testRule({
         @include reset(40px, 10px);
       }
     `,
-      description: "Never. Example: multiple arguments that are not named."
+      description: "Never. Example: multiple arguments that are not named.",
     },
     {
       code: `
@@ -305,7 +305,7 @@ testRule({
       }
     `,
       description:
-        "Never. Example: multiple arguments that are not named in multiline mixin call."
+        "Never. Example: multiple arguments that are not named in multiline mixin call.",
     },
     {
       code: `
@@ -314,7 +314,7 @@ testRule({
       }
     `,
       description:
-        "Never. Example: single argument is a variable and are not named."
+        "Never. Example: single argument is a variable and are not named.",
     },
     {
       code: `
@@ -323,7 +323,7 @@ testRule({
       }
     `,
       description:
-        "Never. Example: single argument is a calculated value and not named."
+        "Never. Example: single argument is a calculated value and not named.",
     },
     {
       code: `
@@ -332,7 +332,7 @@ testRule({
       }
     `,
       description:
-        "Never. Example: single argument is a quoted string and not named."
+        "Never. Example: single argument is a quoted string and not named.",
     },
     {
       code: `
@@ -341,7 +341,7 @@ testRule({
       }
     `,
       description:
-        "Never. Example: single argument is an unquoted string and not named."
+        "Never. Example: single argument is an unquoted string and not named.",
     },
     {
       code: `
@@ -350,22 +350,22 @@ testRule({
       }
     `,
       description:
-        "Never. Example: single argument is an interpolated value and not named."
+        "Never. Example: single argument is an interpolated value and not named.",
     },
     {
       code: `
       @include reset(40px);
     `,
       description:
-        "Never. Example: single argument is not named in standalone mixin."
+        "Never. Example: single argument is not named in standalone mixin.",
     },
     {
       code: `
       @include reset(40px, 10px);
     `,
       description:
-        "Never. Example: all arguments are not named in standalone mixin."
-    }
+        "Never. Example: all arguments are not named in standalone mixin.",
+    },
   ],
 
   reject: [
@@ -378,7 +378,7 @@ testRule({
       line: 3,
       column: 9,
       message: messages.rejected,
-      description: "Never. Example: single argument is named."
+      description: "Never. Example: single argument is named.",
     },
     {
       code: `
@@ -389,7 +389,7 @@ testRule({
       line: 3,
       column: 9,
       message: messages.rejected,
-      description: "Never. Example: single argument is a variable."
+      description: "Never. Example: single argument is a variable.",
     },
     {
       code: `
@@ -400,7 +400,7 @@ testRule({
       line: 3,
       column: 9,
       message: messages.rejected,
-      description: "Never. Example: single argument is an interpolated value."
+      description: "Never. Example: single argument is an interpolated value.",
     },
     {
       code: `
@@ -411,7 +411,7 @@ testRule({
       line: 3,
       column: 9,
       message: messages.rejected,
-      description: "Never. Example: single argument is a calculated value."
+      description: "Never. Example: single argument is a calculated value.",
     },
     {
       code: `
@@ -422,7 +422,7 @@ testRule({
       line: 3,
       column: 9,
       message: messages.rejected,
-      description: "Never. Example: single argument is a quoted string."
+      description: "Never. Example: single argument is a quoted string.",
     },
     {
       code: `
@@ -433,7 +433,7 @@ testRule({
       line: 3,
       column: 9,
       message: messages.rejected,
-      description: "Never. Example: single argument is an unquoted string."
+      description: "Never. Example: single argument is an unquoted string.",
     },
     {
       code: `
@@ -442,7 +442,7 @@ testRule({
       line: 2,
       column: 7,
       message: messages.rejected,
-      description: "Never. Example: standalone mixin."
+      description: "Never. Example: standalone mixin.",
     },
     {
       code: `
@@ -454,20 +454,20 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.rejected
+          message: messages.rejected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.rejected
+          message: messages.rejected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.rejected
-        }
+          message: messages.rejected,
+        },
       ],
-      description: "Never. Example: all arguments are named."
+      description: "Never. Example: all arguments are named.",
     },
     {
       code: `
@@ -483,21 +483,21 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.rejected
+          message: messages.rejected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.rejected
+          message: messages.rejected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.rejected
-        }
+          message: messages.rejected,
+        },
       ],
       description:
-        "Never. Example: all arguments are named in multiline mixin call."
+        "Never. Example: all arguments are named in multiline mixin call.",
     },
     {
       code: `
@@ -509,7 +509,7 @@ testRule({
       column: 9,
       message: messages.rejected,
       description:
-        "Never. Example: first argument is named but remaining are not."
+        "Never. Example: first argument is named but remaining are not.",
     },
     {
       code: `
@@ -520,9 +520,9 @@ testRule({
       line: 3,
       column: 9,
       message: messages.rejected,
-      description: "Never. Example: mixed named arguments."
-    }
-  ]
+      description: "Never. Example: mixed named arguments.",
+    },
+  ],
 });
 
 testRule({
@@ -537,7 +537,7 @@ testRule({
         @include reset;
       }
       `,
-      description: "Always and ignore single argument. Example: no arguments."
+      description: "Always and ignore single argument. Example: no arguments.",
     },
     {
       code: `
@@ -546,7 +546,7 @@ testRule({
       }
       `,
       description:
-        "Always and ignore single argument. Example: no arguments with parenthesis."
+        "Always and ignore single argument. Example: no arguments with parenthesis.",
     },
     {
       code: `
@@ -555,7 +555,7 @@ testRule({
       }
     `,
       description:
-        "Always and ignore single argument. Example: single argument that is not named."
+        "Always and ignore single argument. Example: single argument that is not named.",
     },
     {
       code: `
@@ -564,7 +564,7 @@ testRule({
       }
     `,
       description:
-        "Always and ignore single argument. Example: single argument is a variable and is not named."
+        "Always and ignore single argument. Example: single argument is a variable and is not named.",
     },
     {
       code: `
@@ -573,7 +573,7 @@ testRule({
       }
     `,
       description:
-        "Always and ignore single argument. Example: single argument is a calculated value and is not named."
+        "Always and ignore single argument. Example: single argument is a calculated value and is not named.",
     },
     {
       code: `
@@ -582,7 +582,7 @@ testRule({
       }
       `,
       description:
-        "Always and ignore single argument. Example: all arguments are named."
+        "Always and ignore single argument. Example: all arguments are named.",
     },
     {
       code: `
@@ -595,14 +595,14 @@ testRule({
       }
       `,
       description:
-        "Always and ignore single argument. Example: all arguments are named in multiline mixin call."
+        "Always and ignore single argument. Example: all arguments are named in multiline mixin call.",
     },
     {
       code: `
       @include reset(40px);
     `,
       description:
-        "Always and ignore single argument. Example: single argument is not named in standalone mixin."
+        "Always and ignore single argument. Example: single argument is not named in standalone mixin.",
     },
     {
       code: `
@@ -611,7 +611,7 @@ testRule({
       }
       `,
       description:
-        "Always and ignore single argument. Example: single named argument is a variable."
+        "Always and ignore single argument. Example: single named argument is a variable.",
     },
     {
       code: `
@@ -620,7 +620,7 @@ testRule({
       }
       `,
       description:
-        "Always and ignore single argument. Example: single named argument is an interpolated value."
+        "Always and ignore single argument. Example: single named argument is an interpolated value.",
     },
     {
       code: `
@@ -629,7 +629,7 @@ testRule({
       }
       `,
       description:
-        "Always and ignore single argument. Example: single named argument is a calculated value."
+        "Always and ignore single argument. Example: single named argument is a calculated value.",
     },
     {
       code: `
@@ -638,7 +638,7 @@ testRule({
       }
       `,
       description:
-        "Always and ignore single argument. Example: single named argument is a quoted string."
+        "Always and ignore single argument. Example: single named argument is a quoted string.",
     },
     {
       code: `
@@ -647,15 +647,15 @@ testRule({
       }
       `,
       description:
-        "Always and ignore single argument. Example: single named argument is an unquoted string."
+        "Always and ignore single argument. Example: single named argument is an unquoted string.",
     },
     {
       code: `
       @include reset($value: 40px);
       `,
       description:
-        "Always and ignore single argument. Example: standalone mixin."
-    }
+        "Always and ignore single argument. Example: standalone mixin.",
+    },
   ],
 
   reject: [
@@ -667,16 +667,16 @@ testRule({
         {
           line: 2,
           column: 7,
-          message: messages.expected
+          message: messages.expected,
         },
         {
           line: 2,
           column: 7,
-          message: messages.expected
-        }
+          message: messages.expected,
+        },
       ],
       description:
-        "Always and ignore single argument. Example: first argument is not named in standalone mixin."
+        "Always and ignore single argument. Example: first argument is not named in standalone mixin.",
     },
     {
       code: `
@@ -688,7 +688,7 @@ testRule({
       column: 9,
       message: messages.expected,
       description:
-        "Always and ignore single argument. Example: first argument is named but remaining are not."
+        "Always and ignore single argument. Example: first argument is named but remaining are not.",
     },
     {
       code: `
@@ -703,7 +703,7 @@ testRule({
       column: 9,
       message: messages.expected,
       description:
-        "Always and ignore single argument. Example: first argument is named but remaining are not in multiline mixin call."
+        "Always and ignore single argument. Example: first argument is named but remaining are not in multiline mixin call.",
     },
     {
       code: `
@@ -715,16 +715,16 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.expected
+          message: messages.expected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.expected
-        }
+          message: messages.expected,
+        },
       ],
       description:
-        "Always and ignore single argument. Example: mixed named arguments."
+        "Always and ignore single argument. Example: mixed named arguments.",
     },
     {
       code: `
@@ -736,16 +736,16 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.expected
+          message: messages.expected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.expected
-        }
+          message: messages.expected,
+        },
       ],
       description:
-        "Always and ignore single argument. Example: first argument is named but remaining are not."
+        "Always and ignore single argument. Example: first argument is named but remaining are not.",
     },
     {
       code: `
@@ -757,18 +757,18 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.expected
+          message: messages.expected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.expected
-        }
+          message: messages.expected,
+        },
       ],
       description:
-        "Always and ignore single argument. Example: mixed named arguments."
-    }
-  ]
+        "Always and ignore single argument. Example: mixed named arguments.",
+    },
+  ],
 });
 
 testRule({
@@ -783,7 +783,7 @@ testRule({
         @include reset;
       }
       `,
-      description: "Never and ignore single argument. Example: no arguments."
+      description: "Never and ignore single argument. Example: no arguments.",
     },
     {
       code: `
@@ -792,7 +792,7 @@ testRule({
       }
       `,
       description:
-        "Never and ignore single argument. Example: no arguments with parenthesis."
+        "Never and ignore single argument. Example: no arguments with parenthesis.",
     },
     {
       code: `
@@ -801,7 +801,7 @@ testRule({
       }
     `,
       description:
-        "Never and ignore single argument. Example: single argument that is not named."
+        "Never and ignore single argument. Example: single argument that is not named.",
     },
     {
       code: `
@@ -810,7 +810,7 @@ testRule({
       }
     `,
       description:
-        "Never and ignore single argument. Example: multiple arguments that are not named."
+        "Never and ignore single argument. Example: multiple arguments that are not named.",
     },
     {
       code: `
@@ -822,7 +822,7 @@ testRule({
       }
     `,
       description:
-        "Never and ignore single argument. Example: multiple arguments that are not named in multiline mixin call."
+        "Never and ignore single argument. Example: multiple arguments that are not named in multiline mixin call.",
     },
     {
       code: `
@@ -831,7 +831,7 @@ testRule({
       }
     `,
       description:
-        "Never and ignore single argument. Example: single argument is a variable and are not named."
+        "Never and ignore single argument. Example: single argument is a variable and are not named.",
     },
     {
       code: `
@@ -840,7 +840,7 @@ testRule({
       }
     `,
       description:
-        "Never and ignore single argument. Example: single argument is a calculated value and not named."
+        "Never and ignore single argument. Example: single argument is a calculated value and not named.",
     },
     {
       code: `
@@ -849,7 +849,7 @@ testRule({
       }
     `,
       description:
-        "Never and ignore single argument. Example: single argument is a quoted string and not named."
+        "Never and ignore single argument. Example: single argument is a quoted string and not named.",
     },
     {
       code: `
@@ -858,7 +858,7 @@ testRule({
       }
     `,
       description:
-        "Never and ignore single argument. Example: single argument is an unquoted string and not named."
+        "Never and ignore single argument. Example: single argument is an unquoted string and not named.",
     },
     {
       code: `
@@ -867,14 +867,14 @@ testRule({
       }
     `,
       description:
-        "Never and ignore single argument. Example: single argument is an interpolated value and not named."
+        "Never and ignore single argument. Example: single argument is an interpolated value and not named.",
     },
     {
       code: `
       @include reset(40px);
     `,
       description:
-        "Never and ignore single argument. Example: single argument is not named in standalone mixin."
+        "Never and ignore single argument. Example: single argument is not named in standalone mixin.",
     },
     {
       code: `
@@ -883,7 +883,7 @@ testRule({
       }
       `,
       description:
-        "Never and ignore single argument. Example: single named argument is a variable."
+        "Never and ignore single argument. Example: single named argument is a variable.",
     },
     {
       code: `
@@ -892,7 +892,7 @@ testRule({
       }
       `,
       description:
-        "Never and ignore single argument. Example: single named argument is an interpolated value."
+        "Never and ignore single argument. Example: single named argument is an interpolated value.",
     },
     {
       code: `
@@ -901,7 +901,7 @@ testRule({
       }
       `,
       description:
-        "Never and ignore single argument. Example: single named argument is a calculated value."
+        "Never and ignore single argument. Example: single named argument is a calculated value.",
     },
     {
       code: `
@@ -910,7 +910,7 @@ testRule({
       }
       `,
       description:
-        "Never and ignore single argument. Example: single named argument is a quoted string."
+        "Never and ignore single argument. Example: single named argument is a quoted string.",
     },
     {
       code: `
@@ -919,22 +919,22 @@ testRule({
       }
       `,
       description:
-        "Never and ignore single argument. Example: single named argument is an unquoted string."
+        "Never and ignore single argument. Example: single named argument is an unquoted string.",
     },
     {
       code: `
       @include reset($value: 40px);
       `,
       description:
-        "Never and ignore single argument. Example: standalone mixin."
+        "Never and ignore single argument. Example: standalone mixin.",
     },
     {
       code: `
       @include reset(40px, 10px);
     `,
       description:
-        "Never and ignore single argument. Example: all arguments are not named in standalone mixin."
-    }
+        "Never and ignore single argument. Example: all arguments are not named in standalone mixin.",
+    },
   ],
 
   reject: [
@@ -948,21 +948,21 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.rejected
+          message: messages.rejected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.rejected
+          message: messages.rejected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.rejected
-        }
+          message: messages.rejected,
+        },
       ],
       description:
-        "Never and ignore single argument. Example: all arguments are named."
+        "Never and ignore single argument. Example: all arguments are named.",
     },
     {
       code: `
@@ -978,21 +978,21 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.rejected
+          message: messages.rejected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.rejected
+          message: messages.rejected,
         },
         {
           line: 3,
           column: 9,
-          message: messages.rejected
-        }
+          message: messages.rejected,
+        },
       ],
       description:
-        "Never and ignore single argument. Example: all arguments are named in multiline mixin call."
+        "Never and ignore single argument. Example: all arguments are named in multiline mixin call.",
     },
     {
       code: `
@@ -1004,7 +1004,7 @@ testRule({
       column: 9,
       message: messages.rejected,
       description:
-        "Never and ignore single argument. Example: first argument is named but remaining are not."
+        "Never and ignore single argument. Example: first argument is named but remaining are not.",
     },
     {
       code: `
@@ -1016,7 +1016,7 @@ testRule({
       column: 9,
       message: messages.rejected,
       description:
-        "Never and ignore single argument. Example: mixed named arguments."
-    }
-  ]
+        "Never and ignore single argument. Example: mixed named arguments.",
+    },
+  ],
 });

--- a/src/rules/at-mixin-named-arguments/index.js
+++ b/src/rules/at-mixin-named-arguments/index.js
@@ -5,11 +5,11 @@ export const ruleName = namespace("at-mixin-named-arguments");
 
 export const messages = utils.ruleMessages(ruleName, {
   expected: "Expected a named parameter to be used in at-include call",
-  rejected: "Unexpected a named parameter in at-include call"
+  rejected: "Unexpected a named parameter in at-include call",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 const hasArgumentsRegExp = /\((.*)\)$/;
@@ -22,14 +22,14 @@ export default function rule(expectation, options) {
       ruleName,
       {
         actual: expectation,
-        possible: ["always", "never"]
+        possible: ["always", "never"],
       },
       {
         actual: options,
         possible: {
-          ignore: ["single-argument"]
+          ignore: ["single-argument"],
         },
-        optional: true
+        optional: true,
       }
     );
 
@@ -42,7 +42,7 @@ export default function rule(expectation, options) {
       "single-argument"
     );
 
-    root.walkAtRules("include", atRule => {
+    root.walkAtRules("include", (atRule) => {
       const argsString = atRule.params
         .replace(/\n/g, " ")
         .match(hasArgumentsRegExp);
@@ -60,8 +60,10 @@ export default function rule(expectation, options) {
         // Create array of arguments.
         .split(",")
         // Create a key-value array for every argument.
-        .map(argsString =>
-          argsString.split(":").map(argsKeyValuePair => argsKeyValuePair.trim())
+        .map((argsString) =>
+          argsString
+            .split(":")
+            .map((argsKeyValuePair) => argsKeyValuePair.trim())
         )
         .reduce((resultArray, keyValuePair) => {
           const pair = { value: keyValuePair[1] || keyValuePair[0] };
@@ -79,7 +81,7 @@ export default function rule(expectation, options) {
         return;
       }
 
-      args.forEach(arg => {
+      args.forEach((arg) => {
         switch (expectation) {
           case "never": {
             if (!arg.key) {
@@ -90,7 +92,7 @@ export default function rule(expectation, options) {
               message: messages.rejected,
               node: atRule,
               result,
-              ruleName
+              ruleName,
             });
             break;
           }
@@ -104,7 +106,7 @@ export default function rule(expectation, options) {
               message: messages.expected,
               node: atRule,
               result,
-              ruleName
+              ruleName,
             });
             break;
           }

--- a/src/rules/at-mixin-parentheses-space-before/__tests__/index.js
+++ b/src/rules/at-mixin-parentheses-space-before/__tests__/index.js
@@ -12,50 +12,50 @@ testRule({
       @mixin foo () {
       }
     `,
-      description: "No params with parentheses."
+      description: "No params with parentheses.",
     },
     {
       code: `
       @mixin foo {
       }
     `,
-      description: "No params without parentheses."
+      description: "No params without parentheses.",
     },
     {
       code: `
       @mixin foo ($links: 10){
       }
     `,
-      description: "With default params."
+      description: "With default params.",
     },
     {
       code: `
       @mixin foo ($n) {
       }
     `,
-      description: "With params."
+      description: "With params.",
     },
     {
       code: `
       @mixin  foo ($n) {
       }
     `,
-      description: "Extra spaces after @mixin."
+      description: "Extra spaces after @mixin.",
     },
     {
       code: `
       @bar foo ($n) {
       }
     `,
-      description: "Not a SCSS mixin, skipping."
+      description: "Not a SCSS mixin, skipping.",
     },
     {
       code: `
       @mixin foo-bar () {
       }
     `,
-      description: "No params with parentheses, hyphenated name."
-    }
+      description: "No params with parentheses, hyphenated name.",
+    },
   ],
 
   reject: [
@@ -73,7 +73,7 @@ testRule({
     `,
       line: 2,
       message: messages.expectedBefore(),
-      description: "Newline after mixin name"
+      description: "Newline after mixin name",
     },
     {
       code: `
@@ -86,7 +86,7 @@ testRule({
     `,
       line: 2,
       message: messages.expectedBefore(),
-      description: "No space before parentheses."
+      description: "No space before parentheses.",
     },
     {
       code: `
@@ -99,7 +99,7 @@ testRule({
     `,
       line: 2,
       message: messages.expectedBefore(),
-      description: "Extra spaces after @mixin."
+      description: "Extra spaces after @mixin.",
     },
     {
       code: `
@@ -112,9 +112,9 @@ testRule({
     `,
       line: 2,
       message: messages.expectedBefore(),
-      description: "No space before parentheses, hyphenated name."
-    }
-  ]
+      description: "No space before parentheses, hyphenated name.",
+    },
+  ],
 });
 
 testRule({
@@ -129,50 +129,50 @@ testRule({
       @mixin foo() {
       }
     `,
-      description: "No params with parentheses."
+      description: "No params with parentheses.",
     },
     {
       code: `
       @mixin foo {
       }
     `,
-      description: "No params without parentheses."
+      description: "No params without parentheses.",
     },
     {
       code: `
       @mixin foo($links: 10){
       }
     `,
-      description: "With default params."
+      description: "With default params.",
     },
     {
       code: `
       @mixin foo($n) {
       }
     `,
-      description: "With params."
+      description: "With params.",
     },
     {
       code: `
       @mixin  foo($n) {
       }
     `,
-      description: "Extra spaces after @mixin."
+      description: "Extra spaces after @mixin.",
     },
     {
       code: `
       @bar foo($n) {
       }
     `,
-      description: "Not a SCSS mixin, skipping."
+      description: "Not a SCSS mixin, skipping.",
     },
     {
       code: `
       @mixin foo-bar() {
       }
     `,
-      description: "No params with parentheses, hyphenated name."
-    }
+      description: "No params with parentheses, hyphenated name.",
+    },
   ],
 
   reject: [
@@ -190,7 +190,7 @@ testRule({
     `,
       line: 2,
       message: messages.rejectedBefore(),
-      description: "Newline after mixin name"
+      description: "Newline after mixin name",
     },
     {
       code: `
@@ -203,7 +203,7 @@ testRule({
     `,
       line: 2,
       message: messages.rejectedBefore(),
-      description: "Single space before parentheses."
+      description: "Single space before parentheses.",
     },
     {
       code: `
@@ -216,7 +216,7 @@ testRule({
     `,
       line: 2,
       message: messages.rejectedBefore(),
-      description: "Multiple spaces before parentheses."
+      description: "Multiple spaces before parentheses.",
     },
     {
       code: `
@@ -229,7 +229,7 @@ testRule({
     `,
       line: 2,
       message: messages.rejectedBefore(),
-      description: "Single space before parentheses, hyphenated name."
-    }
-  ]
+      description: "Single space before parentheses, hyphenated name.",
+    },
+  ],
 });

--- a/src/rules/at-mixin-parentheses-space-before/index.js
+++ b/src/rules/at-mixin-parentheses-space-before/index.js
@@ -7,18 +7,18 @@ export const messages = utils.ruleMessages(ruleName, {
   rejectedBefore: () =>
     "Unexpected whitespace before parentheses in mixin declaration",
   expectedBefore: () =>
-    "Expected a single space before parentheses in mixin declaration"
+    "Expected a single space before parentheses in mixin declaration",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(value, _, context) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: value,
-      possible: ["always", "never"]
+      possible: ["always", "never"],
     });
 
     if (!validOptions) {
@@ -30,7 +30,7 @@ export default function rule(value, _, context) {
 
     const checker = whitespaceChecker("space", value, messages).before;
 
-    root.walkAtRules("mixin", decl => {
+    root.walkAtRules("mixin", (decl) => {
       if (context.fix) {
         decl.params = decl.params.replace(match, replacement);
 
@@ -40,7 +40,8 @@ export default function rule(value, _, context) {
       checker({
         source: decl.params,
         index: decl.params.indexOf("("),
-        err: message => utils.report({ message, node: decl, result, ruleName })
+        err: (message) =>
+          utils.report({ message, node: decl, result, ruleName }),
       });
     });
   };

--- a/src/rules/at-mixin-pattern/__tests__/index.js
+++ b/src/rules/at-mixin-pattern/__tests__/index.js
@@ -12,49 +12,49 @@ testRule({
       @mixin foo {
       }
     `,
-      description: "Regexp: sequence part. Example: full match, argumentless."
+      description: "Regexp: sequence part. Example: full match, argumentless.",
     },
     {
       code: `
       @mixin foo () {
       }
     `,
-      description: "Regexp: sequence part. Example: full match."
+      description: "Regexp: sequence part. Example: full match.",
     },
     {
       code: `
       @mixin foo ($links: 10){
       }
     `,
-      description: "Regexp: sequence part. Example: full match, with params."
+      description: "Regexp: sequence part. Example: full match, with params.",
     },
     {
       code: `
       @mixin _foo ($n) {
       }
     `,
-      description: "Regexp: sequence part. Example: matches at the end."
+      description: "Regexp: sequence part. Example: matches at the end.",
     },
     {
       code: `
       @mixin food ($n) {
       }
     `,
-      description: "Regexp: sequence part. Example: matches at the beginning."
+      description: "Regexp: sequence part. Example: matches at the beginning.",
     },
     {
       code: `
       @mixin  foo ($n) {
       }
     `,
-      description: "Regexp: sequence part. Example: space after @mixin."
+      description: "Regexp: sequence part. Example: space after @mixin.",
     },
     {
       code: `
       @mix4in fowdo ($n) {
       }
     `,
-      description: "Any pattern. Example: not a SCSS mixin, skipping."
+      description: "Any pattern. Example: not a SCSS mixin, skipping.",
     },
     {
       code: `
@@ -64,8 +64,8 @@ testRule({
       }
     `,
       description:
-        "Regexp: sequence part. Example: newlines around a mixin name."
-    }
+        "Regexp: sequence part. Example: newlines around a mixin name.",
+    },
   ],
 
   reject: [
@@ -79,9 +79,9 @@ testRule({
       endLine: 3,
       endColumn: 0,
       message: messages.expected,
-      description: "Regexp: sequence part. Example: symbol in between."
-    }
-  ]
+      description: "Regexp: sequence part. Example: symbol in between.",
+    },
+  ],
 });
 
 // Testing against a string, sequence part
@@ -96,22 +96,22 @@ testRule({
       @mixin foo ($p) {
       }
     `,
-      description: "String: sequence part. Example: full match."
+      description: "String: sequence part. Example: full match.",
     },
     {
       code: `
       @mixin _foo ($p) {
       }
     `,
-      description: "String: sequence part. Example: matches at the end."
+      description: "String: sequence part. Example: matches at the end.",
     },
     {
       code: `
       @mixin food ($p) {
       }
     `,
-      description: "String: sequence part. Example: matches at the beginning."
-    }
+      description: "String: sequence part. Example: matches at the beginning.",
+    },
   ],
 
   reject: [
@@ -125,7 +125,7 @@ testRule({
       endLine: 3,
       endColumn: 0,
       message: messages.expected,
-      description: "String: sequence part. Example: symbol in between."
+      description: "String: sequence part. Example: symbol in between.",
     },
     {
       code: `
@@ -137,9 +137,9 @@ testRule({
       endLine: 3,
       endColumn: 0,
       message: messages.expected,
-      description: "String: sequence part. Example: not a full sequence."
-    }
-  ]
+      description: "String: sequence part. Example: not a full sequence.",
+    },
+  ],
 });
 
 // Testing against a regex, full match
@@ -154,14 +154,14 @@ testRule({
       @mixin foo ($options: ()) {}
     `,
       description:
-        "Regexp: strict match. Example: mixin with params that have parens INSIDE."
+        "Regexp: strict match. Example: mixin with params that have parens INSIDE.",
     },
     {
       code: `
       @mixin foo ($options: (), $lol: ()) {}
     `,
       description:
-        "Regexp: strict match. Example: mixin with params that have parens INSIDE #2."
+        "Regexp: strict match. Example: mixin with params that have parens INSIDE #2.",
     },
     {
       code: `
@@ -170,14 +170,14 @@ testRule({
       }
     `,
       description:
-        "Regexp: strict match. Example: mixin with params that have parens INSIDE #3."
+        "Regexp: strict match. Example: mixin with params that have parens INSIDE #3.",
     },
     {
       code: `
       @mixin foo {
       }
     `,
-      description: "Regexp: strict match. Example: matches."
+      description: "Regexp: strict match. Example: matches.",
     },
     {
       code: `
@@ -187,7 +187,7 @@ testRule({
       }
     `,
       description:
-        "Regexp: strict match. Example: newlines around a mixni name."
+        "Regexp: strict match. Example: newlines around a mixni name.",
     },
     {
       code: `
@@ -196,8 +196,8 @@ testRule({
         $p
       ) {}
     `,
-      description: "Regexp: strict match. Example: newline after a brace."
-    }
+      description: "Regexp: strict match. Example: newline after a brace.",
+    },
   ],
 
   reject: [
@@ -211,7 +211,7 @@ testRule({
       endLine: 3,
       endColumn: 0,
       message: messages.expected,
-      description: "Regexp: strict match. Example: matches at the end."
+      description: "Regexp: strict match. Example: matches at the end.",
     },
     {
       code: `
@@ -223,7 +223,7 @@ testRule({
       endLine: 3,
       endColumn: 0,
       message: messages.expected,
-      description: "Regexp: strict match. Example: matches at the beginning."
+      description: "Regexp: strict match. Example: matches at the beginning.",
     },
     {
       code: `
@@ -235,7 +235,7 @@ testRule({
       endLine: 3,
       endColumn: 0,
       message: messages.expected,
-      description: "Regexp: strict match. Example: symbol in between."
+      description: "Regexp: strict match. Example: symbol in between.",
     },
     {
       code: `
@@ -250,9 +250,9 @@ testRule({
       endColumn: 0,
       message: messages.expected,
       description:
-        "Regexp: strict match. Example: mixin name divided by newlines."
-    }
-  ]
+        "Regexp: strict match. Example: mixin name divided by newlines.",
+    },
+  ],
 });
 
 // Testing against a regex, match at the beginning
@@ -267,7 +267,7 @@ testRule({
       @mixin foo {
       }
     `,
-      description: "Regexp: pattern at the beginning. Example: matches."
+      description: "Regexp: pattern at the beginning. Example: matches.",
     },
     {
       code: `
@@ -275,8 +275,8 @@ testRule({
       }
     `,
       description:
-        "Regexp: pattern at the beginning. Example: matches at the beginning."
-    }
+        "Regexp: pattern at the beginning. Example: matches at the beginning.",
+    },
   ],
 
   reject: [
@@ -291,7 +291,7 @@ testRule({
       endColumn: 0,
       message: messages.expected,
       description:
-        "Regexp: pattern at the beginning. Example: matches at the end."
+        "Regexp: pattern at the beginning. Example: matches at the end.",
     },
     {
       code: `
@@ -304,9 +304,9 @@ testRule({
       endColumn: 0,
       message: messages.expected,
       description:
-        "Regexp: pattern at the beginning. Example: symbol in between."
-    }
-  ]
+        "Regexp: pattern at the beginning. Example: symbol in between.",
+    },
+  ],
 });
 
 // Testing against a regex, SUIT naming
@@ -318,12 +318,12 @@ testRule({
   accept: [
     {
       code: "@mixin Foo-bar  ( $p: 1 ) {}",
-      description: "Regexp: SUIT component. Example: comply"
+      description: "Regexp: SUIT component. Example: comply",
     },
     {
       code: "@mixin Foo-barBaz {}",
-      description: "Regexp: SUIT component. Example: comply"
-    }
+      description: "Regexp: SUIT component. Example: comply",
+    },
   ],
 
   reject: [
@@ -335,7 +335,7 @@ testRule({
       endColumn: 0,
       message: messages.expected,
       description:
-        "Regexp: SUIT component. Example: starts with lowercase, two elements"
+        "Regexp: SUIT component. Example: starts with lowercase, two elements",
     },
     {
       code: "@mixin foo-bar ($p) {}",
@@ -344,7 +344,7 @@ testRule({
       endLine: 2,
       endColumn: 0,
       message: messages.expected,
-      description: "Regexp: SUIT component. Example: starts with lowercase"
+      description: "Regexp: SUIT component. Example: starts with lowercase",
     },
     {
       code: "@mixin Foo-Bar ($p) {}",
@@ -354,7 +354,7 @@ testRule({
       endColumn: 0,
       message: messages.expected,
       description:
-        "Regexp: SUIT component. Example: element starts with uppercase"
-    }
-  ]
+        "Regexp: SUIT component. Example: element starts with uppercase",
+    },
+  ],
 });

--- a/src/rules/at-mixin-pattern/index.js
+++ b/src/rules/at-mixin-pattern/index.js
@@ -5,18 +5,18 @@ import { namespace, ruleUrl } from "../../utils";
 export const ruleName = namespace("at-mixin-pattern");
 
 export const messages = utils.ruleMessages(ruleName, {
-  expected: "Expected @mixin name to match specified pattern"
+  expected: "Expected @mixin name to match specified pattern",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(pattern) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: pattern,
-      possible: [isRegExp, isString]
+      possible: [isRegExp, isString],
     });
 
     if (!validOptions) {
@@ -25,7 +25,7 @@ export default function rule(pattern) {
 
     const regexpPattern = isString(pattern) ? new RegExp(pattern) : pattern;
 
-    root.walkAtRules(decl => {
+    root.walkAtRules((decl) => {
       if (decl.name !== "mixin") {
         return;
       }
@@ -46,7 +46,7 @@ export default function rule(pattern) {
         node: decl,
         result,
         ruleName,
-        end: mixinTopLine
+        end: mixinTopLine,
       });
     });
   };

--- a/src/rules/at-rule-conditional-no-parentheses/__tests__/index.js
+++ b/src/rules/at-rule-conditional-no-parentheses/__tests__/index.js
@@ -9,26 +9,26 @@ testRule({
   accept: [
     {
       code: "@if true {}",
-      description: "accepts @if with no parentheses"
+      description: "accepts @if with no parentheses",
     },
     {
       code: "@if (1 + 1) == 2 {}",
-      description: "accepts parentheses statement where () used for math"
+      description: "accepts parentheses statement where () used for math",
     },
     {
       code: "@while true {}",
-      description: "accepts @while with no parentheses"
+      description: "accepts @while with no parentheses",
     },
     {
       code: `@if true {}
       @else if true {}`,
-      description: "accepts @else if with no parentheses"
+      description: "accepts @else if with no parentheses",
     },
     {
       code: `@if true {}
       @else if true {}
       @else {}`,
-      description: "accepts @else unconditionally"
+      description: "accepts @else unconditionally",
     },
     {
       code: `
@@ -40,7 +40,7 @@ testRule({
         @return $number;
       }
       `,
-      description: "accepts function calls using @if"
+      description: "accepts function calls using @if",
     },
     {
       code: `
@@ -55,8 +55,8 @@ testRule({
         @return $number;
       }
       `,
-      description: "accepts function calls using @else if"
-    }
+      description: "accepts function calls using @else if",
+    },
   ],
 
   reject: [
@@ -64,13 +64,13 @@ testRule({
       code: "@if(true) {}",
       fixed: "@if true {}",
       message: messages.rejected,
-      description: "does not accept @if with parentheses"
+      description: "does not accept @if with parentheses",
     },
     {
       code: "@while(true) {}",
       fixed: "@while true {}",
       message: messages.rejected,
-      description: "does not accept @while with parentheses"
+      description: "does not accept @while with parentheses",
     },
     {
       code: `@if true {}
@@ -78,7 +78,7 @@ testRule({
       fixed: `@if true {}
       @else if true {}`,
       message: messages.rejected,
-      description: "does not accept @else if with parentheses"
-    }
-  ]
+      description: "does not accept @else if with parentheses",
+    },
+  ],
 });

--- a/src/rules/at-rule-conditional-no-parentheses/index.js
+++ b/src/rules/at-rule-conditional-no-parentheses/index.js
@@ -4,11 +4,11 @@ import { namespace, ruleUrl } from "../../utils";
 export const ruleName = namespace("at-rule-conditional-no-parentheses");
 
 export const messages = utils.ruleMessages(ruleName, {
-  rejected: "Unexpected () used to surround statements for @-rules"
+  rejected: "Unexpected () used to surround statements for @-rules",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 // postcss picks up else-if as else.
@@ -19,7 +19,7 @@ function report(atrule, result) {
     message: messages.rejected,
     node: atrule,
     result,
-    ruleName
+    ruleName,
   });
 }
 
@@ -35,14 +35,14 @@ function fix(atrule) {
 export default function rule(primary, _unused, context) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
-      actual: primary
+      actual: primary,
     });
 
     if (!validOptions) {
       return;
     }
 
-    root.walkAtRules(atrule => {
+    root.walkAtRules((atrule) => {
       // Check if this is a conditional rule.
       if (!conditional_rules.includes(atrule.name)) {
         return;

--- a/src/rules/at-rule-no-unknown/__tests__/index.js
+++ b/src/rules/at-rule-no-unknown/__tests__/index.js
@@ -7,105 +7,98 @@ testRule({
 
   accept: [
     {
-      code: "@charset 'UTF-8';"
+      code: "@charset 'UTF-8';",
     },
     {
-      code: "@CHARSET 'UTF-8';"
+      code: "@CHARSET 'UTF-8';",
     },
     {
-      code: "@charset 'iso-8859-15'"
+      code: "@charset 'iso-8859-15'",
     },
     {
-      code: '@import url("fineprint.css") print;'
+      code: '@import url("fineprint.css") print;',
     },
     {
-      code: "@import 'custom.css'"
+      code: "@import 'custom.css'",
     },
     {
-      code: "@import url('landscape.css') screen and (orientation:landscape);"
+      code: "@import url('landscape.css') screen and (orientation:landscape);",
     },
     {
-      code: "@namespace url(http://www.w3.org/1999/xhtml);"
+      code: "@namespace url(http://www.w3.org/1999/xhtml);",
     },
     {
-      code: "@namespace prefix url(XML-namespace-URL);"
+      code: "@namespace prefix url(XML-namespace-URL);",
     },
     {
-      code: "@media print { body { font-size: 10pt } }"
+      code: "@media print { body { font-size: 10pt } }",
     },
     {
-      code: "@media (max-width: 960px) { body { font-size: 13px } }"
+      code: "@media (max-width: 960px) { body { font-size: 13px } }",
     },
     {
-      code: "@media screen, print { body { line-height: 1.2 } }"
+      code: "@media screen, print { body { line-height: 1.2 } }",
     },
     {
-      code: "@supports (--foo: green) { body { color: green; } }"
+      code: "@supports (--foo: green) { body { color: green; } }",
     },
     {
-      code:
-        "@supports ( (perspective: 10px) or (-webkit-perspective: 10px) ) { font-size: 10pt }"
+      code: "@supports ( (perspective: 10px) or (-webkit-perspective: 10px) ) { font-size: 10pt }",
     },
     {
-      code:
-        "@counter-style win-list { system: fixed; symbols: url(gold-medal.svg); suffix: ' ';}"
+      code: "@counter-style win-list { system: fixed; symbols: url(gold-medal.svg); suffix: ' ';}",
     },
     {
-      code:
-        "@document url(http://www.w3.org/), url-prefix(http://www.w3.org/Style/), domain(mozilla.org), regexp('https:.*')"
+      code: "@document url(http://www.w3.org/), url-prefix(http://www.w3.org/Style/), domain(mozilla.org), regexp('https:.*')",
     },
     {
-      code: "@page :left { margin-left: 4cm; }"
+      code: "@page :left { margin-left: 4cm; }",
     },
     {
-      code:
-        '@font-face { font-family: MyHelvetica; src: local("Helvetica"), url(MgOpenModern.ttf); }'
+      code: '@font-face { font-family: MyHelvetica; src: local("Helvetica"), url(MgOpenModern.ttf); }',
     },
     {
-      code:
-        "@keyframes identifier { 0% { top: 0; left: 0; } 30% { top: 50px; } 68%, 100% { top: 100px; left: 100%; } }"
+      code: "@keyframes identifier { 0% { top: 0; left: 0; } 30% { top: 50px; } 68%, 100% { top: 100px; left: 100%; } }",
     },
     {
-      code:
-        "@-webkit-keyframes identifier { 0% { top: 0; left: 0; } 30% { top: 50px; } 68%, 100% { top: 100px; left: 100%; } }"
+      code: "@-webkit-keyframes identifier { 0% { top: 0; left: 0; } 30% { top: 50px; } 68%, 100% { top: 100px; left: 100%; } }",
     },
     {
-      code: "@viewport { min-width: 640px; max-width: 800px; }"
+      code: "@viewport { min-width: 640px; max-width: 800px; }",
     },
     {
-      code: "@viewport { orientation: landscape; }"
+      code: "@viewport { orientation: landscape; }",
     },
     {
-      code:
-        '@counter-style winners-list { system: fixed; symbols: url(gold-medal.svg); suffix: " "; }'
+      code: '@counter-style winners-list { system: fixed; symbols: url(gold-medal.svg); suffix: " "; }',
     },
     {
-      code: "@font-feature-values Font One { @styleset { nice-style: 12; } }"
+      code: "@font-feature-values Font One { @styleset { nice-style: 12; } }",
     },
     {
-      code: ".foo { color: red; @nest .parent & { color: blue; } }"
+      code: ".foo { color: red; @nest .parent & { color: blue; } }",
     },
     {
-      code: '@forward "functions";'
+      code: '@forward "functions";',
     },
     {
-      code: "@function foo () {}"
+      code: "@function foo () {}",
     },
     {
-      code: "@extend %p"
+      code: "@extend %p",
     },
     {
-      code: "@if ($i) {}"
+      code: "@if ($i) {}",
     },
     {
-      code: "@if ($i) {} @else {}"
+      code: "@if ($i) {} @else {}",
     },
     {
-      code: "@if ($i) {} @else if {} @else {}"
+      code: "@if ($i) {} @else if {} @else {}",
     },
     {
-      code: '@use "bootstrap";'
-    }
+      code: '@use "bootstrap";',
+    },
   ],
 
   reject: [
@@ -115,7 +108,7 @@ testRule({
     `,
       line: 2,
       description: "",
-      message: messages.rejected("@funciton")
+      message: messages.rejected("@funciton"),
     },
     {
       code: `
@@ -123,7 +116,7 @@ testRule({
     `,
       line: 2,
       description: "",
-      message: messages.rejected("@Function")
+      message: messages.rejected("@Function"),
     },
     {
       code: `
@@ -131,9 +124,9 @@ testRule({
     `,
       line: 2,
       description: "",
-      message: messages.rejected("@While")
-    }
-  ]
+      message: messages.rejected("@While"),
+    },
+  ],
 });
 
 testRule({
@@ -141,21 +134,21 @@ testRule({
   config: [
     true,
     {
-      ignoreAtRules: ["unknown", "/^my-/i"]
-    }
+      ignoreAtRules: ["unknown", "/^my-/i"],
+    },
   ],
   skipBasicChecks: true,
 
   accept: [
     {
-      code: "@unknown { }"
+      code: "@unknown { }",
     },
     {
-      code: "@my-at-rule { }"
+      code: "@my-at-rule { }",
     },
     {
-      code: "@MY-other-at-rule { }"
-    }
+      code: "@MY-other-at-rule { }",
+    },
   ],
 
   reject: [
@@ -163,39 +156,39 @@ testRule({
       code: "@unknown-at-rule { }",
       line: 1,
       column: 1,
-      message: messages.rejected("@unknown-at-rule")
+      message: messages.rejected("@unknown-at-rule"),
     },
     {
       code: "@unknown { @unknown-at-rule { font-size: 14px; } }",
       line: 1,
       column: 12,
-      message: messages.rejected("@unknown-at-rule")
+      message: messages.rejected("@unknown-at-rule"),
     },
     {
       code: "@not-my-at-rule {}",
       line: 1,
       column: 1,
-      message: messages.rejected("@not-my-at-rule")
+      message: messages.rejected("@not-my-at-rule"),
     },
     {
       code: "@Unknown { }",
       line: 1,
       column: 1,
-      message: messages.rejected("@Unknown")
+      message: messages.rejected("@Unknown"),
     },
     {
       code: "@uNkNoWn { }",
       line: 1,
       column: 1,
-      message: messages.rejected("@uNkNoWn")
+      message: messages.rejected("@uNkNoWn"),
     },
     {
       code: "@UNKNOWN { }",
       line: 1,
       column: 1,
-      message: messages.rejected("@UNKNOWN")
-    }
-  ]
+      message: messages.rejected("@UNKNOWN"),
+    },
+  ],
 });
 
 testRule({
@@ -211,14 +204,14 @@ testRule({
         {
           line: 1,
           column: 1,
-          message: messages.rejected("@foo")
+          message: messages.rejected("@foo"),
         },
         {
           line: 1,
           column: 10,
-          message: messages.rejected("@bar")
-        }
-      ]
-    }
-  ]
+          message: messages.rejected("@bar"),
+        },
+      ],
+    },
+  ],
 });

--- a/src/rules/at-rule-no-unknown/index.js
+++ b/src/rules/at-rule-no-unknown/index.js
@@ -22,7 +22,7 @@ const sassAtRules = [
   "return",
   "use",
   "warn",
-  "while"
+  "while",
 ];
 
 const ruleToCheckAgainst = "at-rule-no-unknown";
@@ -34,11 +34,11 @@ export const messages = utils.ruleMessages(ruleName, {
     return rules[ruleToCheckAgainst].messages
       .rejected(...args)
       .replace(` (${ruleToCheckAgainst})`, "");
-  }
+  },
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(primaryOption, secondaryOptions) {
@@ -47,14 +47,14 @@ export default function rule(primaryOption, secondaryOptions) {
       result,
       ruleName,
       {
-        actual: primaryOption
+        actual: primaryOption,
       },
       {
         actual: secondaryOptions,
         possible: {
-          ignoreAtRules: [isRegExp, isString]
+          ignoreAtRules: [isRegExp, isString],
         },
-        optional: true
+        optional: true,
       }
     );
 
@@ -65,16 +65,16 @@ export default function rule(primaryOption, secondaryOptions) {
     const optionsAtRules = secondaryOptions && secondaryOptions.ignoreAtRules;
     const ignoreAtRules = sassAtRules.concat(optionsAtRules || []);
     const defaultedOptions = Object.assign({}, secondaryOptions, {
-      ignoreAtRules
+      ignoreAtRules,
     });
 
     utils.checkAgainstRule(
       {
         ruleName: ruleToCheckAgainst,
         ruleSettings: [primaryOption, defaultedOptions],
-        root
+        root,
       },
-      warning => {
+      (warning) => {
         const name = warning.node.name;
 
         if (!ignoreAtRules.includes(name)) {
@@ -84,7 +84,7 @@ export default function rule(primaryOption, secondaryOptions) {
             result,
             node: warning.node,
             line: warning.line,
-            column: warning.column
+            column: warning.column,
           });
         }
       }

--- a/src/rules/at-use-no-unnamespaced/__tests__/index.js
+++ b/src/rules/at-use-no-unnamespaced/__tests__/index.js
@@ -10,14 +10,14 @@ testRule({
       code: `
       @use "foo";
     `,
-      description: "Default namespace"
+      description: "Default namespace",
     },
     {
       code: `
       @use "foo" as bar;
     `,
-      description: "Explicit namespace"
-    }
+      description: "Explicit namespace",
+    },
   ],
 
   reject: [
@@ -28,7 +28,7 @@ testRule({
       line: 2,
       column: 7,
       message: messages.rejected,
-      description: "Without namespace"
+      description: "Without namespace",
     },
     {
       code: `
@@ -37,7 +37,7 @@ testRule({
       line: 2,
       column: 7,
       message: messages.rejected,
-      description: "Without space"
+      description: "Without space",
     },
     {
       code: `
@@ -46,7 +46,7 @@ testRule({
       line: 2,
       column: 7,
       message: messages.rejected,
-      description: "With many spaces"
+      description: "With many spaces",
     },
     {
       code: `
@@ -55,7 +55,7 @@ testRule({
       line: 2,
       column: 7,
       message: messages.rejected,
-      description: "Configured"
+      description: "Configured",
     },
     {
       code: `
@@ -66,7 +66,7 @@ testRule({
       line: 2,
       column: 7,
       message: messages.rejected,
-      description: "Configured multiline"
-    }
-  ]
+      description: "Configured multiline",
+    },
+  ],
 });

--- a/src/rules/at-use-no-unnamespaced/index.js
+++ b/src/rules/at-use-no-unnamespaced/index.js
@@ -4,11 +4,11 @@ import { namespace, ruleUrl } from "../../utils";
 export const ruleName = namespace("at-use-no-unnamespaced");
 
 export const messages = utils.ruleMessages(ruleName, {
-  rejected: "Unexpected @use without namespace"
+  rejected: "Unexpected @use without namespace",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(actual) {
@@ -19,13 +19,13 @@ export default function rule(actual) {
       return;
     }
 
-    root.walkAtRules("use", decl => {
+    root.walkAtRules("use", (decl) => {
       if (/as\s*\*\s*(?:$|with\s*\()/.test(decl.params)) {
         utils.report({
           message: messages.rejected,
           node: decl,
           result,
-          ruleName
+          ruleName,
         });
       }
     });

--- a/src/rules/comment-no-empty/__tests__/index.js
+++ b/src/rules/comment-no-empty/__tests__/index.js
@@ -8,16 +8,16 @@ testRule({
   accept: [
     {
       code: "// comment",
-      description: "Double slash comment"
+      description: "Double slash comment",
     },
     {
       code: "//* comment",
-      description: "Double slash comments with first character as asterisk"
+      description: "Double slash comments with first character as asterisk",
     },
     {
       code: "/* comment */",
-      description: "Single line block comment"
-    }
+      description: "Single line block comment",
+    },
   ],
   reject: [
     {
@@ -27,7 +27,7 @@ testRule({
       description: "Empty block comment",
       message: messages.rejected,
       line: 2,
-      column: 7
+      column: 7,
     },
     {
       code: `
@@ -37,7 +37,7 @@ testRule({
       description: "Empty multiline block comment",
       message: messages.rejected,
       line: 2,
-      column: 9
+      column: 9,
     },
     {
       code: `
@@ -48,7 +48,7 @@ testRule({
       description: "Empty multiline block comment with an empty line",
       message: messages.rejected,
       line: 2,
-      column: 9
+      column: 9,
     },
     {
       code: `
@@ -56,7 +56,7 @@ testRule({
       `,
       description: "Empty double slash comment",
       message: messages.rejected,
-      line: 2
+      line: 2,
     },
     {
       code: `
@@ -65,7 +65,7 @@ testRule({
       description: "Empty double slash comment with spaces",
       message: messages.rejected,
       line: 2,
-      column: 9
+      column: 9,
     },
     {
       code: `
@@ -74,7 +74,7 @@ testRule({
       description: "Empty double slash comment with tab",
       message: messages.rejected,
       line: 2,
-      column: 9
+      column: 9,
     },
     {
       code: `
@@ -83,7 +83,7 @@ testRule({
       description: "Empty inline comment",
       message: messages.rejected,
       line: 2,
-      column: 23
+      column: 23,
     },
     {
       code: `
@@ -92,7 +92,7 @@ testRule({
       description: "Empty inline block comment",
       message: messages.rejected,
       line: 2,
-      column: 23
+      column: 23,
     },
     {
       code: `
@@ -101,9 +101,9 @@ testRule({
       description: "Empty inline block comment prepends code",
       message: messages.rejected,
       line: 2,
-      column: 7
-    }
-  ]
+      column: 7,
+    },
+  ],
 });
 
 test("messages", () => {

--- a/src/rules/comment-no-empty/index.js
+++ b/src/rules/comment-no-empty/index.js
@@ -9,30 +9,30 @@ export const messages = utils.ruleMessages(ruleName, {
   rejected: rules[coreRuleName].messages.rejected.replace(
     ` (${coreRuleName})`,
     ""
-  )
+  ),
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(primary) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
-      actual: primary
+      actual: primary,
     });
 
     if (!validOptions) {
       return;
     }
 
-    root.walkComments(comment => {
+    root.walkComments((comment) => {
       if (isEmptyComment(comment)) {
         utils.report({
           message: messages.rejected,
           node: comment,
           result,
-          ruleName
+          ruleName,
         });
       }
     });

--- a/src/rules/comment-no-loud/__tests__/index.js
+++ b/src/rules/comment-no-loud/__tests__/index.js
@@ -8,12 +8,12 @@ testRule({
   accept: [
     {
       code: "// comment",
-      description: "Double slash comments"
+      description: "Double slash comments",
     },
     {
       code: "//* comment",
-      description: "Double slash comments with first character as asterisk"
-    }
+      description: "Double slash comments with first character as asterisk",
+    },
   ],
   reject: [
     {
@@ -23,7 +23,7 @@ testRule({
       description: "One line with optional ending",
       line: 2,
       column: 7,
-      message: messages.expected
+      message: messages.expected,
     },
     {
       code: `
@@ -34,7 +34,7 @@ testRule({
       description: "Multiline comment with optional ending on next line",
       line: 2,
       column: 9,
-      message: messages.expected
+      message: messages.expected,
     },
     {
       code: `
@@ -51,7 +51,7 @@ testRule({
       description: "Comment sandwiched between rules",
       line: 6,
       column: 7,
-      message: messages.expected
-    }
-  ]
+      message: messages.expected,
+    },
+  ],
 });

--- a/src/rules/comment-no-loud/index.js
+++ b/src/rules/comment-no-loud/index.js
@@ -4,30 +4,30 @@ import { namespace, ruleUrl } from "../../utils";
 export const ruleName = namespace("comment-no-loud");
 
 export const messages = utils.ruleMessages(ruleName, {
-  expected: "Expected // for comments instead of /*"
+  expected: "Expected // for comments instead of /*",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(primary) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
-      actual: primary
+      actual: primary,
     });
 
     if (!validOptions) {
       return;
     }
 
-    root.walkComments(comment => {
+    root.walkComments((comment) => {
       if (isLoudComment(comment)) {
         utils.report({
           message: messages.expected,
           node: comment,
           result,
-          ruleName
+          ruleName,
         });
       }
     });

--- a/src/rules/declaration-nested-properties-no-divided-groups/__tests__/index.js
+++ b/src/rules/declaration-nested-properties-no-divided-groups/__tests__/index.js
@@ -14,7 +14,7 @@ testRule({
         margin: 1px;
       }
     `,
-      description: "No groups."
+      description: "No groups.",
     },
     {
       code: `
@@ -23,7 +23,7 @@ testRule({
         background-repeat: no-repeat;
       }
     `,
-      description: "No groups #2."
+      description: "No groups #2.",
     },
     {
       code: `
@@ -34,7 +34,7 @@ testRule({
         background-repeat: no-repeat;
       }
     `,
-      description: "One group, one unnested."
+      description: "One group, one unnested.",
     },
     {
       code: `
@@ -46,7 +46,7 @@ testRule({
         background-repeat: no-repeat;
       }
     `,
-      description: "One group, two unnested."
+      description: "One group, two unnested.",
     },
     {
       code: `
@@ -59,7 +59,7 @@ testRule({
         }
       }
     `,
-      description: "One group, one selector."
+      description: "One group, one selector.",
     },
     {
       code: `
@@ -72,7 +72,7 @@ testRule({
         }
       }
     `,
-      description: "Multiple groups, different namespaces."
+      description: "Multiple groups, different namespaces.",
     },
     {
       code: `
@@ -87,7 +87,7 @@ testRule({
         }
       }
     `,
-      description: "Two groups on one namespace, one nested in @media."
+      description: "Two groups on one namespace, one nested in @media.",
     },
     {
       code: `
@@ -96,9 +96,9 @@ testRule({
         &:not(.another-class) { }
       }
     `,
-      description: "Two groups of &:not()."
-    }
-  ]
+      description: "Two groups of &:not().",
+    },
+  ],
 });
 
 // Warnings
@@ -122,14 +122,14 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.expected("background")
+          message: messages.expected("background"),
         },
         {
           line: 6,
           column: 9,
-          message: messages.expected("background")
-        }
-      ]
+          message: messages.expected("background"),
+        },
+      ],
     },
     {
       code: `
@@ -151,14 +151,14 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.expected("background")
+          message: messages.expected("background"),
         },
         {
           line: 10,
           column: 9,
-          message: messages.expected("background")
-        }
-      ]
+          message: messages.expected("background"),
+        },
+      ],
     },
     {
       code: `
@@ -180,19 +180,19 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.expected("background")
+          message: messages.expected("background"),
         },
         {
           line: 6,
           column: 9,
-          message: messages.expected("background")
+          message: messages.expected("background"),
         },
         {
           line: 10,
           column: 9,
-          message: messages.expected("background")
-        }
-      ]
-    }
-  ]
+          message: messages.expected("background"),
+        },
+      ],
+    },
+  ],
 });

--- a/src/rules/declaration-nested-properties-no-divided-groups/index.js
+++ b/src/rules/declaration-nested-properties-no-divided-groups/index.js
@@ -8,25 +8,25 @@ export const ruleName = namespace(
 );
 
 export const messages = utils.ruleMessages(ruleName, {
-  expected: prop =>
-    `Expected all nested properties of "${prop}" namespace to be in one nested group`
+  expected: (prop) =>
+    `Expected all nested properties of "${prop}" namespace to be in one nested group`,
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(expectation) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
-      actual: expectation
+      actual: expectation,
     });
 
     if (!validOptions) {
       return;
     }
 
-    root.walk(item => {
+    root.walk((item) => {
       if (item.type !== "rule" && item.type !== "atrule") {
         return;
       }
@@ -34,7 +34,7 @@ export default function rule(expectation) {
       const nestedGroups = {};
 
       // Find all nested property groups
-      item.each(decl => {
+      item.each((decl) => {
         if (decl.type !== "rule") {
           return;
         }
@@ -52,18 +52,18 @@ export default function rule(expectation) {
         }
       });
 
-      Object.keys(nestedGroups).forEach(namespace => {
+      Object.keys(nestedGroups).forEach((namespace) => {
         // Only warn if there are more than one nested groups with equal namespaces
         if (nestedGroups[namespace].length === 1) {
           return;
         }
 
-        nestedGroups[namespace].forEach(group => {
+        nestedGroups[namespace].forEach((group) => {
           utils.report({
             message: messages.expected(namespace),
             node: group,
             result,
-            ruleName
+            ruleName,
           });
         });
       });

--- a/src/rules/declaration-nested-properties/__tests__/index.js
+++ b/src/rules/declaration-nested-properties/__tests__/index.js
@@ -18,7 +18,7 @@ testRule({
         margin: 1px;
       }
     `,
-      description: "{ always } Nothing to nest"
+      description: "{ always } Nothing to nest",
     },
     {
       code: `
@@ -27,7 +27,7 @@ testRule({
         -webkit-box-shadow: 1px 0 0 red;
       }
     `,
-      description: "{ always } Vendor prefixed rules."
+      description: "{ always } Vendor prefixed rules.",
     },
     {
       code: `
@@ -38,7 +38,7 @@ testRule({
         }
       }
       `,
-      description: "{ always } nested properties"
+      description: "{ always } nested properties",
     },
     {
       code: `
@@ -48,8 +48,8 @@ testRule({
         };
       }
     `,
-      description: "{ always } one `background` in nested form"
-    }
+      description: "{ always } one `background` in nested form",
+    },
   ],
 
   reject: [
@@ -66,14 +66,14 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.expected("background-color")
+          message: messages.expected("background-color"),
         },
         {
           line: 4,
           column: 9,
-          message: messages.expected("background-repeat")
-        }
-      ]
+          message: messages.expected("background-repeat"),
+        },
+      ],
     },
     {
       code: `
@@ -89,19 +89,19 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.expected("background-color")
+          message: messages.expected("background-color"),
         },
         {
           line: 5,
           column: 9,
-          message: messages.expected("background-repeat")
+          message: messages.expected("background-repeat"),
         },
         {
           line: 4,
           column: 26,
-          message: messages.expected("background-image")
-        }
-      ]
+          message: messages.expected("background-image"),
+        },
+      ],
     },
     {
       code: `
@@ -117,9 +117,9 @@ testRule({
         {
           line: 6,
           column: 9,
-          message: messages.expected("background-position")
-        }
-      ]
+          message: messages.expected("background-position"),
+        },
+      ],
     },
     {
       code: `
@@ -135,9 +135,9 @@ testRule({
         {
           line: 6,
           column: 9,
-          message: messages.expected("background-position")
-        }
-      ]
+          message: messages.expected("background-position"),
+        },
+      ],
     },
     {
       code: `
@@ -153,11 +153,11 @@ testRule({
         {
           line: 6,
           column: 9,
-          message: messages.expected("background-position")
-        }
-      ]
-    }
-  ]
+          message: messages.expected("background-position"),
+        },
+      ],
+    },
+  ],
 });
 
 // --------------------------------------------------------------------------
@@ -178,7 +178,8 @@ testRule({
         background-color: red;
       }
     `,
-      description: "{ always, except: only-of-namespace } background-color only"
+      description:
+        "{ always, except: only-of-namespace } background-color only",
     },
     {
       code: `
@@ -190,7 +191,7 @@ testRule({
       }
     `,
       description:
-        "{ always, except: only-of-namespace } `background:red`, one rule inside"
+        "{ always, except: only-of-namespace } `background:red`, one rule inside",
     },
     {
       code: `
@@ -202,7 +203,7 @@ testRule({
       }
     `,
       description:
-        "{ always, except: only-of-namespace } background, two rules inside"
+        "{ always, except: only-of-namespace } background, two rules inside",
     },
   ],
 
@@ -221,14 +222,14 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.expected("background-color")
+          message: messages.expected("background-color"),
         },
         {
           line: 5,
           column: 9,
-          message: messages.expected("background-repeat")
-        }
-      ]
+          message: messages.expected("background-repeat"),
+        },
+      ],
     },
     {
       code: `
@@ -246,14 +247,14 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.rejected("background")
+          message: messages.rejected("background"),
         },
         {
           line: 6,
           column: 9,
-          message: messages.rejected("background")
-        }
-      ]
+          message: messages.rejected("background"),
+        },
+      ],
     },
     {
       code: `
@@ -269,9 +270,9 @@ testRule({
         {
           line: 3,
           column: 9,
-          message: messages.rejected("background")
+          message: messages.rejected("background"),
         },
-      ]
+      ],
     },
     {
       code: `
@@ -289,11 +290,11 @@ testRule({
         {
           line: 7,
           column: 9,
-          message: messages.expected("background-position")
+          message: messages.expected("background-position"),
         },
-      ]
-    }
-  ]
+      ],
+    },
+  ],
 });
 
 // --------------------------------------------------------------------------
@@ -313,7 +314,7 @@ testRule({
         background: red;
       }
     `,
-      description: "{ never } bg shorthand."
+      description: "{ never } bg shorthand.",
     },
     {
       code: `
@@ -321,7 +322,7 @@ testRule({
         background-color: red;
       }
     `,
-      description: "{ never } bgc."
+      description: "{ never } bgc.",
     },
     {
       code: `
@@ -330,7 +331,7 @@ testRule({
         background-repeat: no-repeat;
       }
     `,
-      description: "{ never } bgc, bgr."
+      description: "{ never } bgc, bgr.",
     },
     {
       code: `
@@ -341,18 +342,18 @@ testRule({
         }
       }
     `,
-      description: "{ never } `prop:value` -- selector."
+      description: "{ never } `prop:value` -- selector.",
     },
     {
       code: `.class {
       &:not(.other-class) { }
     }`,
-      description: "{ never } `.class { &:not() { ... } }` -- selector."
+      description: "{ never } `.class { &:not() { ... } }` -- selector.",
     },
     {
       code: `.test4\\:3 {}`,
-      description: "{ never } selector with escaping"
-    }
+      description: "{ never } selector with escaping",
+    },
   ],
 
   reject: [
@@ -380,7 +381,7 @@ testRule({
       description: "{ never } `prop: value { one nested }`.",
       message: messages.rejected("background"),
       line: 3,
-      column: 9
+      column: 9,
     },
     {
       code: `
@@ -398,7 +399,7 @@ testRule({
       description: "{ never } `prop: { two nested }`, deep inside a rule.",
       message: messages.rejected("background"),
       line: 5,
-      column: 13
+      column: 13,
     },
     {
       code: `
@@ -412,7 +413,7 @@ testRule({
       description: "{ never } `-webkit: { ... }`.",
       message: messages.rejected("-webkit"),
       line: 3,
-      column: 9
-    }
-  ]
+      column: 9,
+    },
+  ],
 });

--- a/src/rules/declaration-nested-properties/index.js
+++ b/src/rules/declaration-nested-properties/index.js
@@ -4,7 +4,7 @@ import {
   namespace,
   optionsHaveException,
   parseNestedPropRoot,
-  ruleUrl
+  ruleUrl,
 } from "../../utils";
 
 const hasOwnProp = Object.prototype.hasOwnProperty;
@@ -12,12 +12,12 @@ const hasOwnProp = Object.prototype.hasOwnProperty;
 export const ruleName = namespace("declaration-nested-properties");
 
 export const messages = utils.ruleMessages(ruleName, {
-  expected: prop => `Expected property "${prop}" to be in a nested form`,
-  rejected: prop => `Unexpected nested property "${prop}"`
+  expected: (prop) => `Expected property "${prop}" to be in a nested form`,
+  rejected: (prop) => `Unexpected nested property "${prop}"`,
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(expectation, options) {
@@ -27,14 +27,14 @@ export default function rule(expectation, options) {
       ruleName,
       {
         actual: expectation,
-        possible: ["always", "never"]
+        possible: ["always", "never"],
       },
       {
         actual: options,
         possible: {
-          except: ["only-of-namespace"]
+          except: ["only-of-namespace"],
         },
-        optional: true
+        optional: true,
       }
     );
 
@@ -43,14 +43,14 @@ export default function rule(expectation, options) {
     }
 
     if (expectation === "always") {
-      root.walk(item => {
+      root.walk((item) => {
         if (item.type !== "rule" && item.type !== "atrule") {
           return;
         }
 
         const warningCandidates = {};
 
-        item.each(decl => {
+        item.each((decl) => {
           const { prop, type, selector } = decl;
 
           // Looking for namespaced non-nested properties
@@ -92,21 +92,21 @@ export default function rule(expectation, options) {
 
               warningCandidates[ns].push({
                 node: decl,
-                nested: true
+                nested: true,
               });
             }
           }
         });
 
         // Now check if the found properties deserve warnings
-        Object.keys(warningCandidates).forEach(namespace => {
+        Object.keys(warningCandidates).forEach((namespace) => {
           const exceptIfOnlyOfNs = optionsHaveException(
             options,
             "only-of-namespace"
           );
           const moreThanOneProp = warningCandidates[namespace].length > 1;
 
-          warningCandidates[namespace].forEach(candidate => {
+          warningCandidates[namespace].forEach((candidate) => {
             if (candidate.nested === true) {
               if (exceptIfOnlyOfNs) {
                 // If there is only one prop inside a nested prop - warn (reverse "always")
@@ -118,7 +118,7 @@ export default function rule(expectation, options) {
                     message: messages.rejected(namespace),
                     node: candidate.node,
                     result,
-                    ruleName
+                    ruleName,
                   });
                 }
               }
@@ -133,14 +133,14 @@ export default function rule(expectation, options) {
                 message: messages.expected(candidate.node.prop),
                 node: candidate.node,
                 result,
-                ruleName
+                ruleName,
               });
             }
           });
         });
       });
     } else if (expectation === "never") {
-      root.walk(item => {
+      root.walk((item) => {
         // Just check if there are ANY nested props
         if (item.type === "rule") {
           // `background:red {` - selector;
@@ -152,7 +152,7 @@ export default function rule(expectation, options) {
               message: messages.rejected(testForProp.propName.value),
               result,
               ruleName,
-              node: item
+              node: item,
             });
           }
         }

--- a/src/rules/dimension-no-non-numeric-values/__tests__/index.js
+++ b/src/rules/dimension-no-non-numeric-values/__tests__/index.js
@@ -10,28 +10,28 @@ testRule({
       padding: 1 * 1%unit%;
     }
     `,
-    description: "Accepts proper value interpolation with %unit%"
+    description: "Accepts proper value interpolation with %unit%",
   }).concat([
     {
       code: "$pad: 2; $doublePad: px#{$pad}px;",
-      description: "does not report when a unit is preceded by another string"
+      description: "does not report when a unit is preceded by another string",
     },
     {
       code: "$pad: 2; $doublePad: #{$pad}pxx;",
-      description: "does not report lint when no understood units are used"
+      description: "does not report lint when no understood units are used",
     },
     {
       code: `$pad: "2";
       $string: "#{$pad}px";`,
-      description: "does not report lint when string is quoted"
+      description: "does not report lint when string is quoted",
     },
     {
       code: `
       @include media-breakpoint-up($grid-gutter-breakpoint) {
         --#{$variable-prefix}gutter-x: #{$gutter * 2};
       }`,
-      description: "ignores interpolation without a unit"
-    }
+      description: "ignores interpolation without a unit",
+    },
   ]),
   reject: loopOverUnits({
     code: `
@@ -42,14 +42,14 @@ testRule({
     message: messages.rejected("%unit%"),
     line: 3,
     column: 27,
-    description: "Rejects interpolation with %unit%"
+    description: "Rejects interpolation with %unit%",
   }).concat([
     {
       code: "$pad: 2; $padAndMore: #{$pad + 5}px;",
       description: "reports lint when expression used in interpolation",
       line: 1,
       column: 34,
-      message: messages.rejected("px")
+      message: messages.rejected("px"),
     },
     {
       code: `
@@ -60,7 +60,7 @@ testRule({
       description: "reports lint when mixing accepted and rejected syntax",
       line: 3,
       column: 39,
-      message: messages.rejected("px")
+      message: messages.rejected("px"),
     },
     {
       code: `
@@ -71,7 +71,7 @@ testRule({
       description: "reports lint when mixing accepted and rejected syntax",
       line: 3,
       column: 39,
-      message: messages.rejected("px")
+      message: messages.rejected("px"),
     },
     {
       code: `
@@ -82,7 +82,7 @@ testRule({
       description: "reports lint when mixing normal unit and rejected syntax",
       line: 3,
       column: 29,
-      message: messages.rejected("vmin")
+      message: messages.rejected("vmin"),
     },
     {
       code: `
@@ -93,16 +93,16 @@ testRule({
       description: "reports lint when mixing normal unit and rejected syntax",
       line: 3,
       column: 29,
-      message: messages.rejected("vmin")
-    }
-  ])
+      message: messages.rejected("vmin"),
+    },
+  ]),
 });
 
 function loopOverUnits(codeBlock) {
-  return units.map(unit => {
+  return units.map((unit) => {
     const block = {
       code: codeBlock.code.replace(/%unit%/g, unit),
-      description: codeBlock.description.replace(/%unit%/g, unit)
+      description: codeBlock.description.replace(/%unit%/g, unit),
     };
 
     if (codeBlock.message) {

--- a/src/rules/dimension-no-non-numeric-values/index.js
+++ b/src/rules/dimension-no-non-numeric-values/index.js
@@ -5,12 +5,12 @@ import { declarationValueIndex, namespace, ruleUrl } from "../../utils";
 export const ruleName = namespace("dimension-no-non-numeric-values");
 
 export const messages = utils.ruleMessages(ruleName, {
-  rejected: unit =>
-    `Expected "$value * 1${unit}" instead of "#{$value}${unit}". Consider writing "value" in terms of ${unit} originally.`
+  rejected: (unit) =>
+    `Expected "$value * 1${unit}" instead of "#{$value}${unit}". Consider writing "value" in terms of ${unit} originally.`,
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export const units = [
@@ -70,21 +70,21 @@ export const units = [
 
   // Flexible lengths:
   // https://www.w3.org/TR/css-grid-1/#fr-unit
-  "fr"
+  "fr",
 ];
 
 export default function rule(primary) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
-      actual: primary
+      actual: primary,
     });
 
     if (!validOptions) {
       return;
     }
 
-    root.walkDecls(decl => {
-      valueParser(decl.value).walk(node => {
+    root.walkDecls((decl) => {
+      valueParser(decl.value).walk((node) => {
         // All words are non-quoted, while strings are quoted.
         // If quoted, it's probably a deliberate non-numeric dimension.
         if (node.type !== "word") {
@@ -110,7 +110,7 @@ export default function rule(primary) {
           result,
           message: messages.rejected(unit),
           index: declarationValueIndex(decl) + offset,
-          node: decl
+          node: decl,
         });
       });
     });
@@ -131,7 +131,7 @@ function isInterpolated(value) {
     return true;
   }
 
-  units.forEach(unit => {
+  units.forEach((unit) => {
     const regex = new RegExp(`^#{[$a-z_0-9 +-]*}${unit};?$`);
 
     if (value.match(regex)) {

--- a/src/rules/dollar-variable-colon-newline-after/__tests__/index.js
+++ b/src/rules/dollar-variable-colon-newline-after/__tests__/index.js
@@ -12,35 +12,35 @@ testRule({
       $var1:
         100px;
     }`,
-      description: "a {$var1:\\n100px;}"
+      description: "a {$var1:\\n100px;}",
     },
     {
       code: "a { $var1 :\n100px }",
-      description: "a { $var1 :\\n100px }"
+      description: "a { $var1 :\\n100px }",
     },
     {
       code: "a { $var1\n:\n100px }",
-      description: "a { $var1\\n:\\n100px }"
+      description: "a { $var1\\n:\\n100px }",
     },
     {
       code: "a { $var1\r\n:\r\n100px }",
-      description: "a { $var1\\r\\n:\\r\\n100px }"
+      description: "a { $var1\\r\\n:\\r\\n100px }",
     },
     {
       code: "a { $var1\n:\n(100px) }",
-      description: "always: should allow variable using parens with newline"
+      description: "always: should allow variable using parens with newline",
     },
     {
       code: "a { $var1\r\n:\r\n(100px) }",
-      description: "always: should allow variable using parens with newline"
+      description: "always: should allow variable using parens with newline",
     },
     {
       code: "a { width: 100px; }",
-      description: "a { width: 100px; }"
+      description: "a { width: 100px; }",
     },
     {
       code: "$background:\n  url(data:application/font-woff;...);",
-      description: "$background:\\n  url(data:application/font-woff;...);"
+      description: "$background:\\n  url(data:application/font-woff;...);",
     },
     {
       code: `
@@ -49,7 +49,7 @@ testRule({
         bar: 2,
       );
       `,
-      description: "always: should ignore Sass maps"
+      description: "always: should ignore Sass maps",
     },
     {
       code: `
@@ -58,7 +58,7 @@ testRule({
         bar: 2,
       ) !default;
       `,
-      description: "always: should ignore Sass maps that use !default"
+      description: "always: should ignore Sass maps that use !default",
     },
     {
       code: `
@@ -67,7 +67,7 @@ testRule({
         bar: 2,
       )!default;
       `,
-      description: "always: should ignore Sass maps that use !default"
+      description: "always: should ignore Sass maps that use !default",
     },
     {
       code: `
@@ -77,7 +77,7 @@ testRule({
         3
       );
       `,
-      description: "always: should ignore multiline variables"
+      description: "always: should ignore multiline variables",
     },
     {
       code: `
@@ -87,8 +87,9 @@ testRule({
         3
       ) !default;
       `,
-      description: "always: should ignore multiline variables that use !default"
-    }
+      description:
+        "always: should ignore multiline variables that use !default",
+    },
   ],
 
   reject: [
@@ -108,7 +109,7 @@ testRule({
       }`,
       message: messages.expectedAfter(),
       line: 3,
-      column: 15
+      column: 15,
     },
     {
       code: `
@@ -126,7 +127,7 @@ testRule({
       }`,
       message: messages.expectedAfter(),
       line: 3,
-      column: 15
+      column: 15,
     },
     {
       code: `
@@ -144,7 +145,7 @@ testRule({
       }`,
       message: messages.expectedAfter(),
       line: 3,
-      column: 15
+      column: 15,
     },
     {
       code: `
@@ -162,7 +163,7 @@ testRule({
       }`,
       message: messages.expectedAfter(),
       line: 3,
-      column: 15
+      column: 15,
     },
     {
       code: `
@@ -177,7 +178,7 @@ testRule({
       `,
       message: messages.expectedAfter(),
       line: 2,
-      column: 13
+      column: 13,
     },
     {
       code: `
@@ -192,7 +193,7 @@ testRule({
       `,
       message: messages.expectedAfter(),
       line: 2,
-      column: 13
+      column: 13,
     },
     {
       code: `
@@ -207,7 +208,7 @@ testRule({
       `,
       message: messages.expectedAfter(),
       line: 2,
-      column: 13
+      column: 13,
     },
     {
       code: `
@@ -222,7 +223,7 @@ testRule({
       `,
       message: messages.expectedAfter(),
       line: 2,
-      column: 13
+      column: 13,
     },
     {
       code: `
@@ -235,9 +236,9 @@ testRule({
       description: "always: should report variable with parens without newline",
       message: messages.expectedAfter(),
       line: 2,
-      column: 13
-    }
-  ]
+      column: 13,
+    },
+  ],
 });
 
 testRule({
@@ -248,7 +249,7 @@ testRule({
   accept: [
     {
       code: "a {\n" + "  $var1: 100px\n" + "}",
-      description: "a {\\n" + "  $var1: 100px\\n" + "}"
+      description: "a {\\n" + "  $var1: 100px\\n" + "}",
     },
     {
       code:
@@ -258,28 +259,28 @@ testRule({
       description:
         "  $box-shadow:\\n" +
         "    0 0 0 1px #5b9dd9,\\n" +
-        "    0 0 2px 1px rgba(30, 140, 190, 0.8);"
+        "    0 0 2px 1px rgba(30, 140, 190, 0.8);",
     },
     {
       code: "a { $var1:100px }",
-      description: "a { $var1:100px }"
+      description: "a { $var1:100px }",
     },
     {
       code: "a { $var1: (100px) }",
       description:
-        "always-multi-line: should accept single line variable with parens"
+        "always-multi-line: should accept single line variable with parens",
     },
     {
       code: "a { $var1 :\t100px }",
-      description: "a { $var1 :\\t100px }"
+      description: "a { $var1 :\\t100px }",
     },
     {
       code: "a { $var1\n: 100px }",
-      description: "a { $var1\\n: 100px }"
+      description: "a { $var1\\n: 100px }",
     },
     {
       code: "a { $var1\r\n:  100px }",
-      description: "a { $var1\\r\\n:  100px }"
+      description: "a { $var1\\r\\n:  100px }",
     },
     {
       code:
@@ -287,7 +288,7 @@ testRule({
         "    0 0 0 1px #5b9dd9, 0 0 2px 1px rgba(30, 140, 190, 0.8);",
       description:
         "  $box-shadow:0 0 0 1px #5b9dd9,\\n" +
-        "    0 0 2px 1px rgba(30, 140, 190, 0.8);"
+        "    0 0 2px 1px rgba(30, 140, 190, 0.8);",
     },
     {
       code:
@@ -295,7 +296,7 @@ testRule({
         "  box-shadow: 0 0 0 1px #5b9dd9,\n 0 0 2px 1px rgb(30, 140, 190); }",
       description:
         "a{\n" +
-        "  box-shadow: 0 0 0 1px #5b9dd9,\\n  0 0 2px 1px rgb(30, 140, 190); }"
+        "  box-shadow: 0 0 0 1px #5b9dd9,\\n  0 0 2px 1px rgb(30, 140, 190); }",
     },
     {
       code: `
@@ -305,7 +306,7 @@ testRule({
       );
       `,
       description:
-        "always-multi-line: should allow Sass map using newline after colon"
+        "always-multi-line: should allow Sass map using newline after colon",
     },
     {
       code: `
@@ -315,7 +316,7 @@ testRule({
       ) !default;
       `,
       description:
-        "always-multi-line: should allow Sass map that use !default using newline after colon"
+        "always-multi-line: should allow Sass map that use !default using newline after colon",
     },
     {
       code: `
@@ -326,7 +327,7 @@ testRule({
       );
       `,
       description:
-        "always-multi-line: should allow multiline variable using newline after colon"
+        "always-multi-line: should allow multiline variable using newline after colon",
     },
     {
       code: `
@@ -336,7 +337,7 @@ testRule({
       );
       `,
       description:
-        "always-multi-line: should allow using Sass map without a newline"
+        "always-multi-line: should allow using Sass map without a newline",
     },
     {
       code: `
@@ -346,7 +347,7 @@ testRule({
       ) !default;
       `,
       description:
-        "always-multi-line: should allow using Sass map that use !default without a newline"
+        "always-multi-line: should allow using Sass map that use !default without a newline",
     },
     {
       code: `
@@ -357,7 +358,7 @@ testRule({
       );
       `,
       description:
-        "always-multi-line: should allow using multiline variable with parens without a newline"
+        "always-multi-line: should allow using multiline variable with parens without a newline",
     },
     {
       code: `
@@ -373,8 +374,8 @@ testRule({
       );
       `,
       description:
-        "always-multi-line: should allow using a mix of multiline variables"
-    }
+        "always-multi-line: should allow using a mix of multiline variables",
+    },
   ],
 
   reject: [
@@ -391,7 +392,7 @@ testRule({
         "    0 0 2px 1px rgba(30, 140, 190, 0.8);",
       message: messages.expectedAfterMultiLine(),
       line: 1,
-      column: 14
+      column: 14,
     },
     {
       code:
@@ -406,9 +407,9 @@ testRule({
         "    0 0 2px 1px rgba(30, 140, 190, 0.8);",
       message: messages.expectedAfterMultiLine(),
       line: 1,
-      column: 14
-    }
-  ]
+      column: 14,
+    },
+  ],
 });
 
 testRule({
@@ -416,15 +417,15 @@ testRule({
   config: [
     "always-multi-line",
     {
-      disableFix: true
-    }
+      disableFix: true,
+    },
   ],
   unfixable: true,
 
   accept: [
     {
       code: "a {\n" + "  $var1: 100px\n" + "}",
-      description: "a {\\n" + "  $var1: 100px\\n" + "}"
+      description: "a {\\n" + "  $var1: 100px\\n" + "}",
     },
     {
       code:
@@ -434,28 +435,28 @@ testRule({
       description:
         "  $box-shadow:\\n" +
         "    0 0 0 1px #5b9dd9,\\n" +
-        "    0 0 2px 1px rgba(30, 140, 190, 0.8);"
+        "    0 0 2px 1px rgba(30, 140, 190, 0.8);",
     },
     {
       code: "a { $var1:100px }",
-      description: "a { $var1:100px }"
+      description: "a { $var1:100px }",
     },
     {
       code: "a { $var1: (100px) }",
       description:
-        "always-multi-line: should accept single line variable with parens"
+        "always-multi-line: should accept single line variable with parens",
     },
     {
       code: "a { $var1 :\t100px }",
-      description: "a { $var1 :\\t100px }"
+      description: "a { $var1 :\\t100px }",
     },
     {
       code: "a { $var1\n: 100px }",
-      description: "a { $var1\\n: 100px }"
+      description: "a { $var1\\n: 100px }",
     },
     {
       code: "a { $var1\r\n:  100px }",
-      description: "a { $var1\\r\\n:  100px }"
+      description: "a { $var1\\r\\n:  100px }",
     },
     {
       code:
@@ -463,7 +464,7 @@ testRule({
         "    0 0 0 1px #5b9dd9, 0 0 2px 1px rgba(30, 140, 190, 0.8);",
       description:
         "  $box-shadow:0 0 0 1px #5b9dd9,\\n" +
-        "    0 0 2px 1px rgba(30, 140, 190, 0.8);"
+        "    0 0 2px 1px rgba(30, 140, 190, 0.8);",
     },
     {
       code:
@@ -471,7 +472,7 @@ testRule({
         "  box-shadow: 0 0 0 1px #5b9dd9,\n 0 0 2px 1px rgb(30, 140, 190); }",
       description:
         "a{\n" +
-        "  box-shadow: 0 0 0 1px #5b9dd9,\\n  0 0 2px 1px rgb(30, 140, 190); }"
+        "  box-shadow: 0 0 0 1px #5b9dd9,\\n  0 0 2px 1px rgb(30, 140, 190); }",
     },
     {
       code: `
@@ -481,7 +482,7 @@ testRule({
       );
       `,
       description:
-        "always-multi-line: should allow Sass map using newline after colon"
+        "always-multi-line: should allow Sass map using newline after colon",
     },
     {
       code: `
@@ -492,7 +493,7 @@ testRule({
       );
       `,
       description:
-        "always-multi-line: should allow multiline variable using newline after colon"
+        "always-multi-line: should allow multiline variable using newline after colon",
     },
     {
       code: `
@@ -502,7 +503,7 @@ testRule({
       );
       `,
       description:
-        "always-multi-line: should allow using Sass map without a newline"
+        "always-multi-line: should allow using Sass map without a newline",
     },
     {
       code: `
@@ -513,7 +514,7 @@ testRule({
       );
       `,
       description:
-        "always-multi-line: should allow using multiline variable with parens without a newline"
+        "always-multi-line: should allow using multiline variable with parens without a newline",
     },
     {
       code: `
@@ -529,8 +530,8 @@ testRule({
       );
       `,
       description:
-        "always-multi-line: should allow using a mix of multiline variables"
-    }
+        "always-multi-line: should allow using a mix of multiline variables",
+    },
   ],
 
   reject: [
@@ -543,7 +544,7 @@ testRule({
         "    0 0 2px 1px rgba(30, 140, 190, 0.8);",
       message: messages.expectedAfterMultiLine(),
       line: 1,
-      column: 14
+      column: 14,
     },
     {
       code:
@@ -554,7 +555,7 @@ testRule({
         "    0 0 2px 1px rgba(30, 140, 190, 0.8);",
       message: messages.expectedAfterMultiLine(),
       line: 1,
-      column: 14
-    }
-  ]
+      column: 14,
+    },
+  ],
 });

--- a/src/rules/dollar-variable-colon-newline-after/index.js
+++ b/src/rules/dollar-variable-colon-newline-after/index.js
@@ -5,7 +5,7 @@ import {
   isSingleLineString,
   namespace,
   ruleUrl,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils";
 
 export const ruleName = namespace("dollar-variable-colon-newline-after");
@@ -13,11 +13,11 @@ export const ruleName = namespace("dollar-variable-colon-newline-after");
 export const messages = utils.ruleMessages(ruleName, {
   expectedAfter: () => 'Expected newline after ":"',
   expectedAfterMultiLine: () =>
-    'Expected newline after ":" with a multi-line value'
+    'Expected newline after ":" with a multi-line value',
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(expectation, options, context) {
@@ -29,14 +29,14 @@ export default function rule(expectation, options, context) {
       ruleName,
       {
         actual: expectation,
-        possible: ["always", "always-multi-line"]
+        possible: ["always", "always-multi-line"],
       },
       {
         actual: options,
         possible: {
-          disableFix: isBoolean
+          disableFix: isBoolean,
         },
-        optional: true
+        optional: true,
       }
     );
 
@@ -46,7 +46,7 @@ export default function rule(expectation, options, context) {
 
     const shouldFix = context.fix && (!options || options.disableFix !== true);
 
-    root.walkDecls(decl => {
+    root.walkDecls((decl) => {
       if (!decl.prop || decl.prop[0] !== "$") {
         return;
       }
@@ -84,7 +84,7 @@ export default function rule(expectation, options, context) {
           source: propPlusColon,
           index: indexToCheck,
           lineCheckStr: decl.value,
-          err: m => {
+          err: (m) => {
             if (shouldFix) {
               const nextLinePrefix =
                 expectation === "always"
@@ -106,9 +106,9 @@ export default function rule(expectation, options, context) {
               node: decl,
               index: indexToCheck,
               result,
-              ruleName
+              ruleName,
             });
-          }
+          },
         });
         break;
       }

--- a/src/rules/dollar-variable-colon-space-after/__tests__/index.js
+++ b/src/rules/dollar-variable-colon-space-after/__tests__/index.js
@@ -9,41 +9,41 @@ testRule({
   accept: [
     {
       code: "a { width:10px }",
-      description: "Not an SCSS var, ignored: a { width:10px }"
+      description: "Not an SCSS var, ignored: a { width:10px }",
     },
     {
       code: "a { $var: 10px }",
-      description: "a { $var: 10px }"
+      description: "a { $var: 10px }",
     },
     {
       code: "a { $var : 10px }",
-      description: "a { $var : 10px }"
+      description: "a { $var : 10px }",
     },
     {
       code: "a { $var\n: 10px }",
-      description: "a { $var\n: 10px }"
+      description: "a { $var\n: 10px }",
     },
     {
       code: "a { $var\r\n: 10px }",
-      description: "a { $var\r\n: 10px }"
+      description: "a { $var\r\n: 10px }",
     },
     {
       code: "$var: 10px;",
-      description: "$var: 10px;"
+      description: "$var: 10px;",
     },
     {
       code: "$var : 10px",
-      description: "$var : 10px"
+      description: "$var : 10px",
     },
     {
       code: "$var: url(data:application/font-woff;...);",
-      description: "Data URI: $var: url(data:application/font-woff;...);"
+      description: "Data URI: $var: url(data:application/font-woff;...);",
     },
     {
       code: "@function ($a:10) {}",
       description:
-        "Default in a function definition, ignored: @function ($a: 10)"
-    }
+        "Default in a function definition, ignored: @function ($a: 10)",
+    },
   ],
 
   reject: [
@@ -53,7 +53,7 @@ testRule({
       description: "a { $var :10px; }",
       message: messages.expectedAfter(),
       line: 1,
-      column: 10
+      column: 10,
     },
     {
       code: "a { $var :  10px; }",
@@ -61,7 +61,7 @@ testRule({
       description: "a { $var :  10px; }",
       message: messages.expectedAfter(),
       line: 1,
-      column: 10
+      column: 10,
     },
     {
       code: "a { $var :\t10px; }",
@@ -69,7 +69,7 @@ testRule({
       description: "Tab after: a { $var :\t10px; }",
       message: messages.expectedAfter(),
       line: 1,
-      column: 10
+      column: 10,
     },
     {
       code: "a { $var :\n10px; }",
@@ -77,7 +77,7 @@ testRule({
       description: "Newline after: a { $var :\n10px; }",
       message: messages.expectedAfter(),
       line: 1,
-      column: 10
+      column: 10,
     },
     {
       code: "a { $var :\r\n10px; }",
@@ -85,7 +85,7 @@ testRule({
       description: "Windows newline after: a { $var :\r\n10px; }",
       message: messages.expectedAfter(),
       line: 1,
-      column: 10
+      column: 10,
     },
     {
       code: "a { $var:10px; }",
@@ -93,7 +93,7 @@ testRule({
       description: "a { $var:10px; }",
       message: messages.expectedAfter(),
       line: 1,
-      column: 9
+      column: 9,
     },
     {
       code: "$var :10px;",
@@ -101,7 +101,7 @@ testRule({
       description: "$var :10px;",
       message: messages.expectedAfter(),
       line: 1,
-      column: 6
+      column: 6,
     },
     {
       code: "$var :  10px;",
@@ -109,7 +109,7 @@ testRule({
       description: "$var :  10px;",
       message: messages.expectedAfter(),
       line: 1,
-      column: 6
+      column: 6,
     },
     {
       code: "$var :\t10px;",
@@ -117,7 +117,7 @@ testRule({
       description: "$var :\t10px;",
       message: messages.expectedAfter(),
       line: 1,
-      column: 6
+      column: 6,
     },
     {
       code: "$var :\n10px;",
@@ -125,7 +125,7 @@ testRule({
       description: "$var :\n10px;",
       message: messages.expectedAfter(),
       line: 1,
-      column: 6
+      column: 6,
     },
     {
       code: "$var :\r\n10px;",
@@ -133,7 +133,7 @@ testRule({
       description: "$var :\r\n10px;",
       message: messages.expectedAfter(),
       line: 1,
-      column: 6
+      column: 6,
     },
     {
       code: "$var:10px;",
@@ -141,9 +141,9 @@ testRule({
       description: "$var:10px;",
       message: messages.expectedAfter(),
       line: 1,
-      column: 5
-    }
-  ]
+      column: 5,
+    },
+  ],
 });
 
 testRule({
@@ -155,24 +155,24 @@ testRule({
   accept: [
     {
       code: "a { $var:10px }",
-      description: "a { $var:10px }"
+      description: "a { $var:10px }",
     },
     {
       code: "a { $var :10px }",
-      description: "a { $var :10px }"
+      description: "a { $var :10px }",
     },
     {
       code: "a { $var\n:10px }",
-      description: "a { $var\n:10px }"
+      description: "a { $var\n:10px }",
     },
     {
       code: "a { $var\r\n:10px }",
-      description: "a { $var\r\n:10px }"
+      description: "a { $var\r\n:10px }",
     },
     {
       code: "$map:(key: value)",
-      description: "$map:(key: value)"
-    }
+      description: "$map:(key: value)",
+    },
   ],
 
   reject: [
@@ -182,7 +182,7 @@ testRule({
       description: "a { $var : 10px; }",
       message: messages.rejectedAfter(),
       line: 1,
-      column: 10
+      column: 10,
     },
     {
       code: "a { $var:  10px; }",
@@ -190,7 +190,7 @@ testRule({
       description: "a { $var:  10px; }",
       message: messages.rejectedAfter(),
       line: 1,
-      column: 9
+      column: 9,
     },
     {
       code: "a { $var :\t10px; }",
@@ -198,7 +198,7 @@ testRule({
       description: "a { $var :\t10px; }",
       message: messages.rejectedAfter(),
       line: 1,
-      column: 10
+      column: 10,
     },
     {
       code: "a { $var :\n10px; }",
@@ -206,7 +206,7 @@ testRule({
       description: "a { $var :\n10px; }",
       message: messages.rejectedAfter(),
       line: 1,
-      column: 10
+      column: 10,
     },
     {
       code: "a { $var :\r\n10px; }",
@@ -214,9 +214,9 @@ testRule({
       description: "a { $var :\r\n10px; }",
       message: messages.rejectedAfter(),
       line: 1,
-      column: 10
-    }
-  ]
+      column: 10,
+    },
+  ],
 });
 
 testRule({
@@ -228,24 +228,24 @@ testRule({
   accept: [
     {
       code: "a { $var: 10px }",
-      description: "a { $var: 10px }"
+      description: "a { $var: 10px }",
     },
     {
       code: "$transition: color 1s,\n\twidth 2s;",
-      description: "$transition: color 1s,\n\twidth 2s;"
+      description: "$transition: color 1s,\n\twidth 2s;",
     },
     {
       code: "$transition:color 1s,\n\twidth 2s;",
-      description: "$transition:color 1s,\n\twidth 2s;"
+      description: "$transition:color 1s,\n\twidth 2s;",
     },
     {
       code: "$transition:color 1s,\r\n\twidth 2s;",
-      description: "$transition:color 1s,\r\n\twidth 2s;"
+      description: "$transition:color 1s,\r\n\twidth 2s;",
     },
     {
       code: "a { $transition:\tcolor 1s,\n\twidth 2s; }",
-      description: "a { $transition:\tcolor 1s,\n\twidth 2s; }"
-    }
+      description: "a { $transition:\tcolor 1s,\n\twidth 2s; }",
+    },
   ],
 
   reject: [
@@ -255,7 +255,7 @@ testRule({
       description: "a { $var :10px; }",
       message: messages.expectedAfterSingleLine(),
       line: 1,
-      column: 10
+      column: 10,
     },
     {
       code: "a { $var :  10px; }",
@@ -263,7 +263,7 @@ testRule({
       description: "a { $var :  10px; }",
       message: messages.expectedAfterSingleLine(),
       line: 1,
-      column: 10
+      column: 10,
     },
     {
       code: "a { $var :\t10px; }",
@@ -271,7 +271,7 @@ testRule({
       description: "a { $var :\t10px; }",
       message: messages.expectedAfterSingleLine(),
       line: 1,
-      column: 10
+      column: 10,
     },
     {
       code: "a { $var :\n10px; }",
@@ -279,7 +279,7 @@ testRule({
       description: "a { $var :\n10px; }",
       message: messages.expectedAfterSingleLine(),
       line: 1,
-      column: 10
+      column: 10,
     },
     {
       code: "a { $var :\r\n10px; }",
@@ -287,7 +287,7 @@ testRule({
       description: "a { $var :\r\n10px; }",
       message: messages.expectedAfterSingleLine(),
       line: 1,
-      column: 10
+      column: 10,
     },
     {
       code: "a { $var:10px; }",
@@ -295,9 +295,9 @@ testRule({
       description: "a { $var:10px; }",
       message: messages.expectedAfterSingleLine(),
       line: 1,
-      column: 9
-    }
-  ]
+      column: 9,
+    },
+  ],
 });
 
 testRule({
@@ -309,45 +309,45 @@ testRule({
   accept: [
     {
       code: "a { width:10px }",
-      description: "Not an SCSS var, ignored: a { width:10px }"
+      description: "Not an SCSS var, ignored: a { width:10px }",
     },
     {
       code: "a { $var: 10px }",
-      description: "a { $var: 10px }"
+      description: "a { $var: 10px }",
     },
     {
       code: "a { $var : 10px }",
-      description: "a { $var : 10px }"
+      description: "a { $var : 10px }",
     },
     {
       code: "a { $var\n: 10px }",
-      description: "a { $var\n: 10px }"
+      description: "a { $var\n: 10px }",
     },
     {
       code: "a { $var\r\n: 10px }",
-      description: "a { $var\r\n: 10px }"
+      description: "a { $var\r\n: 10px }",
     },
     {
       code: "$var: 10px;",
-      description: "$var: 10px;"
+      description: "$var: 10px;",
     },
     {
       code: "$var : 10px",
-      description: "$var : 10px"
+      description: "$var : 10px",
     },
     {
       code: "$var: url(data:application/font-woff;...);",
-      description: "Data URI: $var: url(data:application/font-woff;...);"
+      description: "Data URI: $var: url(data:application/font-woff;...);",
     },
     {
       code: "@function ($a:10) {}",
       description:
-        "Default in a function definition, ignored: @function ($a: 10)"
+        "Default in a function definition, ignored: @function ($a: 10)",
     },
     {
       code: "$var:    10px",
-      description: "$var:    10px"
-    }
+      description: "$var:    10px",
+    },
   ],
 
   reject: [
@@ -357,7 +357,7 @@ testRule({
       description: "a { $var :10px; }",
       message: messages.expectedAfterAtLeast(),
       line: 1,
-      column: 10
+      column: 10,
     },
     {
       code: "$var :10px;",
@@ -365,7 +365,7 @@ testRule({
       description: "$var :10px;",
       message: messages.expectedAfterAtLeast(),
       line: 1,
-      column: 6
+      column: 6,
     },
     {
       code: "$var:10px;",
@@ -373,7 +373,7 @@ testRule({
       description: "$var:10px;",
       message: messages.expectedAfterAtLeast(),
       line: 1,
-      column: 5
-    }
-  ]
+      column: 5,
+    },
+  ],
 });

--- a/src/rules/dollar-variable-colon-space-after/index.js
+++ b/src/rules/dollar-variable-colon-space-after/index.js
@@ -3,7 +3,7 @@ import {
   namespace,
   isSingleLineString,
   ruleUrl,
-  whitespaceChecker
+  whitespaceChecker,
 } from "../../utils";
 import { utils } from "stylelint";
 
@@ -14,11 +14,11 @@ export const messages = utils.ruleMessages(ruleName, {
   rejectedAfter: () => 'Unexpected whitespace after ":"',
   expectedAfterSingleLine: () =>
     'Expected single space after ":" with a single-line value',
-  expectedAfterAtLeast: () => 'Expected at least one space after ":"'
+  expectedAfterAtLeast: () => 'Expected at least one space after ":"',
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(expectation, _, context) {
@@ -27,7 +27,7 @@ export default function rule(expectation, _, context) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: expectation,
-      possible: ["always", "never", "always-single-line", "at-least-one-space"]
+      possible: ["always", "never", "always-single-line", "at-least-one-space"],
     });
 
     if (!validOptions) {
@@ -41,7 +41,7 @@ export default function rule(expectation, _, context) {
       checkedRuleName: ruleName,
       position: "after",
       expectation,
-      context
+      context,
     });
   };
 }
@@ -57,9 +57,9 @@ export function variableColonSpaceChecker({
   checkedRuleName,
   position,
   expectation,
-  context
+  context,
 }) {
-  root.walkDecls(decl => {
+  root.walkDecls((decl) => {
     if (decl.prop === undefined || decl.prop[0] !== "$") {
       return;
     }
@@ -101,15 +101,15 @@ export function variableColonSpaceChecker({
         source: propPlusColon,
         index: i,
         lineCheckStr: decl.value,
-        err: m => {
+        err: (m) => {
           utils.report({
             message: m,
             node: decl,
             index: i,
             result,
-            ruleName: checkedRuleName
+            ruleName: checkedRuleName,
           });
-        }
+        },
       });
       break;
     }

--- a/src/rules/dollar-variable-colon-space-before/__tests__/index.js
+++ b/src/rules/dollar-variable-colon-space-before/__tests__/index.js
@@ -9,33 +9,33 @@ testRule({
   accept: [
     {
       code: "a { $var1 :200px }",
-      description: "a { $var1 :200px }"
+      description: "a { $var1 :200px }",
     },
     {
       code: "a { $var1 : 200px }",
-      description: "a { $var1 : 200px }"
+      description: "a { $var1 : 200px }",
     },
     {
       code: "a { $var1 :\n200px }",
-      description: "a { $var1 :\\n200px }"
+      description: "a { $var1 :\\n200px }",
     },
     {
       code: "a { $var1 :\r\n200px }",
-      description: "a { $var1 :\\r\\n200px }"
+      description: "a { $var1 :\\r\\n200px }",
     },
     {
       code: "a { width: 10px; }",
-      description: "Not a SCSS var, ignoring: width: 10px."
+      description: "Not a SCSS var, ignoring: width: 10px.",
     },
     {
       code: "$background : url(data:application/font-woff;...);",
-      description: "$background : url(data:application/font-woff;...);"
+      description: "$background : url(data:application/font-woff;...);",
     },
     {
       code: "@function ($a:10) {}",
       description:
-        "Default in a function definition, ignored: @function ($a: 10)"
-    }
+        "Default in a function definition, ignored: @function ($a: 10)",
+    },
   ],
 
   reject: [
@@ -45,7 +45,7 @@ testRule({
       description: "a { $var1: 200px; }",
       message: messages.expectedBefore(),
       line: 1,
-      column: 10
+      column: 10,
     },
     {
       code: "a { $var1  : 200px; }",
@@ -53,7 +53,7 @@ testRule({
       description: "a { $var1  : 200px; }",
       message: messages.expectedBefore(),
       line: 1,
-      column: 12
+      column: 12,
     },
     {
       code: "a { $var1\t: 200px; }",
@@ -61,7 +61,7 @@ testRule({
       description: "Tab before: a { $var1\\t: 200px; }",
       message: messages.expectedBefore(),
       line: 1,
-      column: 11
+      column: 11,
     },
     {
       code: "a { $var1\n: 200px; }",
@@ -69,7 +69,7 @@ testRule({
       description: "Newline before: a { $var1\\n: 200px; }",
       message: messages.expectedBefore(),
       line: 2,
-      column: 1
+      column: 1,
     },
     {
       code: "a { $var1\r\n: 200px; }",
@@ -77,9 +77,9 @@ testRule({
       description: "CRLF before: a { $var1\\r\\n: 200px; }",
       message: messages.expectedBefore(),
       line: 2,
-      column: 1
-    }
-  ]
+      column: 1,
+    },
+  ],
 });
 
 testRule({
@@ -91,24 +91,24 @@ testRule({
   accept: [
     {
       code: "a { $var1:200px }",
-      description: "a { $var1:200px }"
+      description: "a { $var1:200px }",
     },
     {
       code: "a { $var1: 200px }",
-      description: "a { $var1: 200px }"
+      description: "a { $var1: 200px }",
     },
     {
       code: "a { $var1:\n200px }",
-      description: "a { $var1:\\n200px }"
+      description: "a { $var1:\\n200px }",
     },
     {
       code: "a { $var1:\r\n200px }",
-      description: "a { $var1:\\r\\n200px }"
+      description: "a { $var1:\\r\\n200px }",
     },
     {
       code: "a { width : 10px; }",
-      description: "Not a SCSS var, ignoring: width : 10px;"
-    }
+      description: "Not a SCSS var, ignoring: width : 10px;",
+    },
   ],
 
   reject: [
@@ -118,7 +118,7 @@ testRule({
       description: "a { $var1 : 200px; }",
       message: messages.rejectedBefore(),
       line: 1,
-      column: 11
+      column: 11,
     },
     {
       code: "a { $var1  : 200px; }",
@@ -126,7 +126,7 @@ testRule({
       description: "a { $var1  : 200px; }",
       message: messages.rejectedBefore(),
       line: 1,
-      column: 12
+      column: 12,
     },
     {
       code: "a { $var1\t: 200px; }",
@@ -134,7 +134,7 @@ testRule({
       description: "a { $var1\\t: 200px; }",
       message: messages.rejectedBefore(),
       line: 1,
-      column: 11
+      column: 11,
     },
     {
       code: "a { $var1\n: 200px; }",
@@ -142,7 +142,7 @@ testRule({
       description: "a { $var1\\n: 200px; }",
       message: messages.rejectedBefore(),
       line: 2,
-      column: 1
+      column: 1,
     },
     {
       code: "a { $var1\r\n: 200px; }",
@@ -150,7 +150,7 @@ testRule({
       description: "a { $var1\\r\\n: 200px; }",
       message: messages.rejectedBefore(),
       line: 2,
-      column: 1
-    }
-  ]
+      column: 1,
+    },
+  ],
 });

--- a/src/rules/dollar-variable-colon-space-before/index.js
+++ b/src/rules/dollar-variable-colon-space-before/index.js
@@ -6,11 +6,11 @@ export const ruleName = namespace("dollar-variable-colon-space-before");
 
 export const messages = utils.ruleMessages(ruleName, {
   expectedBefore: () => 'Expected single space before ":"',
-  rejectedBefore: () => 'Unexpected whitespace before ":"'
+  rejectedBefore: () => 'Unexpected whitespace before ":"',
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(expectation, _, context) {
@@ -19,7 +19,7 @@ export default function rule(expectation, _, context) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: expectation,
-      possible: ["always", "never"]
+      possible: ["always", "never"],
     });
 
     if (!validOptions) {
@@ -33,7 +33,7 @@ export default function rule(expectation, _, context) {
       checkedRuleName: ruleName,
       position: "before",
       expectation,
-      context
+      context,
     });
   };
 }

--- a/src/rules/dollar-variable-default/__tests__/index.js
+++ b/src/rules/dollar-variable-default/__tests__/index.js
@@ -8,20 +8,20 @@ testRule({
   accept: [
     {
       code: "a { color: blue }",
-      description: "Basic style definition"
+      description: "Basic style definition",
     },
     {
       code: "$var: 10px !default",
-      description: "Global variable with !default"
+      description: "Global variable with !default",
     },
     {
       code: "a { $var: 10px !default }",
-      description: "Local variable with !default"
+      description: "Local variable with !default",
     },
     {
       code: ".class { a { $var: 10px !default } }",
-      description: "Nested local variable with !default"
-    }
+      description: "Nested local variable with !default",
+    },
   ],
 
   reject: [
@@ -30,7 +30,7 @@ testRule({
       message: messages.expected("$var"),
       description: "Global variable without !default",
       line: 1,
-      column: 1
+      column: 1,
     },
     {
       code: `
@@ -42,7 +42,7 @@ testRule({
       message: messages.expected("$local-var"),
       description: "Local variable without !default",
       line: 4,
-      column: 11
+      column: 11,
     },
     {
       code: `
@@ -56,9 +56,9 @@ testRule({
       message: messages.expected("$nested-var"),
       description: "Nested local variable without !default",
       line: 5,
-      column: 13
-    }
-  ]
+      column: 13,
+    },
+  ],
 });
 
 // "ignore" options
@@ -70,28 +70,28 @@ testRule({
   accept: [
     {
       code: "a { color: blue }",
-      description: "Basic style definition (ignoring local variables)"
+      description: "Basic style definition (ignoring local variables)",
     },
     {
       code: "$var: 10px !default",
-      description: "Global variable with !default (ignoring local variables)"
+      description: "Global variable with !default (ignoring local variables)",
     },
     {
       code: "a { $var: 10px !default }",
-      description: "Ignore local variable with !default"
+      description: "Ignore local variable with !default",
     },
     {
       code: ".class { a { $var: 10px !default } }",
-      description: "Ignore nested local variable with !default"
+      description: "Ignore nested local variable with !default",
     },
     {
       code: "a { $var: 10px }",
-      description: "Ignore local variable without !default"
+      description: "Ignore local variable without !default",
     },
     {
       code: ".class { a { $var: 10px } }",
-      description: "Ignore nested local variable without !default"
-    }
+      description: "Ignore nested local variable without !default",
+    },
   ],
 
   reject: [
@@ -101,7 +101,7 @@ testRule({
       description:
         "Ignore local variable, fail global variable without !default",
       line: 1,
-      column: 1
-    }
-  ]
+      column: 1,
+    },
+  ],
 });

--- a/src/rules/dollar-variable-default/index.js
+++ b/src/rules/dollar-variable-default/index.js
@@ -4,11 +4,11 @@ import { namespace, optionsHaveIgnored, ruleUrl } from "../../utils";
 export const ruleName = namespace("dollar-variable-default");
 
 export const messages = utils.ruleMessages(ruleName, {
-  expected: variable => `Expected !default flag for "${variable}"`
+  expected: (variable) => `Expected !default flag for "${variable}"`,
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(primaryOption, secondaryOptions) {
@@ -17,14 +17,14 @@ export default function rule(primaryOption, secondaryOptions) {
       result,
       ruleName,
       {
-        actual: primaryOption
+        actual: primaryOption,
       },
       {
         actual: secondaryOptions,
         possible: {
-          ignore: ["local"]
+          ignore: ["local"],
         },
-        optional: true
+        optional: true,
       }
     );
 
@@ -32,7 +32,7 @@ export default function rule(primaryOption, secondaryOptions) {
       return;
     }
 
-    root.walkDecls(decl => {
+    root.walkDecls((decl) => {
       // not variable
       if (decl.prop[0] !== "$") {
         return;
@@ -54,7 +54,7 @@ export default function rule(primaryOption, secondaryOptions) {
         message: messages.expected(decl.prop),
         node: decl,
         result,
-        ruleName
+        ruleName,
       });
     });
   };

--- a/src/rules/dollar-variable-empty-line-after/__tests__/index.js
+++ b/src/rules/dollar-variable-empty-line-after/__tests__/index.js
@@ -15,7 +15,7 @@ testRule({
       $var1: 100px;
 
     }`,
-      description: "always. $var inside a rule, emptyline after."
+      description: "always. $var inside a rule, emptyline after.",
     },
     {
       code: `a {
@@ -24,11 +24,11 @@ testRule({
       $var1: 100px;
 
     }`,
-      description: "always. Two $var-s inside a rule, emptyline after both."
+      description: "always. Two $var-s inside a rule, emptyline after both.",
     },
     {
       code: "$var1: 100px;",
-      description: "always. $var in root, no emptyline after."
+      description: "always. $var in root, no emptyline after.",
     },
     {
       code: `
@@ -37,24 +37,24 @@ testRule({
 
       @import '1.css';
     `,
-      description: "always. $var in root, not the last, multiple newlines."
+      description: "always. $var in root, not the last, multiple newlines.",
     },
     {
       code: "a { $var1: 100px;\n\n}",
-      description: "always. Unix newline"
+      description: "always. Unix newline",
     },
     {
       code: "a { $var1: 100px;\r\n\r\n}",
-      description: "always. Windows newline"
+      description: "always. Windows newline",
     },
     {
       code: "a { $var1: 100px;\n\r\n}",
-      description: "always. Mixed newline"
+      description: "always. Mixed newline",
     },
     {
       code: "a { width: 100px; }",
-      description: "always. Not a $-variable"
-    }
+      description: "always. Not a $-variable",
+    },
   ],
 
   reject: [
@@ -69,7 +69,7 @@ testRule({
       description: "always. $var inside a rule, no emptyline after.",
       message: messages.expected,
       line: 2,
-      column: 7
+      column: 7,
     },
     {
       code: `
@@ -87,9 +87,9 @@ testRule({
         "always. Two $var-s at the root start, no empty line between them.",
       message: messages.expected,
       line: 2,
-      column: 7
-    }
-  ]
+      column: 7,
+    },
+  ],
 });
 
 // never
@@ -106,22 +106,22 @@ testRule({
       code: `a {
     $var1: 100px;
   }`,
-      description: "never. $var inside a rule, no emptyline after."
+      description: "never. $var inside a rule, no emptyline after.",
     },
     {
       code: `
     $var1: 100px;
 
   `,
-      description: "never. $var in root, the last, has newline."
+      description: "never. $var in root, the last, has newline.",
     },
     {
       code: `a {
     width: 100px;
 
   }`,
-      description: "never. Not a $-variable"
-    }
+      description: "never. Not a $-variable",
+    },
   ],
 
   reject: [
@@ -136,7 +136,7 @@ testRule({
       description: "never. $var inside a rule, emptyline after.",
       message: messages.rejected,
       line: 2,
-      column: 5
+      column: 5,
     },
     {
       code: `
@@ -151,7 +151,7 @@ testRule({
       description: "never. $var in root, before comment, has empty line.",
       message: messages.rejected,
       line: 2,
-      column: 5
+      column: 5,
     },
     {
       code: "a { $var1: 100px;\n\n}",
@@ -159,7 +159,7 @@ testRule({
       description: "never. Unix newline",
       message: messages.rejected,
       line: 1,
-      column: 5
+      column: 5,
     },
     {
       code: "a { $var1: 100px;\r\n\r\n}",
@@ -167,7 +167,7 @@ testRule({
       description: "never. Windows newline",
       message: messages.rejected,
       line: 1,
-      column: 5
+      column: 5,
     },
     {
       code: "a { $var1: 100px;\n\r\n}",
@@ -175,9 +175,9 @@ testRule({
       description: "never. Mixed newline",
       message: messages.rejected,
       line: 1,
-      column: 5
-    }
-  ]
+      column: 5,
+    },
+  ],
 });
 
 // Ignore: after-comment
@@ -196,7 +196,7 @@ testRule({
     // comment
   `,
       description:
-        "always, { ignore: before-comment }. $var before //-comment, no empty line."
+        "always, { ignore: before-comment }. $var before //-comment, no empty line.",
     },
     {
       code: `
@@ -205,7 +205,7 @@ testRule({
     // comment
   `,
       description:
-        "always, { ignore: before-comment }. $var before //-comment, has empty line."
+        "always, { ignore: before-comment }. $var before //-comment, has empty line.",
     },
     {
       code: `
@@ -213,7 +213,7 @@ testRule({
     /* comment */
   `,
       description:
-        "always, { ignore: before-comment }. $var before CSS-comment, no empty line."
+        "always, { ignore: before-comment }. $var before CSS-comment, no empty line.",
     },
     {
       code: `
@@ -221,8 +221,8 @@ testRule({
     /* comment */
   `,
       description:
-        "always, { ignore: before-comment }. $var before CSS-comment, has empty line."
-    }
+        "always, { ignore: before-comment }. $var before CSS-comment, has empty line.",
+    },
   ],
 
   reject: [
@@ -240,9 +240,9 @@ testRule({
         "always, { ignore: before-comment }. No comment directly after $var, no empty line.",
       message: messages.expected,
       line: 2,
-      column: 5
-    }
-  ]
+      column: 5,
+    },
+  ],
 });
 
 testRule({
@@ -258,7 +258,7 @@ testRule({
     // comment
   `,
       description:
-        "never, { ignore: before-comment }. $var before //-comment, no empty line."
+        "never, { ignore: before-comment }. $var before //-comment, no empty line.",
     },
     {
       code: `
@@ -267,7 +267,7 @@ testRule({
     // comment
   `,
       description:
-        "never, { ignore: before-comment }. $var before //-comment, has empty line."
+        "never, { ignore: before-comment }. $var before //-comment, has empty line.",
     },
     {
       code: `
@@ -275,7 +275,7 @@ testRule({
     /* comment */
   `,
       description:
-        "never, { ignore: before-comment }. $var before CSS-comment, no empty line."
+        "never, { ignore: before-comment }. $var before CSS-comment, no empty line.",
     },
     {
       code: `
@@ -283,8 +283,8 @@ testRule({
     /* comment */
   `,
       description:
-        "never, { ignore: before-comment }. $var before CSS-comment, has empty line."
-    }
+        "never, { ignore: before-comment }. $var before CSS-comment, has empty line.",
+    },
   ],
 
   reject: [
@@ -302,9 +302,9 @@ testRule({
         "never, { ignore: before-comment }. No comment directly before $var, has empty line.",
       message: messages.rejected,
       line: 2,
-      column: 5
-    }
-  ]
+      column: 5,
+    },
+  ],
 });
 
 // Ignore: single-line-block
@@ -319,20 +319,20 @@ testRule({
     {
       code: "a { $var1: 100px; }",
       description:
-        "always, { ignore: inside-single-line-block }. $var inside single-line ruleset, alone."
+        "always, { ignore: inside-single-line-block }. $var inside single-line ruleset, alone.",
     },
     {
       code: `
     a { $var1: 100px; }
   `,
       description:
-        "always, { ignore: inside-single-line-block }. $var inside single-line ruleset with newlines around, alone."
+        "always, { ignore: inside-single-line-block }. $var inside single-line ruleset with newlines around, alone.",
     },
     {
       code: "a { width: 10px; $var1: 100px; color: red; }",
       description:
-        "always, { ignore: inside-single-line-block }. $var inside single-line ruleset, has neighbours."
-    }
+        "always, { ignore: inside-single-line-block }. $var inside single-line ruleset, has neighbours.",
+    },
   ],
 
   reject: [
@@ -344,9 +344,9 @@ testRule({
         "always, { ignore: inside-single-line-block }. Not a single line ruleset, $var and other decl on the same line.",
       message: messages.expected,
       line: 2,
-      column: 15
-    }
-  ]
+      column: 15,
+    },
+  ],
 });
 
 // Except: first-nested
@@ -365,7 +365,7 @@ testRule({
     $var1: 100px;
   }`,
       description:
-        "always, { except: last-nested }. $var is the last inside ruleset, no empty line."
+        "always, { except: last-nested }. $var is the last inside ruleset, no empty line.",
     },
     {
       code: `@mixin name {
@@ -373,8 +373,8 @@ testRule({
     $var1: 100px;
   }`,
       description:
-        "always, { except: last-nested }. $var is the last inside mixin, no empty line."
-    }
+        "always, { except: last-nested }. $var is the last inside mixin, no empty line.",
+    },
   ],
 
   reject: [
@@ -391,7 +391,7 @@ width: 1;
         "always, { except: last-nested }. $var is not the last in a ruleset, no empty line.",
       message: messages.expected,
       line: 2,
-      column: 5
+      column: 5,
     },
     {
       code: `a {
@@ -405,9 +405,9 @@ width: 1;
         "always, { except: last-nested }. $var is the last in a ruleset, has empty line.",
       message: messages.expected,
       line: 2,
-      column: 5
-    }
-  ]
+      column: 5,
+    },
+  ],
 });
 
 testRule({
@@ -424,7 +424,7 @@ testRule({
 
   }`,
       description:
-        "never, { except: last-nested }. $var is the last inside ruleset, has empty line."
+        "never, { except: last-nested }. $var is the last inside ruleset, has empty line.",
     },
     {
       code: `a {
@@ -432,8 +432,8 @@ testRule({
     color: red;
   }`,
       description:
-        "never, { except: last-nested }. $var isn't the last inside ruleset, no empty line."
-    }
+        "never, { except: last-nested }. $var isn't the last inside ruleset, no empty line.",
+    },
   ],
 
   reject: [
@@ -449,7 +449,7 @@ testRule({
         "never, { except: last-nested }. $var is the last in a ruleset, no empty line.",
       message: messages.rejected,
       line: 2,
-      column: 5
+      column: 5,
     },
     {
       code: `a {
@@ -465,9 +465,9 @@ testRule({
         "never, { except: last-nested }. $var isn't the last in a ruleset, has empty line.",
       message: messages.rejected,
       line: 2,
-      column: 5
-    }
-  ]
+      column: 5,
+    },
+  ],
 });
 
 // Except: first-nested with `disableFix: true`
@@ -479,8 +479,8 @@ testRule({
     "always",
     {
       except: "last-nested",
-      disableFix: true
-    }
+      disableFix: true,
+    },
   ],
   customSyntax: "postcss-scss",
   unfixable: true,
@@ -492,7 +492,7 @@ testRule({
     $var1: 100px;
   }`,
       description:
-        "always, { except: last-nested }. $var is the last inside ruleset, no empty line."
+        "always, { except: last-nested }. $var is the last inside ruleset, no empty line.",
     },
     {
       code: `@mixin name {
@@ -500,8 +500,8 @@ testRule({
     $var1: 100px;
   }`,
       description:
-        "always, { except: last-nested }. $var is the last inside mixin, no empty line."
-    }
+        "always, { except: last-nested }. $var is the last inside mixin, no empty line.",
+    },
   ],
 
   reject: [
@@ -513,7 +513,7 @@ testRule({
         "always, { except: last-nested }. $var is not the last in a ruleset, no empty line.",
       message: messages.expected,
       line: 2,
-      column: 5
+      column: 5,
     },
     {
       code: `a {
@@ -524,9 +524,9 @@ testRule({
         "always, { except: last-nested }. $var is the last in a ruleset, has empty line.",
       message: messages.expected,
       line: 2,
-      column: 5
-    }
-  ]
+      column: 5,
+    },
+  ],
 });
 
 // Except: after-comment
@@ -545,12 +545,12 @@ testRule({
     // comment
   `,
       description:
-        "always, { except: before-comment }. $var before //-comment, no empty line."
+        "always, { except: before-comment }. $var before //-comment, no empty line.",
     },
     {
       code: "$var1: 100px; /* comment */",
       description:
-        "always, { except: before-comment }. $var before CSS-comment, no empty line."
+        "always, { except: before-comment }. $var before CSS-comment, no empty line.",
     },
     {
       code: `
@@ -559,8 +559,8 @@ testRule({
     @import 'a.css';
   `,
       description:
-        "always, { except: before-comment }. $var is not before CSS-comment, has empty line."
-    }
+        "always, { except: before-comment }. $var is not before CSS-comment, has empty line.",
+    },
   ],
 
   reject: [
@@ -578,7 +578,7 @@ testRule({
         "always, { except: before-comment }. $var before //-comment, has empty line.",
       message: messages.expected,
       line: 2,
-      column: 5
+      column: 5,
     },
     {
       code: `
@@ -594,7 +594,7 @@ testRule({
         "always, { except: before-comment }. $var before CSS-comment, has empty line.",
       message: messages.expected,
       line: 2,
-      column: 5
+      column: 5,
     },
     {
       code: `a {
@@ -610,9 +610,9 @@ testRule({
         "always, { except: before-comment }. No comment after $var, has empty line.",
       message: messages.expected,
       line: 2,
-      column: 5
-    }
-  ]
+      column: 5,
+    },
+  ],
 });
 
 testRule({
@@ -629,7 +629,7 @@ testRule({
     // comment
   `,
       description:
-        "never, { except: before-comment }. $var before //-comment, has empty line."
+        "never, { except: before-comment }. $var before //-comment, has empty line.",
     },
     {
       code: `
@@ -638,7 +638,7 @@ testRule({
     /* comment */
   `,
       description:
-        "never, { except: before-comment }. $var before CSS-comment, has empty line."
+        "never, { except: before-comment }. $var before CSS-comment, has empty line.",
     },
     {
       code: `
@@ -646,8 +646,8 @@ testRule({
     @import 'a.css';
   `,
       description:
-        "never, { except: before-comment }. $var is not before CSS-comment, no empty line."
-    }
+        "never, { except: before-comment }. $var is not before CSS-comment, no empty line.",
+    },
   ],
 
   reject: [
@@ -665,7 +665,7 @@ testRule({
         "never, { except: before-comment }. $var before //-comment, no empty line.",
       message: messages.rejected,
       line: 2,
-      column: 5
+      column: 5,
     },
     {
       code: `
@@ -681,7 +681,7 @@ testRule({
         "never, { except: before-comment }. $var before CSS-comment, no empty line.",
       message: messages.rejected,
       line: 2,
-      column: 5
+      column: 5,
     },
     {
       code: `a {
@@ -697,9 +697,9 @@ testRule({
         "never, { except: before-comment }. No comment before $var, has empty line.",
       message: messages.rejected,
       line: 2,
-      column: 5
-    }
-  ]
+      column: 5,
+    },
+  ],
 });
 
 // Except: after-dollar-variable
@@ -718,7 +718,7 @@ testRule({
 
   }`,
       description:
-        "always, { except: before-dollar-variable }. Just a single var with empty line."
+        "always, { except: before-dollar-variable }. Just a single var with empty line.",
     },
     {
       code: `
@@ -727,7 +727,7 @@ testRule({
 
   `,
       description:
-        "always, { except: before-dollar-variable }. $var2 has empty line, $var1 before it doesn't."
+        "always, { except: before-dollar-variable }. $var2 has empty line, $var1 before it doesn't.",
     },
     {
       code: `
@@ -737,9 +737,9 @@ testRule({
 
   `,
       description:
-        "always, { except: before-dollar-variable }. Three $var-s, last with empty line, others without."
-    }
-  ]
+        "always, { except: before-dollar-variable }. Three $var-s, last with empty line, others without.",
+    },
+  ],
 });
 
 testRule({
@@ -755,7 +755,7 @@ testRule({
     $var2: 1;
   `,
       description:
-        "never, { except: before-dollar-variable }. $var2 doesn't have empty line, $var2 before it does."
+        "never, { except: before-dollar-variable }. $var2 doesn't have empty line, $var2 before it does.",
     },
     {
       code: `$var1: 1;
@@ -765,8 +765,8 @@ testRule({
     $var3: 1;
   `,
       description:
-        "never, { except: before-dollar-variable }. Three $var-s, last w/o empty line, others with."
-    }
+        "never, { except: before-dollar-variable }. Three $var-s, last w/o empty line, others with.",
+    },
   ],
 
   reject: [
@@ -784,9 +784,9 @@ testRule({
         "never, { except: before-dollar-variable }. $var1 and $var2 have no empty lines.",
       message: messages.rejected,
       line: 2,
-      column: 5
-    }
-  ]
+      column: 5,
+    },
+  ],
 });
 
 // Combining secondary options
@@ -796,7 +796,7 @@ testRule({
   ruleName,
   config: [
     "always",
-    { except: ["last-nested", "before-comment", "before-dollar-variable"] }
+    { except: ["last-nested", "before-comment", "before-dollar-variable"] },
   ],
   customSyntax: "postcss-scss",
 
@@ -822,7 +822,7 @@ testRule({
     }
   `,
       description:
-        "always, { except: [last-nested, before-comment, before-dollar-variable] }."
-    }
-  ]
+        "always, { except: [last-nested, before-comment, before-dollar-variable] }.",
+    },
+  ],
 });

--- a/src/rules/dollar-variable-empty-line-after/index.js
+++ b/src/rules/dollar-variable-empty-line-after/index.js
@@ -5,7 +5,7 @@ import {
   optionsHaveException,
   optionsHaveIgnored,
   blockString,
-  ruleUrl
+  ruleUrl,
 } from "../../utils";
 import { utils } from "stylelint";
 import { isBoolean } from "lodash";
@@ -14,11 +14,11 @@ export const ruleName = namespace("dollar-variable-empty-line-after");
 
 export const messages = utils.ruleMessages(ruleName, {
   expected: "Expected an empty line after $-variable",
-  rejected: "Unexpected empty line after $-variable"
+  rejected: "Unexpected empty line after $-variable",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(expectation, options, context) {
@@ -28,16 +28,16 @@ export default function rule(expectation, options, context) {
       ruleName,
       {
         actual: expectation,
-        possible: ["always", "never"]
+        possible: ["always", "never"],
       },
       {
         actual: options,
         possible: {
           except: ["last-nested", "before-comment", "before-dollar-variable"],
           ignore: ["before-comment", "inside-single-line-block"],
-          disableFix: isBoolean
+          disableFix: isBoolean,
         },
-        optional: true
+        optional: true,
       }
     );
 
@@ -59,10 +59,10 @@ export default function rule(expectation, options, context) {
       );
     };
 
-    const hasNewline = str => str.indexOf(context.newline) > -1;
-    const isDollarVar = node => node.prop && node.prop[0] === "$";
+    const hasNewline = (str) => str.indexOf(context.newline) > -1;
+    const isDollarVar = (node) => node.prop && node.prop[0] === "$";
 
-    root.walkDecls(decl => {
+    root.walkDecls((decl) => {
       let expectEmptyLineAfter = expectation === "always";
       const exceptLastNested = optionsHaveException(options, "last-nested");
       const exceptBeforeComment = optionsHaveException(
@@ -238,7 +238,7 @@ export default function rule(expectation, options, context) {
         message: expectEmptyLineAfter ? messages.expected : messages.rejected,
         node: decl,
         result,
-        ruleName
+        ruleName,
       });
     });
   };

--- a/src/rules/dollar-variable-empty-line-before/__tests__/index.js
+++ b/src/rules/dollar-variable-empty-line-before/__tests__/index.js
@@ -15,11 +15,11 @@ testRule({
 
       $var1: 100px;
     }`,
-      description: "always. $var inside a rule, emptyline before."
+      description: "always. $var inside a rule, emptyline before.",
     },
     {
       code: "$var1: 100px;",
-      description: "always. $var in root, inside a rule, no emptyline before."
+      description: "always. $var in root, inside a rule, no emptyline before.",
     },
     {
       code: `
@@ -28,24 +28,24 @@ testRule({
 
       $var1: 100px;
     `,
-      description: "always. $var in root, not the 1st, multiple newlines."
+      description: "always. $var in root, not the 1st, multiple newlines.",
     },
     {
       code: "a {\n\n$var1: 100px; }",
-      description: "always. Unix newline"
+      description: "always. Unix newline",
     },
     {
       code: "a {\r\n\r\n$var1: 100px; }",
-      description: "always. Windows newline"
+      description: "always. Windows newline",
     },
     {
       code: "a {\n\r\n$var1: 100px; }",
-      description: "always. Mixed newline"
+      description: "always. Mixed newline",
     },
     {
       code: "a { width: 100px; }",
-      description: "always. Not a $-variable"
-    }
+      description: "always. Not a $-variable",
+    },
   ],
 
   reject: [
@@ -60,7 +60,7 @@ testRule({
       description: "always. $var inside a rule, no emptyline before.",
       message: messages.expected,
       line: 2,
-      column: 7
+      column: 7,
     },
     {
       code: `
@@ -76,9 +76,9 @@ testRule({
         "always. Two $var-s at the root start, no empty line between them.",
       message: messages.expected,
       line: 3,
-      column: 7
-    }
-  ]
+      column: 7,
+    },
+  ],
 });
 
 // never
@@ -95,22 +95,22 @@ testRule({
       code: `a {
       $var1: 100px;
     }`,
-      description: "never. $var inside a rule, no emptyline before."
+      description: "never. $var inside a rule, no emptyline before.",
     },
     {
       code: `
 
       $var1: 100px;
     `,
-      description: "never. $var in root, the 1st, has newline."
+      description: "never. $var in root, the 1st, has newline.",
     },
     {
       code: `a {
 
       width: 100px;
     }`,
-      description: "never. Not a $-variable"
-    }
+      description: "never. Not a $-variable",
+    },
   ],
 
   reject: [
@@ -125,7 +125,7 @@ testRule({
       description: "never. $var inside a rule, emptyline before.",
       message: messages.rejected,
       line: 3,
-      column: 7
+      column: 7,
     },
     {
       code: `
@@ -140,7 +140,7 @@ testRule({
       description: "never. $var in root, after comment, has empty line.",
       message: messages.rejected,
       line: 4,
-      column: 7
+      column: 7,
     },
     {
       code: "a {\n\n$var1: 100px; }",
@@ -148,7 +148,7 @@ testRule({
       description: "never. Unix newline",
       message: messages.rejected,
       line: 3,
-      column: 1
+      column: 1,
     },
     {
       code: "a {\r\n\r\n$var1: 100px; }",
@@ -156,7 +156,7 @@ testRule({
       description: "never. Windows newline",
       message: messages.rejected,
       line: 3,
-      column: 1
+      column: 1,
     },
     {
       code: "a {\n\r\n$var1: 100px; }",
@@ -164,9 +164,9 @@ testRule({
       description: "never. Mixed newline",
       message: messages.rejected,
       line: 3,
-      column: 1
-    }
-  ]
+      column: 1,
+    },
+  ],
 });
 
 // Ignore: after-comment
@@ -185,7 +185,7 @@ testRule({
       $var1: 100px;
     `,
       description:
-        "always, { ignore: after-comment }. $var after //-comment, no empty line."
+        "always, { ignore: after-comment }. $var after //-comment, no empty line.",
     },
     {
       code: `
@@ -194,7 +194,7 @@ testRule({
       $var1: 100px;
     `,
       description:
-        "always, { ignore: after-comment }. $var after //-comment, has empty line."
+        "always, { ignore: after-comment }. $var after //-comment, has empty line.",
     },
     {
       code: `
@@ -202,7 +202,7 @@ testRule({
       $var1: 100px;
     `,
       description:
-        "always, { ignore: after-comment }. $var after CSS-comment, no empty line."
+        "always, { ignore: after-comment }. $var after CSS-comment, no empty line.",
     },
     {
       code: `
@@ -210,8 +210,8 @@ testRule({
       $var1: 100px;
     `,
       description:
-        "always, { ignore: after-comment }. $var after CSS-comment, has empty line."
-    }
+        "always, { ignore: after-comment }. $var after CSS-comment, has empty line.",
+    },
   ],
 
   reject: [
@@ -229,9 +229,9 @@ testRule({
         "always, { ignore: after-comment }. No comment directly before $var, no empty line.",
       message: messages.expected,
       line: 3,
-      column: 7
-    }
-  ]
+      column: 7,
+    },
+  ],
 });
 
 testRule({
@@ -247,7 +247,7 @@ testRule({
       $var1: 100px;
     `,
       description:
-        "never, { ignore: after-comment }. $var after //-comment, no empty line."
+        "never, { ignore: after-comment }. $var after //-comment, no empty line.",
     },
     {
       code: `
@@ -256,7 +256,7 @@ testRule({
       $var1: 100px;
     `,
       description:
-        "never, { ignore: after-comment }. $var after //-comment, has empty line."
+        "never, { ignore: after-comment }. $var after //-comment, has empty line.",
     },
     {
       code: `
@@ -264,7 +264,7 @@ testRule({
       $var1: 100px;
     `,
       description:
-        "never, { ignore: after-comment }. $var after CSS-comment, no empty line."
+        "never, { ignore: after-comment }. $var after CSS-comment, no empty line.",
     },
     {
       code: `
@@ -272,8 +272,8 @@ testRule({
       $var1: 100px;
     `,
       description:
-        "never, { ignore: after-comment }. $var after CSS-comment, has empty line."
-    }
+        "never, { ignore: after-comment }. $var after CSS-comment, has empty line.",
+    },
   ],
 
   reject: [
@@ -291,9 +291,9 @@ testRule({
         "never, { ignore: after-comment }. No comment directly before $var, has empty line.",
       message: messages.rejected,
       line: 4,
-      column: 7
-    }
-  ]
+      column: 7,
+    },
+  ],
 });
 
 // Ignore: single-line-block
@@ -308,20 +308,20 @@ testRule({
     {
       code: "a { $var1: 100px; }",
       description:
-        "always, { ignore: inside-single-line-block }. $var inside single-line ruleset, alone."
+        "always, { ignore: inside-single-line-block }. $var inside single-line ruleset, alone.",
     },
     {
       code: `
       a { $var1: 100px; }
     `,
       description:
-        "always, { ignore: inside-single-line-block }. $var inside single-line ruleset with newlines around, alone."
+        "always, { ignore: inside-single-line-block }. $var inside single-line ruleset with newlines around, alone.",
     },
     {
       code: "a { width: 10px; $var1: 100px; color: red; }",
       description:
-        "always, { ignore: inside-single-line-block }. $var inside single-line ruleset, has neighbours."
-    }
+        "always, { ignore: inside-single-line-block }. $var inside single-line ruleset, has neighbours.",
+    },
   ],
 
   reject: [
@@ -333,7 +333,7 @@ testRule({
         "always, { ignore: inside-single-line-block }. Not a single line ruleset, $var and other decl on the same line.",
       message: messages.expected,
       line: 2,
-      column: 17
+      column: 17,
     },
     {
       code: "@include name; $var2: 2",
@@ -341,9 +341,9 @@ testRule({
         "always, { ignore: inside-single-line-block }. In root, $var and a mixin call on the same line.",
       message: messages.expected,
       line: 1,
-      column: 16
-    }
-  ]
+      column: 16,
+    },
+  ],
 });
 
 // Ignore: after-dollar-variable
@@ -362,7 +362,7 @@ testRule({
       $var2: 200px;
     `,
       description:
-        "always, { ignore: after-dollar-variable }. $var after $var, no empty line."
+        "always, { ignore: after-dollar-variable }. $var after $var, no empty line.",
     },
     {
       code: `
@@ -371,8 +371,8 @@ testRule({
       $var2: 200px;
     `,
       description:
-        "always, { ignore: after-dollar-variable }. $var after $var, has empty line."
-    }
+        "always, { ignore: after-dollar-variable }. $var after $var, has empty line.",
+    },
   ],
 
   reject: [
@@ -390,9 +390,9 @@ testRule({
         "always, { ignore: after-dollar-variable }. No $var directly before $var, no empty line.",
       message: messages.expected,
       line: 3,
-      column: 7
-    }
-  ]
+      column: 7,
+    },
+  ],
 });
 
 testRule({
@@ -408,7 +408,7 @@ testRule({
       $var2: 200px;
     `,
       description:
-        "never, { ignore: after-dollar-variable }. $var after $var, no empty line."
+        "never, { ignore: after-dollar-variable }. $var after $var, no empty line.",
     },
     {
       code: `
@@ -417,8 +417,8 @@ testRule({
       $var2: 200px;
     `,
       description:
-        "never, { ignore: after-dollar-variable }. $var after $var, has empty line."
-    }
+        "never, { ignore: after-dollar-variable }. $var after $var, has empty line.",
+    },
   ],
 
   reject: [
@@ -436,9 +436,9 @@ testRule({
         "never, { ignore: after-dollar-variable }. No $var directly before $var, has empty line.",
       message: messages.rejected,
       line: 4,
-      column: 7
-    }
-  ]
+      column: 7,
+    },
+  ],
 });
 
 // Except: first-nested
@@ -457,7 +457,7 @@ testRule({
       color: red;
     }`,
       description:
-        "always, { except: first-nested }. $var is the 1st inside ruleset, no empty line."
+        "always, { except: first-nested }. $var is the 1st inside ruleset, no empty line.",
     },
     {
       code: `@mixin name {
@@ -465,8 +465,8 @@ testRule({
       color: red;
     }`,
       description:
-        "always, { except: first-nested }. $var is the 1st inside mixin, no empty line."
-    }
+        "always, { except: first-nested }. $var is the 1st inside mixin, no empty line.",
+    },
   ],
 
   reject: [
@@ -483,7 +483,7 @@ $var2: 2;
         "always, { except: first-nested }. $var is not the 1st in a ruleset, no empty line.",
       message: messages.expected,
       line: 2,
-      column: 17
+      column: 17,
     },
     {
       code: `a {
@@ -497,9 +497,9 @@ $var2: 2;
         "always, { except: first-nested }. $var is the 1st in a ruleset, has empty line.",
       message: messages.rejected,
       line: 3,
-      column: 7
-    }
-  ]
+      column: 7,
+    },
+  ],
 });
 
 testRule({
@@ -516,7 +516,7 @@ testRule({
       color: red;
     }`,
       description:
-        "never, { except: first-nested }. $var is the 1st inside ruleset, has empty line."
+        "never, { except: first-nested }. $var is the 1st inside ruleset, has empty line.",
     },
     {
       code: `a {
@@ -524,8 +524,8 @@ testRule({
       $var1: 100px;
     }`,
       description:
-        "never, { except: first-nested }. $var isn't the 1st inside ruleset, no empty line."
-    }
+        "never, { except: first-nested }. $var isn't the 1st inside ruleset, no empty line.",
+    },
   ],
 
   reject: [
@@ -541,7 +541,7 @@ testRule({
         "never, { except: first-nested }. $var is the 1st in a ruleset, no empty line.",
       message: messages.expected,
       line: 2,
-      column: 7
+      column: 7,
     },
     {
       code: `a {
@@ -557,9 +557,9 @@ testRule({
         "never, { except: first-nested }. $var isn't the 1st in a ruleset, has empty line.",
       message: messages.rejected,
       line: 4,
-      column: 7
-    }
-  ]
+      column: 7,
+    },
+  ],
 });
 
 // Except: first-nested with `disableFix: true`
@@ -571,8 +571,8 @@ testRule({
     "always",
     {
       except: "first-nested",
-      disableFix: true
-    }
+      disableFix: true,
+    },
   ],
   customSyntax: "postcss-scss",
   unfixable: true,
@@ -584,7 +584,7 @@ testRule({
       color: red;
     }`,
       description:
-        "always, { except: first-nested }. $var is the 1st inside ruleset, no empty line."
+        "always, { except: first-nested }. $var is the 1st inside ruleset, no empty line.",
     },
     {
       code: `@mixin name {
@@ -592,8 +592,8 @@ testRule({
       color: red;
     }`,
       description:
-        "always, { except: first-nested }. $var is the 1st inside mixin, no empty line."
-    }
+        "always, { except: first-nested }. $var is the 1st inside mixin, no empty line.",
+    },
   ],
 
   reject: [
@@ -605,7 +605,7 @@ testRule({
         "always, { except: first-nested }. $var is not the 1st in a ruleset, no empty line.",
       message: messages.expected,
       line: 2,
-      column: 17
+      column: 17,
     },
     {
       code: `a {
@@ -616,9 +616,9 @@ testRule({
         "always, { except: first-nested }. $var is the 1st in a ruleset, has empty line.",
       message: messages.rejected,
       line: 3,
-      column: 7
-    }
-  ]
+      column: 7,
+    },
+  ],
 });
 
 // Except: after-comment
@@ -637,12 +637,12 @@ testRule({
       $var1: 100px;
     `,
       description:
-        "always, { except: after-comment }. $var after //-comment, no empty line."
+        "always, { except: after-comment }. $var after //-comment, no empty line.",
     },
     {
       code: "/* comment */  $var1: 100px;",
       description:
-        "always, { except: after-comment }. $var after CSS-comment, no empty line."
+        "always, { except: after-comment }. $var after CSS-comment, no empty line.",
     },
     {
       code: `
@@ -651,8 +651,8 @@ testRule({
       $var1: 100px;
     `,
       description:
-        "always, { except: after-comment }. $var is not after CSS-comment, has empty line."
-    }
+        "always, { except: after-comment }. $var is not after CSS-comment, has empty line.",
+    },
   ],
 
   reject: [
@@ -670,7 +670,7 @@ testRule({
         "always, { except: after-comment }. $var after //-comment, has empty line.",
       message: messages.rejected,
       line: 4,
-      column: 7
+      column: 7,
     },
     {
       code: `
@@ -686,7 +686,7 @@ testRule({
         "always, { except: after-comment }. $var after CSS-comment, has empty line.",
       message: messages.rejected,
       line: 4,
-      column: 7
+      column: 7,
     },
     {
       code: `a {
@@ -702,9 +702,9 @@ testRule({
         "always, { except: after-comment }. No comment before $var, has empty line.",
       message: messages.expected,
       line: 3,
-      column: 7
-    }
-  ]
+      column: 7,
+    },
+  ],
 });
 
 testRule({
@@ -721,7 +721,7 @@ testRule({
       $var1: 100px;
     `,
       description:
-        "never, { except: after-comment }. $var after //-comment, has empty line."
+        "never, { except: after-comment }. $var after //-comment, has empty line.",
     },
     {
       code: `
@@ -730,7 +730,7 @@ testRule({
       $var1: 100px;
     `,
       description:
-        "never, { except: after-comment }. $var after CSS-comment, has empty line."
+        "never, { except: after-comment }. $var after CSS-comment, has empty line.",
     },
     {
       code: `
@@ -738,8 +738,8 @@ testRule({
       $var1: 100px;
     `,
       description:
-        "never, { except: after-comment }. $var is not after CSS-comment, no empty line."
-    }
+        "never, { except: after-comment }. $var is not after CSS-comment, no empty line.",
+    },
   ],
 
   reject: [
@@ -757,7 +757,7 @@ testRule({
         "never, { except: after-comment }. $var after //-comment, no empty line.",
       message: messages.expected,
       line: 3,
-      column: 7
+      column: 7,
     },
     {
       code: `
@@ -773,7 +773,7 @@ testRule({
         "never, { except: after-comment }. $var after CSS-comment, no empty line.",
       message: messages.expected,
       line: 3,
-      column: 7
+      column: 7,
     },
     {
       code: `a {
@@ -789,9 +789,9 @@ testRule({
         "never, { except: after-comment }. No comment before $var, has empty line.",
       message: messages.rejected,
       line: 4,
-      column: 7
-    }
-  ]
+      column: 7,
+    },
+  ],
 });
 
 // Except: after-dollar-variable
@@ -810,7 +810,7 @@ testRule({
       $var1: 1;
     }`,
       description:
-        "always, { except: after-dollar-variable }. Just a single var with empty line."
+        "always, { except: after-dollar-variable }. Just a single var with empty line.",
     },
     {
       code: `
@@ -819,7 +819,7 @@ testRule({
       $var2: 1;
     `,
       description:
-        "always, { except: after-dollar-variable }. $var1 has empty line, $var2 after it doesn't."
+        "always, { except: after-dollar-variable }. $var1 has empty line, $var2 after it doesn't.",
     },
     {
       code: `
@@ -829,8 +829,8 @@ testRule({
       $var3: 1;
     `,
       description:
-        "always, { except: after-dollar-variable }. Three $var-s, 1st with empty line, others without."
-    }
+        "always, { except: after-dollar-variable }. Three $var-s, 1st with empty line, others without.",
+    },
   ],
 
   reject: [
@@ -848,9 +848,9 @@ testRule({
         "always, { except: after-dollar-variable }. $var1 and $var2 have empty lines.",
       message: messages.rejected,
       line: 4,
-      column: 7
-    }
-  ]
+      column: 7,
+    },
+  ],
 });
 
 testRule({
@@ -866,7 +866,7 @@ testRule({
       $var2: 1;
     `,
       description:
-        "never, { except: after-dollar-variable }. $var1 doesn't have empty line, $var2 after it does."
+        "never, { except: after-dollar-variable }. $var1 doesn't have empty line, $var2 after it does.",
     },
     {
       code: `$var1: 1;
@@ -876,8 +876,8 @@ testRule({
       $var3: 1;
     `,
       description:
-        "never, { except: after-dollar-variable }. Three $var-s, 1st w/o empty line, others with."
-    }
+        "never, { except: after-dollar-variable }. Three $var-s, 1st w/o empty line, others with.",
+    },
   ],
 
   reject: [
@@ -895,9 +895,9 @@ testRule({
         "never, { except: after-dollar-variable }. $var1 and $var2 have empty lines.",
       message: messages.expected,
       line: 3,
-      column: 7
-    }
-  ]
+      column: 7,
+    },
+  ],
 });
 
 // Combining secondary options
@@ -907,7 +907,7 @@ testRule({
   ruleName,
   config: [
     "always",
-    { except: ["first-nested", "after-comment", "after-dollar-variable"] }
+    { except: ["first-nested", "after-comment", "after-dollar-variable"] },
   ],
   customSyntax: "postcss-scss",
 
@@ -933,7 +933,7 @@ testRule({
       }
     `,
       description:
-        "always, { except: [first-nested, after-comment, after-declaration] }."
-    }
-  ]
+        "always, { except: [first-nested, after-comment, after-declaration] }.",
+    },
+  ],
 });

--- a/src/rules/dollar-variable-empty-line-before/index.js
+++ b/src/rules/dollar-variable-empty-line-before/index.js
@@ -5,7 +5,7 @@ import {
   optionsHaveException,
   optionsHaveIgnored,
   blockString,
-  ruleUrl
+  ruleUrl,
 } from "../../utils";
 import { utils } from "stylelint";
 import { isBoolean } from "lodash";
@@ -14,11 +14,11 @@ export const ruleName = namespace("dollar-variable-empty-line-before");
 
 export const messages = utils.ruleMessages(ruleName, {
   expected: "Expected an empty line before $-variable",
-  rejected: "Unexpected empty line before $-variable"
+  rejected: "Unexpected empty line before $-variable",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(expectation, options, context) {
@@ -28,7 +28,7 @@ export default function rule(expectation, options, context) {
       ruleName,
       {
         actual: expectation,
-        possible: ["always", "never"]
+        possible: ["always", "never"],
       },
       {
         actual: options,
@@ -37,11 +37,11 @@ export default function rule(expectation, options, context) {
           ignore: [
             "after-comment",
             "inside-single-line-block",
-            "after-dollar-variable"
+            "after-dollar-variable",
           ],
-          disableFix: isBoolean
+          disableFix: isBoolean,
         },
-        optional: true
+        optional: true,
       }
     );
 
@@ -56,9 +56,9 @@ export default function rule(expectation, options, context) {
       );
     };
 
-    const hasNewline = str => str.includes(context.newline);
+    const hasNewline = (str) => str.includes(context.newline);
 
-    root.walkDecls(decl => {
+    root.walkDecls((decl) => {
       if (!isDollarVar(decl)) {
         return;
       }
@@ -159,7 +159,7 @@ export default function rule(expectation, options, context) {
           : messages.rejected,
         node: decl,
         result,
-        ruleName
+        ruleName,
       });
     });
   };

--- a/src/rules/dollar-variable-first-in-block/__tests__/index.js
+++ b/src/rules/dollar-variable-first-in-block/__tests__/index.js
@@ -13,7 +13,7 @@ testRule({
       code: `a {
       $var1: 100px;
     }`,
-      description: "$var first inside a rule."
+      description: "$var first inside a rule.",
     },
     {
       code: `a {
@@ -21,14 +21,14 @@ testRule({
       width: 100px;
       height: 100px;
     }`,
-      description: "$var first inside a rule followed by properties."
+      description: "$var first inside a rule followed by properties.",
     },
     {
       code: `a {
       $var1: 100px;
       $var1: 100px;
     }`,
-      description: "Two $var-s first inside a rule."
+      description: "Two $var-s first inside a rule.",
     },
     {
       code: `a {
@@ -36,7 +36,7 @@ testRule({
 
       $var1: 100px;
     }`,
-      description: "Two $var-s first inside a rule, empty line between them."
+      description: "Two $var-s first inside a rule, empty line between them.",
     },
     {
       code: `a {
@@ -44,48 +44,48 @@ testRule({
       $var1: 100px;
       $var1: 100px;
     }`,
-      description: "Two $var-s first inside a rule, empty line before them."
+      description: "Two $var-s first inside a rule, empty line before them.",
     },
     {
       code: "$var1: 100px;",
-      description: "$var in root."
+      description: "$var in root.",
     },
     {
       code: `
       $var1: 100px;
       @import '1.css';
     `,
-      description: "$var first in root."
+      description: "$var first in root.",
     },
     {
       code: `@media (min-width: 100px) {
       $var: 1000px;
     }`,
-      description: "$var first inside a media query."
+      description: "$var first inside a media query.",
     },
     {
       code: `@function function-name($base) {
       $var: 1000px;
     }`,
-      description: "$var first inside a `@function`."
+      description: "$var first inside a `@function`.",
     },
     {
       code: `@mixin mixin-name {
       $var: 1000px;
     }`,
-      description: "$var first inside a `@mixin`."
+      description: "$var first inside a `@mixin`.",
     },
     {
       code: `@at-root .class {
       $var: 1000px;
     }`,
-      description: "$var first inside an `@at-root`."
+      description: "$var first inside an `@at-root`.",
     },
     {
       code: `@if $direction == up {
       $var: 1000px;
     }`,
-      description: "$var first inside an `@if`."
+      description: "$var first inside an `@if`.",
     },
     {
       code: `@if $direction == up {
@@ -93,26 +93,26 @@ testRule({
     } @else {
       $var: 1000px;
     }`,
-      description: "$var first inside an `@else`."
+      description: "$var first inside an `@else`.",
     },
     {
       code: `@each $size in $sizes {
       $var: 1000px;
     }`,
-      description: "$var first inside an `@each` rule."
+      description: "$var first inside an `@each` rule.",
     },
     {
       code: `@for $i from 1 through 3 {
       $var: 1000px;
     }`,
-      description: "$var first inside a `@for` rule."
+      description: "$var first inside a `@for` rule.",
     },
     {
       code: `@while $value > $base {
       $var: 1000px;
     }`,
-      description: "$var first inside a `@while` rule."
-    }
+      description: "$var first inside a `@while` rule.",
+    },
   ],
 
   reject: [
@@ -124,7 +124,7 @@ testRule({
       description: "$var inside a rule, not first.",
       message: messages.expected,
       line: 3,
-      column: 7
+      column: 7,
     },
     {
       code: `
@@ -137,7 +137,7 @@ testRule({
       description: "$var following nested selector.",
       message: messages.expected,
       line: 5,
-      column: 9
+      column: 9,
     },
     {
       code: `
@@ -149,7 +149,7 @@ testRule({
       description: "$var following a comment.",
       message: messages.expected,
       line: 4,
-      column: 9
+      column: 9,
     },
     {
       code: `@media (min-width: 100px) {
@@ -159,7 +159,7 @@ testRule({
       description: "$var not first inside a media query.",
       message: messages.expected,
       line: 3,
-      column: 7
+      column: 7,
     },
     {
       code: `@function function-name($base) {
@@ -169,7 +169,7 @@ testRule({
       description: "$var not first inside a `@function`.",
       message: messages.expected,
       line: 3,
-      column: 7
+      column: 7,
     },
     {
       code: `@mixin mixin-name {
@@ -179,7 +179,7 @@ testRule({
       description: "$var not first inside a `@mixin`.",
       message: messages.expected,
       line: 3,
-      column: 7
+      column: 7,
     },
     {
       code: `@at-root .class {
@@ -189,7 +189,7 @@ testRule({
       description: "$var not first inside an `@at-root`.",
       message: messages.expected,
       line: 3,
-      column: 7
+      column: 7,
     },
     {
       code: `@if $direction == up {
@@ -199,7 +199,7 @@ testRule({
       description: "$var not first inside an `@if`.",
       message: messages.expected,
       line: 3,
-      column: 7
+      column: 7,
     },
     {
       code: `@if $direction == up {
@@ -211,7 +211,7 @@ testRule({
       description: "$var not first inside an `@else`.",
       message: messages.expected,
       line: 5,
-      column: 7
+      column: 7,
     },
     {
       code: `@each $size in $sizes {
@@ -221,7 +221,7 @@ testRule({
       description: "$var not first inside an `@each` rule.",
       message: messages.expected,
       line: 3,
-      column: 7
+      column: 7,
     },
     {
       code: `@for $i from 1 through 3 {
@@ -231,7 +231,7 @@ testRule({
       description: "$var not first inside a `@for` rule.",
       message: messages.expected,
       line: 3,
-      column: 7
+      column: 7,
     },
     {
       code: `@while $value > $base {
@@ -241,7 +241,7 @@ testRule({
       description: "$var not first inside a `@while` rule.",
       message: messages.expected,
       line: 3,
-      column: 7
+      column: 7,
     },
     {
       code: `
@@ -253,7 +253,7 @@ testRule({
       description: "$var in root, preceded by import, followed by selector.",
       message: messages.expected,
       line: 3,
-      column: 7
+      column: 7,
     },
     {
       code: `
@@ -263,7 +263,7 @@ testRule({
       description: "$var in root, preceded by import.",
       message: messages.expected,
       line: 3,
-      column: 7
+      column: 7,
     },
     {
       code: `
@@ -275,7 +275,7 @@ testRule({
       description: "variables in root, preceded by @use.",
       message: messages.expected,
       line: 4,
-      column: 7
+      column: 7,
     },
     {
       code: `
@@ -286,9 +286,9 @@ testRule({
       description: "$var in root, preceded by @forward.",
       message: messages.expected,
       line: 4,
-      column: 7
-    }
-  ]
+      column: 7,
+    },
+  ],
 });
 
 testRule({
@@ -302,7 +302,7 @@ testRule({
       a { }
       $var1: 100px;
     `,
-      description: "$var in root, preceded by selector."
+      description: "$var in root, preceded by selector.",
     },
     {
       code: `
@@ -310,9 +310,9 @@ testRule({
       $var1: 100px;
       b { }
     `,
-      description: "$var in root, preceded and followed by selectors."
-    }
-  ]
+      description: "$var in root, preceded and followed by selectors.",
+    },
+  ],
 });
 
 testRule({
@@ -326,9 +326,9 @@ testRule({
       width: 100px;
       $var: 1000px;
     }`,
-      description: "$var in at-rule, preceded by selector."
-    }
-  ]
+      description: "$var in at-rule, preceded by selector.",
+    },
+  ],
 });
 
 testRule({
@@ -353,9 +353,9 @@ testRule({
 
       @return $var1 + $var2;
     }`,
-      description: "$var in function, preceded by selector."
-    }
-  ]
+      description: "$var in function, preceded by selector.",
+    },
+  ],
 });
 
 testRule({
@@ -370,9 +370,9 @@ testRule({
       $var: 1000px;
       height: $var1;
     }`,
-      description: "$var in mixin, preceded by selector."
-    }
-  ]
+      description: "$var in mixin, preceded by selector.",
+    },
+  ],
 });
 
 testRule({
@@ -386,7 +386,7 @@ testRule({
       width: 100px;
       $var: 1000px;
     }`,
-      description: "$var in @if, preceded by selector."
+      description: "$var in @if, preceded by selector.",
     },
     {
       code: `@if $direction == up {
@@ -395,7 +395,7 @@ testRule({
       height: 100px;
       $var: 1000px;
     }`,
-      description: "$var in @else, preceded by selector."
+      description: "$var in @else, preceded by selector.",
     },
     {
       code: `@if $direction == up {
@@ -405,9 +405,9 @@ testRule({
       height: 100px;
       $var2: 1000px;
     }`,
-      description: "$var in @if and @else, both preceded by selector."
-    }
-  ]
+      description: "$var in @if and @else, both preceded by selector.",
+    },
+  ],
 });
 
 testRule({
@@ -421,23 +421,23 @@ testRule({
       width: 100px;
       $var: 1000px;
     }`,
-      description: "$var not first inside an `@each` rule."
+      description: "$var not first inside an `@each` rule.",
     },
     {
       code: `@for $i from 1 through 3 {
       width: 100px;
       $var: 1000px;
     }`,
-      description: "$var not first inside a `@for` rule."
+      description: "$var not first inside a `@for` rule.",
     },
     {
       code: `@while $value > $base {
       width: 100px;
       $var: 1000px;
     }`,
-      description: "$var not first inside a `@while` rule."
-    }
-  ]
+      description: "$var not first inside a `@while` rule.",
+    },
+  ],
 });
 
 testRule({
@@ -453,14 +453,14 @@ testRule({
 
       a { }
     `,
-      description: "$var in root, preceded by import, followed by selector."
+      description: "$var in root, preceded by import, followed by selector.",
     },
     {
       code: `
       @import '1.css';
       $var1: 100px;
     `,
-      description: "$var in root, preceded by import."
+      description: "$var in root, preceded by import.",
     },
     {
       code: `
@@ -469,7 +469,7 @@ testRule({
       $primary-color: #f26e21 !default;
       $secondary-color: color.change($primary-color, $alpha: 0.08) !default;
     `,
-      description: "variables in root, preceded by @use."
+      description: "variables in root, preceded by @use.",
     },
     {
       code: `
@@ -477,8 +477,8 @@ testRule({
 
       $var1: 100px;
     `,
-      description: "$var in root, preceded by @forward."
-    }
+      description: "$var in root, preceded by @forward.",
+    },
   ],
 
   reject: [
@@ -491,7 +491,7 @@ testRule({
       description: "$var inside a rule, preceded by an import and not first.",
       message: messages.expected,
       line: 4,
-      column: 7
+      column: 7,
     },
     {
       code: `
@@ -505,9 +505,9 @@ testRule({
       description: "$var following import and nested selector.",
       message: messages.expected,
       line: 6,
-      column: 9
-    }
-  ]
+      column: 9,
+    },
+  ],
 });
 
 testRule({
@@ -521,7 +521,7 @@ testRule({
       // Comment
       $var2: 100px;
     }`,
-      description: "$var inside a rule following a //-comment."
+      description: "$var inside a rule following a //-comment.",
     },
     {
       code: `a {
@@ -529,7 +529,7 @@ testRule({
       // Comment
       $var2: 100px;
     }`,
-      description: "Two $var-s inside a rule, //-comment between them."
+      description: "Two $var-s inside a rule, //-comment between them.",
     },
     {
       code: `a {
@@ -540,7 +540,7 @@ testRule({
       $var2: 100px;
     }`,
       description:
-        "Two $var-s inside a rule, multiple //-comments between them."
+        "Two $var-s inside a rule, multiple //-comments between them.",
     },
     {
       code: `a {
@@ -550,7 +550,7 @@ testRule({
       $var2: 100px;
     }`,
       description:
-        "Two $var-s inside a rule, CSS-comment and space between them."
+        "Two $var-s inside a rule, CSS-comment and space between them.",
     },
     {
       code: `a {
@@ -563,8 +563,8 @@ testRule({
       $var2: 100px;
     }`,
       description:
-        "Two $var-s inside a rule, empty lines and multi-line CSS-comment between them."
-    }
+        "Two $var-s inside a rule, empty lines and multi-line CSS-comment between them.",
+    },
   ],
 
   reject: [
@@ -577,7 +577,7 @@ testRule({
       description: "$var inside a rule, preceded by //-comment and not first.",
       message: messages.expected,
       line: 4,
-      column: 7
+      column: 7,
     },
     {
       code: `
@@ -591,7 +591,7 @@ testRule({
       description: "$var following comment and nested selector.",
       message: messages.expected,
       line: 6,
-      column: 9
+      column: 9,
     },
     {
       code: `
@@ -608,9 +608,9 @@ testRule({
         "$var preceded by comment, a nested selector and another $var.",
       message: messages.expected,
       line: 8,
-      column: 9
-    }
-  ]
+      column: 9,
+    },
+  ],
 });
 
 testRule({
@@ -625,7 +625,7 @@ testRule({
       // Comment
       $var2: 100px;
     }`,
-      description: "$var inside a rule following a //-comment and an import."
+      description: "$var inside a rule following a //-comment and an import.",
     },
     {
       code: `
@@ -633,7 +633,7 @@ testRule({
       // Comment
       $var2: 100px;
     `,
-      description: "$var in root following a //-comment and an import."
+      description: "$var in root following a //-comment and an import.",
     },
     {
       code: `a {
@@ -644,7 +644,7 @@ testRule({
       $var2: 100px;
     }`,
       description:
-        "Two $var-s inside a rule, multiple comments and an import between them."
+        "Two $var-s inside a rule, multiple comments and an import between them.",
     },
     {
       code: `a {
@@ -652,7 +652,7 @@ testRule({
       @import url("path/_file2.css");
       $var1: 100px;
     }`,
-      description: "$var preceded by two imports inside a rule."
+      description: "$var preceded by two imports inside a rule.",
     },
     {
       code: `
@@ -660,8 +660,8 @@ testRule({
       @import url("path/_file2.css");
       $var1: 100px;
     `,
-      description: "$var preceded by two imports in root."
-    }
+      description: "$var preceded by two imports in root.",
+    },
   ],
 
   reject: [
@@ -676,7 +676,7 @@ testRule({
         "$var inside a rule, preceded by //-comment, an import and not first.",
       message: messages.expected,
       line: 5,
-      column: 7
-    }
-  ]
+      column: 7,
+    },
+  ],
 });

--- a/src/rules/dollar-variable-first-in-block/index.js
+++ b/src/rules/dollar-variable-first-in-block/index.js
@@ -2,18 +2,18 @@ import {
   namespace,
   optionsHaveException,
   optionsHaveIgnored,
-  ruleUrl
+  ruleUrl,
 } from "../../utils";
 import { utils } from "stylelint";
 
 export const ruleName = namespace("dollar-variable-first-in-block");
 
 export const messages = utils.ruleMessages(ruleName, {
-  expected: "Expected $-variable to be first in block"
+  expected: "Expected $-variable to be first in block",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(primary, options) {
@@ -22,15 +22,15 @@ export default function rule(primary, options) {
       result,
       ruleName,
       {
-        actual: primary
+        actual: primary,
       },
       {
         actual: options,
         possible: {
           ignore: ["comments", "imports"],
-          except: ["root", "at-rule", "function", "mixin", "if-else", "loops"]
+          except: ["root", "at-rule", "function", "mixin", "if-else", "loops"],
         },
-        optional: true
+        optional: true,
       }
     );
 
@@ -38,9 +38,9 @@ export default function rule(primary, options) {
       return;
     }
 
-    const isDollarVar = node => node.prop && node.prop[0] === "$";
+    const isDollarVar = (node) => node.prop && node.prop[0] === "$";
 
-    root.walkDecls(decl => {
+    root.walkDecls((decl) => {
       // Ignore declarations that aren't variables.
       // ------------------------------------------
       if (!isDollarVar(decl)) {
@@ -112,7 +112,7 @@ export default function rule(primary, options) {
         message: messages.expected,
         node: decl,
         result,
-        ruleName
+        ruleName,
       });
     });
   };

--- a/src/rules/dollar-variable-no-missing-interpolation/__tests__/index.js
+++ b/src/rules/dollar-variable-no-missing-interpolation/__tests__/index.js
@@ -15,7 +15,7 @@ testRule({
       }
     `,
       description:
-        "when variable is a string and it is interpolated in animation-name property"
+        "when variable is a string and it is interpolated in animation-name property",
     },
     {
       code: `
@@ -24,7 +24,7 @@ testRule({
       @keyframes #{$var} {}
     `,
       description:
-        "when variable is a string and it is interpolated in @keyframes"
+        "when variable is a string and it is interpolated in @keyframes",
     },
     {
       code: `
@@ -35,7 +35,7 @@ testRule({
       }
     `,
       description:
-        "when variable is not a string and it is used in animation-name property"
+        "when variable is not a string and it is used in animation-name property",
     },
     {
       code: `
@@ -46,7 +46,7 @@ testRule({
       }
     `,
       description:
-        "when variable is not a string and it is interpolated in animation-name property"
+        "when variable is not a string and it is interpolated in animation-name property",
     },
     {
       code: `
@@ -57,7 +57,7 @@ testRule({
       }
     `,
       description:
-        "when variable is not a string and it is interpolated in counter-reset property"
+        "when variable is not a string and it is interpolated in counter-reset property",
     },
     {
       code: `
@@ -66,7 +66,7 @@ testRule({
       @keyframes #{$var} {}
     `,
       description:
-        "when variable is not a string and it is interpolated in @keyframes"
+        "when variable is not a string and it is interpolated in @keyframes",
     },
     {
       code: `
@@ -80,7 +80,7 @@ testRule({
       }
     `,
       description:
-        "when variable is a not string and it is interpolated in @counter-style"
+        "when variable is a not string and it is interpolated in @counter-style",
     },
     {
       code: `
@@ -91,7 +91,7 @@ testRule({
       }
     `,
       description:
-        "when variable is not a string and it is interpolated in @supports"
+        "when variable is not a string and it is interpolated in @supports",
     },
     {
       code: `
@@ -102,7 +102,7 @@ testRule({
       }
     `,
       description:
-        "when variable is a string and it is interpolated in @supports"
+        "when variable is a string and it is interpolated in @supports",
     },
     {
       code: `
@@ -112,7 +112,7 @@ testRule({
         @keyframes {}
       }
     `,
-      description: "when variable is not a string and it is used in @supports"
+      description: "when variable is not a string and it is used in @supports",
     },
     {
       code: `
@@ -124,7 +124,7 @@ testRule({
       }
     `,
       description:
-        "when variable is a string and the same name is used inside another string"
+        "when variable is a string and the same name is used inside another string",
     },
     {
       code: `
@@ -134,7 +134,7 @@ testRule({
       }
     `,
       description:
-        "when variable is a string and it is used with content property"
+        "when variable is a string and it is used with content property",
     },
     {
       code: `
@@ -144,7 +144,7 @@ testRule({
       }
     `,
       description:
-        "when variable name has dashes and it is used with content property"
+        "when variable name has dashes and it is used with content property",
     },
     {
       code: `
@@ -155,8 +155,8 @@ testRule({
       }
     `,
       description:
-        "when variable is a string and it is interpolated in @keyframes inside a mixin"
-    }
+        "when variable is a string and it is interpolated in @keyframes inside a mixin",
+    },
   ],
 
   reject: [
@@ -170,7 +170,7 @@ testRule({
       line: 4,
       message: messages.rejected("animation-name", "$var"),
       description:
-        "when variable is a string and it is not interpolated in animation-name property"
+        "when variable is a string and it is not interpolated in animation-name property",
     },
     {
       code: `
@@ -183,7 +183,7 @@ testRule({
       line: 5,
       message: messages.rejected("animation-name", "$var"),
       description:
-        "when variable is a string and it is not interpolated in animation-name property"
+        "when variable is a string and it is not interpolated in animation-name property",
     },
     {
       code: `
@@ -196,7 +196,7 @@ testRule({
       line: 5,
       message: messages.rejected("counter-reset", "$var"),
       description:
-        "when variable is a string and it is not interpolated in counter-reset"
+        "when variable is a string and it is not interpolated in counter-reset",
     },
     {
       code: `
@@ -206,7 +206,7 @@ testRule({
     `,
       line: 4,
       message: messages.rejected("@keyframes", "$var"),
-      description: "when variable is not a string and it is used in @keyframes"
+      description: "when variable is not a string and it is used in @keyframes",
     },
     {
       code: `
@@ -217,7 +217,7 @@ testRule({
       line: 4,
       message: messages.rejected("@keyframes", "$var"),
       description:
-        "when variable is a string and it is not interpolated in @keyframes"
+        "when variable is a string and it is not interpolated in @keyframes",
     },
     {
       code: `
@@ -228,7 +228,7 @@ testRule({
       line: 4,
       message: messages.rejected("@keyframes", "$var"),
       description:
-        "when variable is a string and it is not interpolated in @keyframes"
+        "when variable is a string and it is not interpolated in @keyframes",
     },
     {
       code: `
@@ -243,7 +243,7 @@ testRule({
     `,
       line: 4,
       message: messages.rejected("@counter-style", "$var"),
-      description: "when variable is a string and it is used in @counter-style"
+      description: "when variable is a string and it is used in @counter-style",
     },
     {
       code: `
@@ -259,7 +259,7 @@ testRule({
       line: 4,
       message: messages.rejected("@counter-style", "$var"),
       description:
-        "when variable is not a string and it is used in @counter-style"
+        "when variable is not a string and it is used in @counter-style",
     },
     {
       code: `
@@ -271,7 +271,7 @@ testRule({
     `,
       line: 4,
       message: messages.rejected("@supports", "$var"),
-      description: "when variable is a string and it is used in @supports"
+      description: "when variable is a string and it is used in @supports",
     },
     {
       code: `
@@ -284,7 +284,7 @@ testRule({
       line: 4,
       message: messages.rejected("@supports", "$var"),
       description:
-        "when variable is a string and it is used in @supports and there is whitespace"
+        "when variable is a string and it is used in @supports and there is whitespace",
     },
     {
       code: `
@@ -297,7 +297,7 @@ testRule({
       line: 5,
       message: messages.rejected("@keyframes", "$var"),
       description:
-        "when variable is a string and it is not interpolated in @keyframes inside a mixin"
-    }
-  ]
+        "when variable is a string and it is not interpolated in @keyframes inside a mixin",
+    },
+  ],
 });

--- a/src/rules/dollar-variable-no-missing-interpolation/index.js
+++ b/src/rules/dollar-variable-no-missing-interpolation/index.js
@@ -6,11 +6,11 @@ export const ruleName = namespace("dollar-variable-no-missing-interpolation");
 
 export const messages = utils.ruleMessages(ruleName, {
   rejected: (n, v) =>
-    `Expected variable ${v} to be interpolated when using it with ${n}`
+    `Expected variable ${v} to be interpolated when using it with ${n}`,
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 // https://developer.mozilla.org/en/docs/Web/CSS/custom-ident#Lists_of_excluded_values
@@ -20,7 +20,7 @@ const customIdentProps = [
   "counter-reset",
   "counter-increment",
   "list-style-type",
-  "will-change"
+  "will-change",
 ];
 
 // https://developer.mozilla.org/en/docs/Web/CSS/At-rule
@@ -66,7 +66,7 @@ export default function rule(actual) {
     const vars = [];
 
     function findVars(node) {
-      node.walkDecls(decl => {
+      node.walkDecls((decl) => {
         const { prop, value } = decl;
 
         if (!isSassVar(prop) || vars.includes(prop)) {
@@ -108,7 +108,7 @@ export default function rule(actual) {
         ruleName,
         result,
         node,
-        message: messages.rejected(nodeName, value)
+        message: messages.rejected(nodeName, value),
       });
     }
 
@@ -117,7 +117,7 @@ export default function rule(actual) {
     }
 
     function walkValues(node, value) {
-      valueParser(value).walk(valNode => {
+      valueParser(value).walk((valNode) => {
         const { value } = valNode;
 
         if (exitEarly(valNode) || !shouldReport(node, value)) {
@@ -128,11 +128,11 @@ export default function rule(actual) {
       });
     }
 
-    root.walkDecls(toRegex(customIdentProps), decl => {
+    root.walkDecls(toRegex(customIdentProps), (decl) => {
       walkValues(decl, decl.value);
     });
 
-    root.walkAtRules(toRegex(customIdentAtRules), atRule => {
+    root.walkAtRules(toRegex(customIdentAtRules), (atRule) => {
       walkValues(atRule, atRule.params);
     });
   };

--- a/src/rules/dollar-variable-no-namespaced-assignment/__tests__/index.js
+++ b/src/rules/dollar-variable-no-namespaced-assignment/__tests__/index.js
@@ -12,7 +12,7 @@ testRule({
         $foo: 10px;
       }
     `,
-      description: "Non-namespaced assignment"
+      description: "Non-namespaced assignment",
     },
     {
       code: `
@@ -20,8 +20,8 @@ testRule({
         a: imported.$foo;
       }
     `,
-      description: "Namespaced usage"
-    }
+      description: "Namespaced usage",
+    },
   ],
 
   reject: [
@@ -33,7 +33,7 @@ testRule({
     `,
       line: 3,
       message: messages.rejected,
-      description: "Namespaced assignment"
-    }
-  ]
+      description: "Namespaced assignment",
+    },
+  ],
 });

--- a/src/rules/dollar-variable-no-namespaced-assignment/index.js
+++ b/src/rules/dollar-variable-no-namespaced-assignment/index.js
@@ -4,11 +4,11 @@ import { namespace, ruleUrl } from "../../utils";
 export const ruleName = namespace("dollar-variable-no-namespaced-assignment");
 
 export const messages = utils.ruleMessages(ruleName, {
-  rejected: "Unexpected assignment to a namespaced $ variable"
+  rejected: "Unexpected assignment to a namespaced $ variable",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(actual) {
@@ -19,7 +19,7 @@ export default function rule(actual) {
       return;
     }
 
-    root.walkDecls(decl => {
+    root.walkDecls((decl) => {
       if (!/^[^$.]+\.\$./.test(decl.prop)) {
         return;
       }
@@ -28,7 +28,7 @@ export default function rule(actual) {
         message: messages.rejected,
         node: decl,
         result,
-        ruleName
+        ruleName,
       });
     });
   };

--- a/src/rules/dollar-variable-pattern/__tests__/index.js
+++ b/src/rules/dollar-variable-pattern/__tests__/index.js
@@ -13,7 +13,7 @@ testRule({
         $foo: 10px;
       }
     `,
-      description: "Regexp: sequence part. Example: full match."
+      description: "Regexp: sequence part. Example: full match.",
     },
     {
       code: `
@@ -21,7 +21,7 @@ testRule({
         $_foo: 10px;
       }
     `,
-      description: "Regexp: sequence part. Example: matches at the end."
+      description: "Regexp: sequence part. Example: matches at the end.",
     },
     {
       code: `
@@ -29,8 +29,8 @@ testRule({
         $food: 10px;
       }
     `,
-      description: "Regexp: sequence part. Example: matches at the beginning."
-    }
+      description: "Regexp: sequence part. Example: matches at the beginning.",
+    },
   ],
 
   reject: [
@@ -42,9 +42,9 @@ testRule({
     `,
       line: 3,
       message: messages.expected,
-      description: "Regexp: sequence part. Example: symbol in between."
-    }
-  ]
+      description: "Regexp: sequence part. Example: symbol in between.",
+    },
+  ],
 });
 
 // Testing against a string, sequence part
@@ -60,7 +60,7 @@ testRule({
         $foo: 10px;
       }
     `,
-      description: "String: sequence part. Example: full match."
+      description: "String: sequence part. Example: full match.",
     },
     {
       code: `
@@ -68,7 +68,7 @@ testRule({
         $_foo: 10px;
       }
     `,
-      description: "String: sequence part. Example: matches at the end."
+      description: "String: sequence part. Example: matches at the end.",
     },
     {
       code: `
@@ -76,8 +76,8 @@ testRule({
         $food: 10px;
       }
     `,
-      description: "String: sequence part. Example: matches at the beginning."
-    }
+      description: "String: sequence part. Example: matches at the beginning.",
+    },
   ],
 
   reject: [
@@ -89,7 +89,7 @@ testRule({
     `,
       line: 3,
       message: messages.expected,
-      description: "String: sequence part. Example: symbol in between."
+      description: "String: sequence part. Example: symbol in between.",
     },
     {
       code: `
@@ -99,9 +99,9 @@ testRule({
     `,
       line: 3,
       message: messages.expected,
-      description: "String: sequence part. Example: not a full sequence."
-    }
-  ]
+      description: "String: sequence part. Example: not a full sequence.",
+    },
+  ],
 });
 
 // Testing against a regex, full match
@@ -117,8 +117,8 @@ testRule({
         $foo: 10px;
       }
     `,
-      description: "Regexp: strict pattern. Example: matches."
-    }
+      description: "Regexp: strict pattern. Example: matches.",
+    },
   ],
 
   reject: [
@@ -130,7 +130,7 @@ testRule({
     `,
       line: 3,
       message: messages.expected,
-      description: "Regexp: strict pattern. Example: matches at the end."
+      description: "Regexp: strict pattern. Example: matches at the end.",
     },
     {
       code: `
@@ -140,7 +140,7 @@ testRule({
     `,
       line: 3,
       message: messages.expected,
-      description: "Regexp: strict pattern. Example: matches at the beginning."
+      description: "Regexp: strict pattern. Example: matches at the beginning.",
     },
     {
       code: `
@@ -150,9 +150,9 @@ testRule({
     `,
       line: 3,
       message: messages.expected,
-      description: "Regexp: strict pattern. Example: symbol in between."
-    }
-  ]
+      description: "Regexp: strict pattern. Example: symbol in between.",
+    },
+  ],
 });
 
 // Testing against a regex, match at the beginning
@@ -168,7 +168,7 @@ testRule({
         $foo: 10px;
       }
     `,
-      description: "Regexp: pattern at the beginning. Example: matches."
+      description: "Regexp: pattern at the beginning. Example: matches.",
     },
     {
       code: `
@@ -177,8 +177,8 @@ testRule({
       }
     `,
       description:
-        "Regexp: pattern at the beginning. Example: matches at the beginning."
-    }
+        "Regexp: pattern at the beginning. Example: matches at the beginning.",
+    },
   ],
 
   reject: [
@@ -191,7 +191,7 @@ testRule({
       line: 3,
       message: messages.expected,
       description:
-        "Regexp: pattern at the beginning. Example: matches at the end."
+        "Regexp: pattern at the beginning. Example: matches at the end.",
     },
     {
       code: `
@@ -202,9 +202,9 @@ testRule({
       line: 3,
       message: messages.expected,
       description:
-        "Regexp: pattern at the beginning. Example: symbol in between."
-    }
-  ]
+        "Regexp: pattern at the beginning. Example: symbol in between.",
+    },
+  ],
 });
 
 // Testing against a regex, SUIT naming
@@ -216,12 +216,12 @@ testRule({
   accept: [
     {
       code: "a { $Foo-bar: 0; }",
-      description: "Regexp: SUIT component. Example: comply"
+      description: "Regexp: SUIT component. Example: comply",
     },
     {
       code: "a { $Foo-barBaz: 0; }",
-      description: "Regexp: SUIT component. Example: comply"
-    }
+      description: "Regexp: SUIT component. Example: comply",
+    },
   ],
 
   reject: [
@@ -230,22 +230,22 @@ testRule({
       line: 1,
       message: messages.expected,
       description:
-        "Regexp: SUIT component. Example: starts with lowercase, two elements"
+        "Regexp: SUIT component. Example: starts with lowercase, two elements",
     },
     {
       code: "a { $foo-bar: 0; }",
       line: 1,
       message: messages.expected,
-      description: "Regexp: SUIT component. Example: starts with lowercase"
+      description: "Regexp: SUIT component. Example: starts with lowercase",
     },
     {
       code: "a { $Foo-Bar: 0; }",
       line: 1,
       message: messages.expected,
       description:
-        "Regexp: SUIT component. Example: element starts with uppercase"
-    }
-  ]
+        "Regexp: SUIT component. Example: element starts with uppercase",
+    },
+  ],
 });
 
 // "ignore" options
@@ -257,13 +257,13 @@ testRule({
   accept: [
     {
       code: "a { $oo-bar: 0; }",
-      description: "Ignore local variable (not matching the pattern)."
+      description: "Ignore local variable (not matching the pattern).",
     },
     {
       code: "$Foo-barBaz: 0;",
       description:
-        "Ignore local variable (passing global, matching the pattern)."
-    }
+        "Ignore local variable (passing global, matching the pattern).",
+    },
   ],
 
   reject: [
@@ -272,9 +272,9 @@ testRule({
       line: 1,
       message: messages.expected,
       description:
-        "Ignore local variable (passing global, not matching the pattern)."
-    }
-  ]
+        "Ignore local variable (passing global, not matching the pattern).",
+    },
+  ],
 });
 
 testRule({
@@ -285,13 +285,13 @@ testRule({
   accept: [
     {
       code: "$oo-bar: 0;",
-      description: "Ignore global variable (not matching the pattern)."
+      description: "Ignore global variable (not matching the pattern).",
     },
     {
       code: "a { $Foo-barBaz: 0; }",
       description:
-        "Ignore global variable (passing local, matching the pattern)."
-    }
+        "Ignore global variable (passing local, matching the pattern).",
+    },
   ],
 
   reject: [
@@ -300,7 +300,7 @@ testRule({
       line: 1,
       message: messages.expected,
       description:
-        "Ignore global variable (passing local, not matching the pattern)."
-    }
-  ]
+        "Ignore global variable (passing local, not matching the pattern).",
+    },
+  ],
 });

--- a/src/rules/dollar-variable-pattern/index.js
+++ b/src/rules/dollar-variable-pattern/index.js
@@ -5,11 +5,11 @@ import { namespace, optionsHaveIgnored, ruleUrl } from "../../utils";
 export const ruleName = namespace("dollar-variable-pattern");
 
 export const messages = utils.ruleMessages(ruleName, {
-  expected: "Expected $ variable name to match specified pattern"
+  expected: "Expected $ variable name to match specified pattern",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(pattern, options) {
@@ -19,14 +19,14 @@ export default function rule(pattern, options) {
       ruleName,
       {
         actual: pattern,
-        possible: [isRegExp, isString]
+        possible: [isRegExp, isString],
       },
       {
         actual: options,
         possible: {
-          ignore: ["local", "global"]
+          ignore: ["local", "global"],
         },
-        optional: true
+        optional: true,
       }
     );
 
@@ -36,7 +36,7 @@ export default function rule(pattern, options) {
 
     const regexpPattern = isString(pattern) ? new RegExp(pattern) : pattern;
 
-    root.walkDecls(decl => {
+    root.walkDecls((decl) => {
       const { prop } = decl;
 
       if (prop[0] !== "$") {
@@ -60,7 +60,7 @@ export default function rule(pattern, options) {
         message: messages.expected,
         node: decl,
         result,
-        ruleName
+        ruleName,
       });
     });
   };

--- a/src/rules/double-slash-comment-empty-line-before/__tests__/index.js
+++ b/src/rules/double-slash-comment-empty-line-before/__tests__/index.js
@@ -5,22 +5,22 @@ const alwaysGeneralTests = {
   accept: [
     {
       code: "// First node, ignored",
-      description: "First node, ignored."
+      description: "First node, ignored.",
     },
     {
       code: `
       a { color: pink; /* CSS comment */
       top: 0; }
     `,
-      description: "CSS comment inside ruleset, ignored."
+      description: "CSS comment inside ruleset, ignored.",
     },
     {
       code: "a {} /* CSS comment */",
-      description: "CSS comment in root scope, ignored."
+      description: "CSS comment in root scope, ignored.",
     },
     {
       code: "a {} // Inline comment",
-      description: "Inline comment (on the same line as some code)."
+      description: "Inline comment (on the same line as some code).",
     },
     {
       code: `
@@ -28,15 +28,15 @@ const alwaysGeneralTests = {
 
       // comment with empty line before it
     `,
-      description: "Proper empty line, root scope."
+      description: "Proper empty line, root scope.",
     },
     {
       code: "a {}\r\n\r\n// comment with Win empty line",
-      description: "Proper empty line (Windows style)."
+      description: "Proper empty line (Windows style).",
     },
     {
       code: "a {}\n\r\n// comment with mixed empty line",
-      description: "Proper empty lint (mixed styles)."
+      description: "Proper empty lint (mixed styles).",
     },
     {
       code: `
@@ -45,8 +45,8 @@ const alwaysGeneralTests = {
       // comment with proper empty line
       top: 0; }
     `,
-      description: "Proper empty line, inside ruleset."
-    }
+      description: "Proper empty line, inside ruleset.",
+    },
   ],
 
   reject: [
@@ -60,13 +60,13 @@ const alwaysGeneralTests = {
 
       // comment 2
     `,
-      message: messages.expected
+      message: messages.expected,
     },
     {
       code: "// comment\r\n// comment",
       fixed: "// comment\r\n\r\n// comment",
       description: "One windows newline between comments.",
-      message: messages.expected
+      message: messages.expected,
     },
     {
       code: `
@@ -80,17 +80,16 @@ const alwaysGeneralTests = {
       // comment w/o empty line
       top: 0; }
     `,
-      message: messages.expected
+      message: messages.expected,
     },
     {
-      code:
-        "a { color: pink;\r\n// comment w/o empty lines, Win style\r\ntop: 0; }",
+      code: "a { color: pink;\r\n// comment w/o empty lines, Win style\r\ntop: 0; }",
       fixed:
         "a { color: pink;\r\n\r\n// comment w/o empty lines, Win style\r\ntop: 0; }",
       description: "One Windows newline before comment.",
-      message: messages.expected
-    }
-  ]
+      message: messages.expected,
+    },
+  ],
 };
 
 // -------------------------------------------------------------------------
@@ -111,8 +110,8 @@ testRule({
       // First-nested, empty line before
       color: pink;
     }`,
-      description: "First-nested, empty line before."
-    }
+      description: "First-nested, empty line before.",
+    },
   ]),
 
   reject: alwaysGeneralTests.reject.concat([
@@ -129,9 +128,9 @@ testRule({
       description: "First-nested, no empty line before.",
       message: messages.expected,
       line: 2,
-      column: 7
-    }
-  ])
+      column: 7,
+    },
+  ]),
 });
 
 testRule({
@@ -149,8 +148,8 @@ testRule({
         color: pink;
       }
     `,
-      description: "First nested, no empty line."
-    }
+      description: "First nested, no empty line.",
+    },
   ]),
 
   reject: alwaysGeneralTests.reject.concat([
@@ -169,9 +168,9 @@ testRule({
       description: "First-nested, with empty line (rejected).",
       message: messages.rejected,
       line: 4,
-      column: 7
-    }
-  ])
+      column: 7,
+    },
+  ]),
 });
 
 testRule({
@@ -189,8 +188,8 @@ testRule({
         color: pink;
       }
     `,
-      description: "Inside block, no empty line."
-    }
+      description: "Inside block, no empty line.",
+    },
   ],
 
   reject: [
@@ -211,7 +210,7 @@ testRule({
       description: "Inside rule block, with empty line (rejected).",
       message: messages.rejected,
       line: 4,
-      column: 9
+      column: 9,
     },
     {
       code: `
@@ -230,9 +229,9 @@ testRule({
       description: "Inside at-rule block, with empty line (rejected).",
       message: messages.rejected,
       line: 4,
-      column: 9
-    }
-  ]
+      column: 9,
+    },
+  ],
 });
 
 testRule({
@@ -251,9 +250,9 @@ testRule({
       }
     `,
       description:
-        "stylelint command line-comment, no empty line before (ignored)."
-    }
-  ])
+        "stylelint command line-comment, no empty line before (ignored).",
+    },
+  ]),
 });
 
 testRule({
@@ -271,7 +270,7 @@ testRule({
       // comment 3
       body { color: red; }
     `,
-      description: "Multiple comments, root level, no empty lines between."
+      description: "Multiple comments, root level, no empty lines between.",
     },
     {
       code: `
@@ -282,7 +281,7 @@ testRule({
       top: 0;
     }`,
       description:
-        "Multiple comments, inside ruleset, empty line only before the 1st."
+        "Multiple comments, inside ruleset, empty line only before the 1st.",
     },
     {
       code: `
@@ -293,7 +292,7 @@ testRule({
       top: 0;
     }`,
       description:
-        "2 comments, 1st is CSS one, 2nd is single-line, empty line only before the 1st."
+        "2 comments, 1st is CSS one, 2nd is single-line, empty line only before the 1st.",
     },
     {
       code: `
@@ -304,8 +303,8 @@ testRule({
       top: 0;
     }`,
       description:
-        "2 comments, 1st is single-line, 2nd is CSS one, empty line only before the 1st."
-    }
+        "2 comments, 1st is single-line, 2nd is CSS one, empty line only before the 1st.",
+    },
   ],
 
   reject: [
@@ -328,9 +327,9 @@ testRule({
       }
     `,
       description: "Multiple comments, inside ruleset, no empty lines.",
-      message: messages.expected
-    }
-  ]
+      message: messages.expected,
+    },
+  ],
 });
 
 testRule({
@@ -347,7 +346,7 @@ testRule({
 
       // comment 1
     `,
-      description: "Empty line before root level comment"
+      description: "Empty line before root level comment",
     },
     {
       code: `
@@ -356,7 +355,7 @@ testRule({
         color: red;
       }
     `,
-      description: "Non-empty line before comment inside a rule block"
+      description: "Non-empty line before comment inside a rule block",
     },
     {
       code: `
@@ -365,8 +364,8 @@ testRule({
         p { color: red; }
       }
     `,
-      description: "Non-empty line before comment inside an at-rule block"
-    }
+      description: "Non-empty line before comment inside an at-rule block",
+    },
   ],
 
   reject: [
@@ -381,9 +380,9 @@ testRule({
       // comment 1
     `,
       description: "Non-empty line before root level comment",
-      message: messages.expected
-    }
-  ]
+      message: messages.expected,
+    },
+  ],
 });
 
 // -------------------------------------------------------------------------
@@ -403,11 +402,11 @@ testRule({
 
       // comment
     `,
-      description: "First nested, empty line, ignored."
+      description: "First nested, empty line, ignored.",
     },
     {
       code: "\r\n\r\n// comment",
-      description: "First nested, CRLF-empty line, ignored."
+      description: "First nested, CRLF-empty line, ignored.",
     },
     {
       code: `
@@ -418,10 +417,10 @@ testRule({
         top: 0;
       }
     `,
-      description: "CSS comment, ignored"
+      description: "CSS comment, ignored",
     },
     {
-      code: "a {} // Inline comment"
+      code: "a {} // Inline comment",
     },
     {
       code: `a {
@@ -430,12 +429,12 @@ testRule({
 
       top: 0;
     }
-  `
+  `,
     },
     {
       code: "a { color: pink;\r\n// comment\r\n\r\ntop: 0; }",
-      description: "CRLF"
-    }
+      description: "CRLF",
+    },
   ],
 
   reject: [
@@ -449,7 +448,7 @@ testRule({
       // comment
       /// comment
     `,
-      message: messages.rejected
+      message: messages.rejected,
     },
     {
       code: `
@@ -461,7 +460,7 @@ testRule({
       a {}
       // comment
     `,
-      message: messages.rejected
+      message: messages.rejected,
     },
     {
       code: `
@@ -475,25 +474,25 @@ testRule({
       // comment
     `,
       description: "multiple lines",
-      message: messages.rejected
+      message: messages.rejected,
     },
     {
       code: "a {}\n\n\n\n\n\n// comment",
       fixed: "a {}\n// comment",
       description: "multiple lines",
-      message: messages.rejected
+      message: messages.rejected,
     },
     {
       code: "a {}\r\n\r\n// comment",
       fixed: "a {}\r\n// comment",
       description: "CRLF",
-      message: messages.rejected
+      message: messages.rejected,
     },
     {
       code: "a {}\r\n\r\n\r\n// comment",
       fixed: "a {}\r\n// comment",
       description: "CRLF",
-      message: messages.rejected
+      message: messages.rejected,
     },
     {
       code: `
@@ -511,7 +510,7 @@ testRule({
         top: 0;
       }
     `,
-      message: messages.rejected
+      message: messages.rejected,
     },
     {
       code: `
@@ -543,16 +542,16 @@ testRule({
         {
           line: 4,
           column: 9,
-          message: messages.rejected
+          message: messages.rejected,
         },
         {
           line: 9,
           column: 9,
-          message: messages.rejected
-        }
-      ]
-    }
-  ]
+          message: messages.rejected,
+        },
+      ],
+    },
+  ],
 });
 
 testRule({
@@ -571,8 +570,8 @@ testRule({
         color: pink;
       }
     `,
-      description: "Inside block, with empty line."
-    }
+      description: "Inside block, with empty line.",
+    },
   ],
 
   reject: [
@@ -593,7 +592,7 @@ testRule({
       description: "Inside rule block, no empty line (rejected).",
       message: messages.expected,
       line: 3,
-      column: 9
+      column: 9,
     },
     {
       code: `
@@ -612,7 +611,7 @@ testRule({
       description: "Inside at-rule block, no empty line (rejected).",
       message: messages.expected,
       line: 3,
-      column: 9
-    }
-  ]
+      column: 9,
+    },
+  ],
 });

--- a/src/rules/double-slash-comment-empty-line-before/index.js
+++ b/src/rules/double-slash-comment-empty-line-before/index.js
@@ -6,18 +6,18 @@ import {
   optionsHaveException,
   optionsHaveIgnored,
   removeEmptyLinesBefore,
-  ruleUrl
+  ruleUrl,
 } from "../../utils";
 
 export const ruleName = namespace("double-slash-comment-empty-line-before");
 
 export const messages = utils.ruleMessages(ruleName, {
   expected: "Expected empty line before comment",
-  rejected: "Unexpected empty line before comment"
+  rejected: "Unexpected empty line before comment",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 const stylelintCommandPrefix = "stylelint-";
@@ -29,15 +29,15 @@ export default function rule(expectation, options, context) {
       ruleName,
       {
         actual: expectation,
-        possible: ["always", "never"]
+        possible: ["always", "never"],
       },
       {
         actual: options,
         possible: {
           except: ["first-nested", "inside-block"],
-          ignore: ["stylelint-commands", "between-comments", "inside-block"]
+          ignore: ["stylelint-commands", "between-comments", "inside-block"],
         },
-        optional: true
+        optional: true,
       }
     );
 
@@ -45,7 +45,7 @@ export default function rule(expectation, options, context) {
       return;
     }
 
-    root.walkComments(comment => {
+    root.walkComments((comment) => {
       // Only process // comments
       if (!comment.raws.inline && !comment.inline) {
         return;
@@ -138,7 +138,7 @@ export default function rule(expectation, options, context) {
         message,
         node: comment,
         result,
-        ruleName
+        ruleName,
       });
     });
   };

--- a/src/rules/double-slash-comment-inline/__tests__/index.js
+++ b/src/rules/double-slash-comment-inline/__tests__/index.js
@@ -13,13 +13,13 @@ testRule({
   accept: [
     {
       code: "a {} // Inline comment, outside a ruleset.",
-      description: "Inline comment, outside a ruleset."
+      description: "Inline comment, outside a ruleset.",
     },
     {
       code: `a { // Inline comment, after {.
       width: 10px;
     }`,
-      description: "Inline comment, after {."
+      description: "Inline comment, after {.",
     },
     {
       code: `
@@ -28,15 +28,15 @@ testRule({
         width: 10px;
       }
     `,
-      description: "Inline comment between selectors."
+      description: "Inline comment between selectors.",
     },
     {
       code: `a {
       /* Non-inline CSS comment, ignored */
       width: 10px;
     }`,
-      description: "Non-inline CSS comment, ignored."
-    }
+      description: "Non-inline CSS comment, ignored.",
+    },
   ],
 
   reject: [
@@ -48,7 +48,7 @@ testRule({
       description: "Non-inline comment (after a ruleset)",
       message: messages.expected,
       line: 3,
-      column: 7
+      column: 7,
     },
     {
       code: `
@@ -59,7 +59,7 @@ testRule({
       description: "Non-inline comment between selectors.",
       message: messages.expected,
       line: 3,
-      column: 7
+      column: 7,
     },
     {
       code: `
@@ -71,9 +71,9 @@ testRule({
       description: "Non-inline comment (before a decl)",
       message: messages.expected,
       line: 3,
-      column: 9
-    }
-  ]
+      column: 9,
+    },
+  ],
 });
 
 testRule({
@@ -90,8 +90,8 @@ testRule({
 a {} // Inline comment, outside a ruleset.
 </style>
 // Just text
-`
-    }
+`,
+    },
   ],
 
   reject: [
@@ -108,9 +108,9 @@ a {
 `,
       message: messages.expected,
       line: 5,
-      column: 3
-    }
-  ]
+      column: 3,
+    },
+  ],
 });
 
 testRule({
@@ -128,9 +128,9 @@ testRule({
         top: 0;
       }
     `,
-      description: "stylelint command non-inline comment."
-    }
-  ]
+      description: "stylelint command non-inline comment.",
+    },
+  ],
 });
 
 // -------------------------------------------------------------------------
@@ -148,19 +148,19 @@ testRule({
       code: `
       // comment
     `,
-      description: "Non-inline comment, outside rulesets."
+      description: "Non-inline comment, outside rulesets.",
     },
     {
       code: `// comment
     `,
-      description: "Non-inline comment, the very start of the stylesheet."
+      description: "Non-inline comment, the very start of the stylesheet.",
     },
     {
       code: `
       a { color: red; }
       // Non-inline comment, outside rulesets.
     `,
-      description: "Non-inline comment, outside rulesets."
+      description: "Non-inline comment, outside rulesets.",
     },
     {
       code: `
@@ -168,15 +168,15 @@ testRule({
         color: red; /* Inline CSS comment, ignored */
       }
     `,
-      description: "Inline CSS comment, ignored."
-    }
+      description: "Inline CSS comment, ignored.",
+    },
   ],
 
   reject: [
     {
       code: "a {} // comment",
       message: messages.rejected,
-      description: "Inline comment, outside a ruleset."
+      description: "Inline comment, outside a ruleset.",
     },
     {
       code: `
@@ -187,7 +187,7 @@ testRule({
       message: messages.rejected,
       description: "Inline comment, inside a ruleset.",
       line: 3,
-      column: 34
+      column: 34,
     },
     {
       code: `
@@ -199,9 +199,9 @@ testRule({
       message: messages.rejected,
       description: "Inline comment, between selectors.",
       line: 2,
-      column: 10
-    }
-  ]
+      column: 10,
+    },
+  ],
 });
 
 testRule({
@@ -218,8 +218,8 @@ testRule({
 // comment
 </style>
 // Just text
-`
-    }
+`,
+    },
   ],
 
   reject: [
@@ -233,9 +233,9 @@ a {} // comment
 `,
       message: messages.rejected,
       line: 4,
-      column: 6
-    }
-  ]
+      column: 6,
+    },
+  ],
 });
 
 testRule({
@@ -252,7 +252,7 @@ testRule({
         top: 0;
       }
     `,
-      description: "stylelint command inline comment."
-    }
-  ]
+      description: "stylelint command inline comment.",
+    },
+  ],
 });

--- a/src/rules/double-slash-comment-inline/index.js
+++ b/src/rules/double-slash-comment-inline/index.js
@@ -3,7 +3,7 @@ import {
   findCommentsInRaws,
   namespace,
   optionsHaveIgnored,
-  ruleUrl
+  ruleUrl,
 } from "../../utils";
 import { utils } from "stylelint";
 
@@ -11,11 +11,11 @@ export const ruleName = namespace("double-slash-comment-inline");
 
 export const messages = utils.ruleMessages(ruleName, {
   expected: "Expected //-comment to be inline comment",
-  rejected: "Unexpected inline //-comment"
+  rejected: "Unexpected inline //-comment",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 const stylelintCommandPrefix = "stylelint-";
@@ -27,14 +27,14 @@ export default function rule(expectation, options) {
       ruleName,
       {
         actual: expectation,
-        possible: ["always", "never"]
+        possible: ["always", "never"],
       },
       {
         actual: options,
         possible: {
-          ignore: ["stylelint-commands"]
+          ignore: ["stylelint-commands"],
         },
-        optional: true
+        optional: true,
       }
     );
 
@@ -53,7 +53,7 @@ export default function rule(expectation, options) {
 
       const comments = findCommentsInRaws(rootString);
 
-      comments.forEach(comment => {
+      comments.forEach((comment) => {
         // Only process // comments
         if (comment.type !== "double-slash") {
           return;
@@ -83,7 +83,7 @@ export default function rule(expectation, options) {
           node: root,
           index: comment.source.start,
           result,
-          ruleName
+          ruleName,
         });
       });
     }

--- a/src/rules/double-slash-comment-whitespace-inside/__tests__/index.js
+++ b/src/rules/double-slash-comment-whitespace-inside/__tests__/index.js
@@ -13,35 +13,35 @@ testRule({
   accept: [
     {
       code: "// Comment with one space",
-      description: "{always} // Comment with one space."
+      description: "{always} // Comment with one space.",
     },
     {
       code: "//    Comment with multiple spaces",
-      description: "{always} //    Comment with multiple spaces."
+      description: "{always} //    Comment with multiple spaces.",
     },
     {
       code: "/// 3-slash comment with space",
-      description: "{always} /// 3-slash comment with space."
+      description: "{always} /// 3-slash comment with space.",
     },
     {
       code: "/*CSS comment*/",
-      description: "{always} /*CSS comment*/ (ignored)"
+      description: "{always} /*CSS comment*/ (ignored)",
     },
     {
       code: "///",
-      description: "{always} `///`."
+      description: "{always} `///`.",
     },
     {
       code: "/// ",
-      description: "{always} `/// `."
+      description: "{always} `/// `.",
     },
     {
       code: `
       $breadcrumbs-item-separator-item-rtl: '\\\\';
       $button-background: background('');
       `,
-      description: "should not throw an error (issue #294)"
-    }
+      description: "should not throw an error (issue #294)",
+    },
   ],
 
   reject: [
@@ -50,14 +50,14 @@ testRule({
       description: "{always} //Comment with no whitespace",
       message: messages.expected,
       line: 1,
-      column: 3
+      column: 3,
     },
     {
       code: "///3-slash comment with no whitespace",
       description: "{always} ///3-slash comment with no whitespace",
       message: messages.expected,
       line: 1,
-      column: 4
+      column: 4,
     },
     {
       code: `
@@ -74,7 +74,7 @@ testRule({
       description: "\r\n\r\n\r\n\r\n  /// 3-slash comment with space.",
       message: messages.expected,
       line: 9,
-      column: 36
+      column: 36,
     },
     {
       code: `
@@ -88,9 +88,9 @@ testRule({
       description: "\r\n\r\n\r\n\r\n  /// 3-slash comment with space.",
       message: messages.expected,
       line: 6,
-      column: 36
-    }
-  ]
+      column: 36,
+    },
+  ],
 });
 
 testRule({
@@ -107,8 +107,8 @@ testRule({
 // Comment with one space
 </style>
 //Just text
-`
-    }
+`,
+    },
   ],
 
   reject: [
@@ -122,9 +122,9 @@ testRule({
 `,
       message: messages.expected,
       line: 4,
-      column: 3
-    }
-  ]
+      column: 3,
+    },
+  ],
 });
 
 // -------------------------------------------------------------------------
@@ -140,24 +140,24 @@ testRule({
   accept: [
     {
       code: "//Comment with no whitespace",
-      description: "{never} //Comment with no whitespace"
+      description: "{never} //Comment with no whitespace",
     },
     {
       code: "///3-slash comment with no whitespace",
-      description: "{never} ///3-slash comment with no whitespace"
+      description: "{never} ///3-slash comment with no whitespace",
     },
     {
       code: "/*   CSS comment  */",
-      description: "{never} /*   CSS comment  */ (ignored)"
+      description: "{never} /*   CSS comment  */ (ignored)",
     },
     {
       code: "///",
-      description: "{never} `///`."
+      description: "{never} `///`.",
     },
     {
       code: "/// ",
-      description: "{never} `/// `."
-    }
+      description: "{never} `/// `.",
+    },
   ],
 
   reject: [
@@ -166,28 +166,28 @@ testRule({
       description: "{never} // Comment with one space.",
       message: messages.rejected,
       line: 1,
-      column: 3
+      column: 3,
     },
     {
       code: "//    Comment with multiple spaces",
       description: "{never} //    Comment with multiple spaces.",
       message: messages.rejected,
       line: 1,
-      column: 3
+      column: 3,
     },
     {
       code: "\n\n\n\n  /// 3-slash comment with space",
       description: "\n\n\n\n  /// 3-slash comment with space.",
       message: messages.rejected,
       line: 5,
-      column: 6
+      column: 6,
     },
     {
       code: "\r\n\r\n\r\n\r\n  /// 3-slash comment with space",
       description: "\r\n\r\n\r\n\r\n  /// 3-slash comment with space.",
       message: messages.rejected,
       line: 5,
-      column: 6
+      column: 6,
     },
     {
       code: `
@@ -199,9 +199,9 @@ testRule({
       description: "\r\n\r\n\r\n\r\n  /// 3-slash comment with space.",
       message: messages.rejected,
       line: 5,
-      column: 10
-    }
-  ]
+      column: 10,
+    },
+  ],
 });
 
 testRule({
@@ -218,8 +218,8 @@ testRule({
 //Comment with one space
 </style>
 // Just text
-`
-    }
+`,
+    },
   ],
 
   reject: [
@@ -233,7 +233,7 @@ testRule({
 `,
       message: messages.rejected,
       line: 4,
-      column: 3
-    }
-  ]
+      column: 3,
+    },
+  ],
 });

--- a/src/rules/double-slash-comment-whitespace-inside/index.js
+++ b/src/rules/double-slash-comment-whitespace-inside/index.js
@@ -5,18 +5,18 @@ export const ruleName = namespace("double-slash-comment-whitespace-inside");
 
 export const messages = utils.ruleMessages(ruleName, {
   expected: "Expected a space after //",
-  rejected: "Unexpected space after //"
+  rejected: "Unexpected space after //",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(expectation) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: expectation,
-      possible: ["always", "never"]
+      possible: ["always", "never"],
     });
 
     if (!validOptions) {
@@ -34,7 +34,7 @@ export default function rule(expectation) {
 
       const comments = findCommentsInRaws(rootString);
 
-      comments.forEach(comment => {
+      comments.forEach((comment) => {
         // Only process // comments
         if (comment.type !== "double-slash") {
           return;
@@ -61,7 +61,7 @@ export default function rule(expectation) {
           node: root,
           index: comment.source.start + comment.raws.startToken.length,
           result,
-          ruleName
+          ruleName,
         });
       });
     }

--- a/src/rules/function-color-relative/__tests__/index.js
+++ b/src/rules/function-color-relative/__tests__/index.js
@@ -12,7 +12,7 @@ testRule({
           color: scale-color(blue, $alpha: -40%);
         }
       `,
-      description: "accepts the scalar-color function"
+      description: "accepts the scalar-color function",
     },
     {
       code: `
@@ -20,7 +20,7 @@ testRule({
           filter: saturate(50%);
         }
       `,
-      description: "ignores a color function inside the filter property"
+      description: "ignores a color function inside the filter property",
     },
     {
       code: `
@@ -29,8 +29,8 @@ testRule({
         }
       `,
       description:
-        "ignores a color function inside the filter property when multiple values are used"
-    }
+        "ignores a color function inside the filter property when multiple values are used",
+    },
   ],
 
   reject: [
@@ -43,7 +43,7 @@ testRule({
       description: "does not accept the saturate function",
       message: messages.rejected,
       line: 3,
-      column: 18
+      column: 18,
     },
     {
       code: `
@@ -54,7 +54,7 @@ testRule({
       description: "does not accept the desaturate function",
       message: messages.rejected,
       line: 3,
-      column: 18
+      column: 18,
     },
     {
       code: `
@@ -65,7 +65,7 @@ testRule({
       description: "does not accept the darken function",
       message: messages.rejected,
       line: 3,
-      column: 18
+      column: 18,
     },
     {
       code: `
@@ -76,7 +76,7 @@ testRule({
       description: "does not accept the lighten function",
       message: messages.rejected,
       line: 3,
-      column: 18
+      column: 18,
     },
     {
       code: `
@@ -87,7 +87,7 @@ testRule({
       description: "does not accept the opacify function",
       message: messages.rejected,
       line: 3,
-      column: 18
+      column: 18,
     },
     {
       code: `
@@ -98,7 +98,7 @@ testRule({
       description: "does not accept the fade-in function",
       message: messages.rejected,
       line: 3,
-      column: 18
+      column: 18,
     },
     {
       code: `
@@ -109,7 +109,7 @@ testRule({
       description: "does not accept the transparentize function",
       message: messages.rejected,
       line: 3,
-      column: 18
+      column: 18,
     },
     {
       code: `
@@ -120,7 +120,7 @@ testRule({
       description: "does not accept the fade-out function",
       message: messages.rejected,
       line: 3,
-      column: 18
+      column: 18,
     },
     {
       code: `
@@ -132,7 +132,7 @@ testRule({
         "does not accept color functions inside a drop-shadow filter",
       message: messages.rejected,
       line: 3,
-      column: 39
+      column: 39,
     },
     {
       code: `
@@ -144,7 +144,7 @@ testRule({
         "does not accept color functions inside a drop-shadow filter when multiple filters are used",
       message: messages.rejected,
       line: 3,
-      column: 54
+      column: 54,
     },
     {
       code: `
@@ -156,7 +156,7 @@ testRule({
         "does not accept color functions inside a drop-shadow filter when multiple filters are used",
       message: messages.rejected,
       line: 3,
-      column: 53
+      column: 53,
     },
     {
       code: `
@@ -168,7 +168,7 @@ testRule({
         "does not accept color functions inside a drop-shadow filter when multiple filters are used",
       message: messages.rejected,
       line: 3,
-      column: 39
-    }
-  ]
+      column: 39,
+    },
+  ],
 });

--- a/src/rules/function-color-relative/index.js
+++ b/src/rules/function-color-relative/index.js
@@ -5,11 +5,11 @@ import { declarationValueIndex, namespace, ruleUrl } from "../../utils";
 export const ruleName = namespace("function-color-relative");
 
 export const messages = utils.ruleMessages(ruleName, {
-  rejected: "Expected the scale-color function to be used"
+  rejected: "Expected the scale-color function to be used",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 const function_names = [
@@ -20,7 +20,7 @@ const function_names = [
   "opacify",
   "fade-in",
   "transparentize",
-  "fade-out"
+  "fade-out",
 ];
 
 function isColorFunction(node) {
@@ -30,15 +30,15 @@ function isColorFunction(node) {
 export default function rule(primary) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
-      actual: primary
+      actual: primary,
     });
 
     if (!validOptions) {
       return;
     }
 
-    root.walkDecls(decl => {
-      valueParser(decl.value).walk(node => {
+    root.walkDecls((decl) => {
+      valueParser(decl.value).walk((node) => {
         // Verify that we're only looking at functions.
         if (node.type !== "function" || node.value === "") {
           return;
@@ -56,13 +56,13 @@ export default function rule(primary) {
             ? node.nodes.filter(isColorFunction)
             : [node];
 
-          nodes.forEach(node => {
+          nodes.forEach((node) => {
             utils.report({
               message: messages.rejected,
               node: decl,
               index: declarationValueIndex(decl) + node.sourceIndex,
               result,
-              ruleName
+              ruleName,
             });
           });
         }

--- a/src/rules/function-no-unknown/__tests__/index.js
+++ b/src/rules/function-no-unknown/__tests__/index.js
@@ -8,22 +8,22 @@ testRule({
   accept: [
     {
       code: "a { color: hwb(240 100% 50%); }",
-      description: "Normal CSS function"
+      description: "Normal CSS function",
     },
     {
       code: "a { color: hsl(240 100% 50%); }",
-      description: "Function both in CSS and SCSS"
+      description: "Function both in CSS and SCSS",
     },
     {
       code: "a { color: if(true, green, red); }",
-      description: "SCSS function"
+      description: "SCSS function",
     },
     {
-      code: "a { color: adjust-color(#6b717f, $red: 15); }"
+      code: "a { color: adjust-color(#6b717f, $red: 15); }",
     },
     {
-      code: "a { color: color.adjust(#6b717f, $red: 15); }"
-    }
+      code: "a { color: color.adjust(#6b717f, $red: 15); }",
+    },
   ],
 
   reject: [
@@ -31,15 +31,15 @@ testRule({
       code: "a { color: unknown(1); }",
       message: messages.rejected("unknown"),
       line: 1,
-      column: 12
+      column: 12,
     },
     {
       code: "a { color: color.unknown(#6b717f, $red: 15); }",
       message: messages.rejected("color.unknown"),
       line: 1,
-      column: 12
-    }
-  ]
+      column: 12,
+    },
+  ],
 });
 
 testRule({
@@ -49,17 +49,17 @@ testRule({
 
   accept: [
     {
-      code: "a { color: my-func(1); }"
+      code: "a { color: my-func(1); }",
     },
     {
-      code: "a { color: MY-FUNC(1); }"
+      code: "a { color: MY-FUNC(1); }",
     },
     {
-      code: "a { color: func-foo(1); }"
+      code: "a { color: func-foo(1); }",
     },
     {
-      code: "a { color: bar(1); }"
-    }
+      code: "a { color: bar(1); }",
+    },
   ],
 
   reject: [
@@ -67,19 +67,19 @@ testRule({
       code: "a { color: my(1); }",
       message: messages.rejected("my"),
       line: 1,
-      column: 12
+      column: 12,
     },
     {
       code: "a { color: foo-func(1); }",
       message: messages.rejected("foo-func"),
       line: 1,
-      column: 12
+      column: 12,
     },
     {
       code: "a { color: barrr(1); }",
       message: messages.rejected("barrr"),
       line: 1,
-      column: 12
-    }
-  ]
+      column: 12,
+    },
+  ],
 });

--- a/src/rules/function-no-unknown/index.js
+++ b/src/rules/function-no-unknown/index.js
@@ -12,11 +12,11 @@ export const messages = utils.ruleMessages(ruleName, {
     return rules[ruleToCheckAgainst].messages
       .rejected(...args)
       .replace(` (${ruleToCheckAgainst})`, "");
-  }
+  },
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(primaryOption, secondaryOptions) {
@@ -25,14 +25,14 @@ export default function rule(primaryOption, secondaryOptions) {
       result,
       ruleName,
       {
-        actual: primaryOption
+        actual: primaryOption,
       },
       {
         actual: secondaryOptions,
         possible: {
-          ignoreFunctions: [isString, isRegExp]
+          ignoreFunctions: [isString, isRegExp],
         },
-        optional: true
+        optional: true,
       }
     );
 
@@ -45,20 +45,20 @@ export default function rule(primaryOption, secondaryOptions) {
     const ignoreFunctions = ALL_FUNCTIONS.concat(optionsFunctions);
     const ignoreFunctionsAsSet = new Set(ignoreFunctions);
     const newSecondaryOptions = Object.assign({}, secondaryOptions, {
-      ignoreFunctions
+      ignoreFunctions,
     });
 
     utils.checkAgainstRule(
       {
         ruleName: ruleToCheckAgainst,
         ruleSettings: [primaryOption, newSecondaryOptions],
-        root
+        root,
       },
-      warning => {
+      (warning) => {
         const { node, index } = warning;
 
         // NOTE: Using `valueParser` is necessary for extracting a function name. This may be a performance waste.
-        valueParser(node.value).walk(valueNode => {
+        valueParser(node.value).walk((valueNode) => {
           const { type, value: funcName } = valueNode;
 
           if (type !== "function") {
@@ -71,7 +71,7 @@ export default function rule(primaryOption, secondaryOptions) {
               ruleName,
               result,
               node,
-              index
+              index,
             });
           }
         });

--- a/src/rules/function-quote-no-quoted-strings-inside/__tests__/index.js
+++ b/src/rules/function-quote-no-quoted-strings-inside/__tests__/index.js
@@ -14,7 +14,7 @@ testRule({
           font-family: quote(Helvetica);
         }
       `,
-      description: "accepts strings without quotes"
+      description: "accepts strings without quotes",
     },
     {
       code: `
@@ -23,8 +23,8 @@ testRule({
           font-family: quote($font);
         }
       `,
-      description: "accepts variables representing strings that are unquoted."
-    }
+      description: "accepts variables representing strings that are unquoted.",
+    },
   ],
 
   reject: [
@@ -42,7 +42,7 @@ testRule({
         p {
           font-family: "Helvetica";
         }
-      `
+      `,
     },
     {
       code: `
@@ -61,7 +61,7 @@ testRule({
         p {
           font-family: $font;
         }
-      `
-    }
-  ]
+      `,
+    },
+  ],
 });

--- a/src/rules/function-quote-no-quoted-strings-inside/index.js
+++ b/src/rules/function-quote-no-quoted-strings-inside/index.js
@@ -4,23 +4,23 @@ import {
   declarationValueIndex,
   isNativeCssFunction,
   namespace,
-  ruleUrl
+  ruleUrl,
 } from "../../utils";
 
 export const ruleName = namespace("function-quote-no-quoted-strings-inside");
 
 export const messages = utils.ruleMessages(ruleName, {
-  rejected: "Quote function used with an already-quoted string"
+  rejected: "Quote function used with an already-quoted string",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(primary, _, context) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
-      actual: primary
+      actual: primary,
     });
 
     if (!validOptions) {
@@ -30,18 +30,18 @@ export default function rule(primary, _, context) {
     // Setup variable naming.
     const vars = {};
 
-    root.walkDecls(decl => {
+    root.walkDecls((decl) => {
       if (decl.prop[0] !== "$") {
         return;
       }
 
-      valueParser(decl.value).walk(node => {
+      valueParser(decl.value).walk((node) => {
         vars[decl.prop] = node.type;
       });
     });
 
-    root.walkDecls(decl => {
-      valueParser(decl.value).walk(node => {
+    root.walkDecls((decl) => {
+      valueParser(decl.value).walk((node) => {
         // Verify that we're only looking at functions.
         if (
           node.type !== "function" ||
@@ -69,7 +69,7 @@ export default function rule(primary, _, context) {
               node: decl,
               index: declarationValueIndex(decl) + node.sourceIndex,
               result,
-              ruleName
+              ruleName,
             });
           }
         }

--- a/src/rules/function-unquote-no-unquoted-strings-inside/__tests__/index.js
+++ b/src/rules/function-unquote-no-unquoted-strings-inside/__tests__/index.js
@@ -14,7 +14,7 @@ testRule({
           font-family: unquote("Helvetica");
         }
       `,
-      description: "accepts strings with quotes"
+      description: "accepts strings with quotes",
     },
     {
       code: `
@@ -23,8 +23,8 @@ testRule({
           font-family: unquote($font);
         }
       `,
-      description: "accepts variables representing strings that are quoted."
-    }
+      description: "accepts variables representing strings that are quoted.",
+    },
   ],
 
   reject: [
@@ -42,7 +42,7 @@ testRule({
         p {
           font-family: Helvetica;
         }
-      `
+      `,
     },
     {
       code: `
@@ -61,7 +61,7 @@ testRule({
         p {
           font-family: $font;
         }
-      `
-    }
-  ]
+      `,
+    },
+  ],
 });

--- a/src/rules/function-unquote-no-unquoted-strings-inside/index.js
+++ b/src/rules/function-unquote-no-unquoted-strings-inside/index.js
@@ -4,7 +4,7 @@ import {
   declarationValueIndex,
   isNativeCssFunction,
   namespace,
-  ruleUrl
+  ruleUrl,
 } from "../../utils";
 
 export const ruleName = namespace(
@@ -12,17 +12,17 @@ export const ruleName = namespace(
 );
 
 export const messages = utils.ruleMessages(ruleName, {
-  rejected: "Unquote function used with an already-unquoted string"
+  rejected: "Unquote function used with an already-unquoted string",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(primary, _, context) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
-      actual: primary
+      actual: primary,
     });
 
     if (!validOptions) {
@@ -32,18 +32,18 @@ export default function rule(primary, _, context) {
     // Setup variable naming.
     const vars = {};
 
-    root.walkDecls(decl => {
+    root.walkDecls((decl) => {
       if (decl.prop[0] !== "$") {
         return;
       }
 
-      valueParser(decl.value).walk(node => {
+      valueParser(decl.value).walk((node) => {
         vars[decl.prop] = node.type;
       });
     });
 
-    root.walkDecls(decl => {
-      valueParser(decl.value).walk(node => {
+    root.walkDecls((decl) => {
+      valueParser(decl.value).walk((node) => {
         // Verify that we're only looking at functions.
         if (
           node.type !== "function" ||
@@ -74,7 +74,7 @@ export default function rule(primary, _, context) {
               node: decl,
               index: declarationValueIndex(decl) + node.sourceIndex,
               result,
-              ruleName
+              ruleName,
             });
           }
         }

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -85,7 +85,8 @@ export default {
   "comment-no-empty": commentNoEmpty,
   "comment-no-loud": commentNoLoud,
   "declaration-nested-properties": declarationNestedProperties,
-  "declaration-nested-properties-no-divided-groups": declarationNestedPropertiesNoDividedGroups,
+  "declaration-nested-properties-no-divided-groups":
+    declarationNestedPropertiesNoDividedGroups,
   "dimension-no-non-numeric-values": dimensionNoNonNumeric,
   "dollar-variable-colon-newline-after": dollarVariableColonNewlineAfter,
   "dollar-variable-colon-space-after": dollarVariableColonSpaceAfter,
@@ -94,8 +95,10 @@ export default {
   "dollar-variable-empty-line-after": dollarVariableEmptyLineAfter,
   "dollar-variable-empty-line-before": dollarVariableEmptyLineBefore,
   "dollar-variable-first-in-block": dollarVariableFirstInBlock,
-  "dollar-variable-no-missing-interpolation": dollarVariableNoMissingInterpolation,
-  "dollar-variable-no-namespaced-assignment": dollarVariableNoNamespacedAssignment,
+  "dollar-variable-no-missing-interpolation":
+    dollarVariableNoMissingInterpolation,
+  "dollar-variable-no-namespaced-assignment":
+    dollarVariableNoNamespacedAssignment,
   "dollar-variable-pattern": dollarVariablePattern,
   "double-slash-comment-empty-line-before": doubleSlashCommentEmptyLineBefore,
   "double-slash-comment-inline": doubleSlashCommentInline,
@@ -117,5 +120,5 @@ export default {
   "partial-no-import": partialNoImport,
   "selector-nest-combinators": selectorNestCombinators,
   "selector-no-redundant-nesting-selector": selectorNoRedundantNestingSelector,
-  "selector-no-union-class-name": selectorNoUnionClassName
+  "selector-no-union-class-name": selectorNoUnionClassName,
 };

--- a/src/rules/map-keys-quotes/__tests__/index.js
+++ b/src/rules/map-keys-quotes/__tests__/index.js
@@ -10,13 +10,13 @@ testRule({
       code: `
         $test: ("foo": 14px, "bar": 25px);
       `,
-      description: "accepts strings without quotes"
+      description: "accepts strings without quotes",
     },
     {
       code: `
         $test: ('foo': 14px, 'bar': 25px);
       `,
-      description: "accepts strings with quotes"
+      description: "accepts strings with quotes",
     },
     {
       code: `
@@ -29,7 +29,7 @@ testRule({
         900: #2e4662
       );
       `,
-      description: "accepts numbers"
+      description: "accepts numbers",
     },
     {
       code: `
@@ -44,7 +44,7 @@ testRule({
         )
       );
       `,
-      description: "accepts numbers (nested)"
+      description: "accepts numbers (nested)",
     },
     {
       code: `
@@ -53,7 +53,7 @@ testRule({
         "key-two": $variable * 2,
       );
       `,
-      description: "accepts * operator inside a value"
+      description: "accepts * operator inside a value",
     },
     {
       code: `
@@ -62,7 +62,7 @@ testRule({
         "key-two": $variable*2,
       );
       `,
-      description: "accepts * operator without spaces inside a value"
+      description: "accepts * operator without spaces inside a value",
     },
     {
       code: `
@@ -71,7 +71,7 @@ testRule({
         "key-two": $variable - 2,
       );
       `,
-      description: "accepts - operator inside a value"
+      description: "accepts - operator inside a value",
     },
     {
       code: `
@@ -80,7 +80,7 @@ testRule({
         "key-two": $variable + 2,
       );
       `,
-      description: "accepts + operator inside a value"
+      description: "accepts + operator inside a value",
     },
     {
       code: `
@@ -89,7 +89,7 @@ testRule({
         "key-two": $variable / 2,
       );
       `,
-      description: "accepts / operator inside a value"
+      description: "accepts / operator inside a value",
     },
     {
       code: `
@@ -98,7 +98,7 @@ testRule({
         "key-two": $variable % 2,
       );
       `,
-      description: "accepts % operator inside a value"
+      description: "accepts % operator inside a value",
     },
     {
       code: `
@@ -107,8 +107,8 @@ testRule({
         "key-two": (1+2),
       );
       `,
-      description: "accepts parens inside a value"
-    }
+      description: "accepts parens inside a value",
+    },
   ],
 
   reject: [
@@ -120,16 +120,16 @@ testRule({
         {
           line: 2,
           column: 9,
-          message: messages.expected
+          message: messages.expected,
         },
         {
           line: 2,
           column: 9,
-          message: messages.expected
-        }
+          message: messages.expected,
+        },
       ],
       description:
-        "does not accept variables representing strings that are quoted."
-    }
-  ]
+        "does not accept variables representing strings that are quoted.",
+    },
+  ],
 });

--- a/src/rules/map-keys-quotes/index.js
+++ b/src/rules/map-keys-quotes/index.js
@@ -5,11 +5,11 @@ import { namespace, ruleUrl } from "../../utils";
 export const ruleName = namespace("map-keys-quotes");
 
 export const messages = utils.ruleMessages(ruleName, {
-  expected: "Expected keys in map to be quoted."
+  expected: "Expected keys in map to be quoted.",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 const mathOperators = ["+", "/", "-", "*", "%"];
@@ -18,19 +18,19 @@ export default function rule(primary) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: primary,
-      possible: ["always"]
+      possible: ["always"],
     });
 
     if (!validOptions) {
       return;
     }
 
-    root.walkDecls(decl => {
+    root.walkDecls((decl) => {
       if (decl.prop[0] !== "$") {
         return;
       }
 
-      valueParser(decl.value).walk(node => {
+      valueParser(decl.value).walk((node) => {
         if (
           node.type === "function" &&
           node.value === "" &&
@@ -39,7 +39,7 @@ export default function rule(primary) {
           // Identify all of the map-keys and see if they're strings (not words).
           const mapKeys = returnMapKeys(node.nodes);
 
-          mapKeys.forEach(map_key => {
+          mapKeys.forEach((map_key) => {
             if (mathOperators.includes(map_key.value)) {
               return;
             }
@@ -49,7 +49,7 @@ export default function rule(primary) {
                 message: messages.expected,
                 node: decl,
                 result,
-                ruleName
+                ruleName,
               });
             }
           });

--- a/src/rules/media-feature-value-dollar-variable/__tests__/index.js
+++ b/src/rules/media-feature-value-dollar-variable/__tests__/index.js
@@ -13,7 +13,7 @@ testRule({
         .navbar { display: none; }
       }
     `,
-      description: "Always. Example: no value."
+      description: "Always. Example: no value.",
     },
     {
       code: `
@@ -21,7 +21,7 @@ testRule({
         a { display: none; }
       }
     `,
-      description: "Always. Example: value is a var."
+      description: "Always. Example: value is a var.",
     },
     {
       code: `
@@ -29,7 +29,7 @@ testRule({
         a { display: none; }
       }
     `,
-      description: "Always. Example: value is interpolation of a single var."
+      description: "Always. Example: value is interpolation of a single var.",
     },
     {
       code: `
@@ -38,7 +38,7 @@ testRule({
       }
     `,
       description:
-        "Always. Example: value is interpolation of a single var; space after the interpolation."
+        "Always. Example: value is interpolation of a single var; space after the interpolation.",
     },
     {
       code: `
@@ -47,7 +47,7 @@ testRule({
       }
     `,
       description:
-        "Always. Example: value is interpolation of a single var spaces inside the interpolation."
+        "Always. Example: value is interpolation of a single var spaces inside the interpolation.",
     },
     {
       code: `
@@ -56,8 +56,8 @@ testRule({
       }
     `,
       description:
-        "Always. Example: value is interpolation of a single var; spaces before and after the interpolation."
-    }
+        "Always. Example: value is interpolation of a single var; spaces before and after the interpolation.",
+    },
   ],
 
   reject: [
@@ -70,7 +70,7 @@ testRule({
       line: 2,
       column: 26,
       message: messages.expected,
-      description: "Always. Example: value is not a var, space before."
+      description: "Always. Example: value is not a var, space before.",
     },
     {
       code: `
@@ -81,7 +81,7 @@ testRule({
       line: 2,
       column: 25,
       message: messages.expected,
-      description: "Always. Example: value is not a var, no spaces."
+      description: "Always. Example: value is not a var, no spaces.",
     },
     {
       code: `
@@ -94,7 +94,7 @@ testRule({
       column: 19,
       message: messages.expected,
       description:
-        "Always. Example: value is not a var, newline before statement."
+        "Always. Example: value is not a var, newline before statement.",
     },
     {
       code: `
@@ -106,7 +106,7 @@ testRule({
       line: 3,
       column: 9,
       message: messages.expected,
-      description: "Always. Example: value is not a var, newline before value."
+      description: "Always. Example: value is not a var, newline before value.",
     },
     {
       code: `
@@ -118,7 +118,7 @@ testRule({
       line: 2,
       column: 37,
       message: messages.expected,
-      description: "Always. Example: value is not a var, newline after value."
+      description: "Always. Example: value is not a var, newline after value.",
     },
     {
       code: `
@@ -131,7 +131,7 @@ testRule({
       line: 4,
       column: 19,
       message: messages.expected,
-      description: "Always. Example: multiple statements, one has non-var."
+      description: "Always. Example: multiple statements, one has non-var.",
     },
     {
       code: `
@@ -143,7 +143,7 @@ testRule({
       column: 37,
       message: messages.expected,
       description:
-        "Always. Example: value is a math op on an interpolation of a single var and a regular value."
+        "Always. Example: value is a math op on an interpolation of a single var and a regular value.",
     },
     {
       code: `
@@ -155,7 +155,7 @@ testRule({
       column: 37,
       message: messages.expected,
       description:
-        "Always. Example: value is an interpolation of a math op on a var and a regular value."
+        "Always. Example: value is an interpolation of a math op on a var and a regular value.",
     },
     {
       code: `
@@ -167,7 +167,7 @@ testRule({
       column: 37,
       message: messages.expected,
       description:
-        "Always. Example: value is an interpolation of a math op on a var and a var."
+        "Always. Example: value is an interpolation of a math op on a var and a var.",
     },
     {
       code: `
@@ -178,7 +178,7 @@ testRule({
       line: 2,
       column: 37,
       message: messages.expected,
-      description: "Always. Example: math operation without a var as a value."
+      description: "Always. Example: math operation without a var as a value.",
     },
     {
       code: `
@@ -189,7 +189,7 @@ testRule({
       line: 2,
       column: 37,
       message: messages.expected,
-      description: "Always. Example: math operation with a var as a value."
+      description: "Always. Example: math operation with a var as a value.",
     },
     {
       code: `
@@ -200,7 +200,7 @@ testRule({
       line: 2,
       column: 37,
       message: messages.expected,
-      description: "Always. Example: math operation with a var as a value."
+      description: "Always. Example: math operation with a var as a value.",
     },
     {
       code: `
@@ -211,7 +211,7 @@ testRule({
       line: 2,
       column: 37,
       message: messages.expected,
-      description: "Always. Example: function call as a value."
+      description: "Always. Example: function call as a value.",
     },
     {
       code: `
@@ -222,9 +222,9 @@ testRule({
       line: 2,
       column: 35,
       message: messages.expected,
-      description: "Always. Example: keyword as a value."
-    }
-  ]
+      description: "Always. Example: keyword as a value.",
+    },
+  ],
 });
 
 // Not allowed ("never")
@@ -240,7 +240,7 @@ testRule({
         .navbar { display: none; }
       }
     `,
-      description: "Never. Example: no value."
+      description: "Never. Example: no value.",
     },
     {
       code: `
@@ -248,7 +248,7 @@ testRule({
         b { color: red; }
       }
     `,
-      description: "Never. Example: math operation without a var as a value."
+      description: "Never. Example: math operation without a var as a value.",
     },
     {
       code: `
@@ -257,8 +257,8 @@ testRule({
         b { color: red; }
       }
     `,
-      description: "Never. Example: value is not a var, newline before value."
-    }
+      description: "Never. Example: value is not a var, newline before value.",
+    },
   ],
 
   reject: [
@@ -271,7 +271,7 @@ testRule({
       line: 2,
       column: 37,
       message: messages.rejected,
-      description: "Never. Example: value is a var."
+      description: "Never. Example: value is a var.",
     },
     {
       code: `
@@ -284,7 +284,7 @@ testRule({
       line: 3,
       column: 19,
       message: messages.rejected,
-      description: "Never. Example: multiple statements, one has non-var."
+      description: "Never. Example: multiple statements, one has non-var.",
     },
     {
       code: `
@@ -296,7 +296,7 @@ testRule({
       column: 37,
       message: messages.rejected,
       description:
-        "Never. Example: function call and with a var as a parameter."
+        "Never. Example: function call and with a var as a parameter.",
     },
     {
       code: `
@@ -306,7 +306,7 @@ testRule({
     `,
       message: messages.rejected,
       description:
-        "Never. Example: math operation with a var (not the 1st operand) as a value."
+        "Never. Example: math operation with a var (not the 1st operand) as a value.",
     },
     {
       code: `
@@ -318,9 +318,9 @@ testRule({
       column: 37,
       message: messages.rejected,
       description:
-        "Never. Example: value is an interpolation of a math op on a var and a regular value."
-    }
-  ]
+        "Never. Example: value is an interpolation of a math op on a var and a regular value.",
+    },
+  ],
 });
 
 // Required ("always"), ignore keywords
@@ -336,7 +336,7 @@ testRule({
         a { display: none; }
       }
     `,
-      description: "Always. Example: value is a keyword."
+      description: "Always. Example: value is a keyword.",
     },
     {
       code: `
@@ -344,7 +344,7 @@ testRule({
         a { display: none; }
       }
     `,
-      description: "Always. Example: values contain var and keyword with dash."
+      description: "Always. Example: values contain var and keyword with dash.",
     },
     {
       code: `
@@ -352,9 +352,9 @@ testRule({
         a { display: none; }
       }
     `,
-      description: "Always. Example: value is a keyword with number."
-    }
-  ]
+      description: "Always. Example: value is a keyword with number.",
+    },
+  ],
 });
 
 // Invalid option (false)
@@ -370,7 +370,7 @@ testRule({
         a { display: none; }
       }
     `,
-      description: "Invalid option. Example: values are mixed."
-    }
-  ]
+      description: "Invalid option. Example: values are mixed.",
+    },
+  ],
 });

--- a/src/rules/media-feature-value-dollar-variable/index.js
+++ b/src/rules/media-feature-value-dollar-variable/index.js
@@ -6,11 +6,11 @@ export const ruleName = namespace("media-feature-value-dollar-variable");
 export const messages = utils.ruleMessages(ruleName, {
   rejected: "Unexpected dollar-variable as a media feature value",
   expected:
-    "Expected a dollar-variable (e.g. $var) to be used as a media feature value"
+    "Expected a dollar-variable (e.g. $var) to be used as a media feature value",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(expectation, options) {
@@ -20,14 +20,14 @@ export default function rule(expectation, options) {
       ruleName,
       {
         actual: expectation,
-        possible: ["always", "never"]
+        possible: ["always", "never"],
       },
       {
         actual: options,
         possible: {
-          ignore: ["keywords"]
+          ignore: ["keywords"],
         },
-        optional: true
+        optional: true,
       }
     );
 
@@ -47,7 +47,7 @@ export default function rule(expectation, options) {
     // `none`, `dark`
     const keywordValueRegex = /^[a-z][a-z\d-]*$/;
 
-    root.walkAtRules("media", atRule => {
+    root.walkAtRules("media", (atRule) => {
       const found = atRule.params.match(valueRegexGlobal);
 
       // If there are no values
@@ -55,7 +55,7 @@ export default function rule(expectation, options) {
         return;
       }
 
-      found.forEach(found => {
+      found.forEach((found) => {
         // ... parse `: 10px )` to `10px`
         const valueParsed = found.match(valueRegex)[1];
 
@@ -66,7 +66,7 @@ export default function rule(expectation, options) {
             result,
             node: atRule,
             word: valueParsed,
-            message
+            message,
           });
         }
 

--- a/src/rules/no-dollar-variables/__tests__/index.js
+++ b/src/rules/no-dollar-variables/__tests__/index.js
@@ -8,16 +8,16 @@ testRule({
   accept: [
     {
       code: "a { color: blue; }",
-      description: "No variables"
+      description: "No variables",
     },
     {
       code: "a { @less: 0; @less: @less + 1; }",
-      description: "Less variables are ignored"
+      description: "Less variables are ignored",
     },
     {
       code: "a { --custom-property: 0; --custom-property: 1; }",
-      description: "Custom properties are ignored"
-    }
+      description: "Custom properties are ignored",
+    },
   ],
 
   reject: [
@@ -28,7 +28,7 @@ testRule({
       line: 2,
       column: 7,
       message: messages.rejected("$a"),
-      description: "A dollar variable"
+      description: "A dollar variable",
     },
     {
       code: `
@@ -40,15 +40,15 @@ testRule({
         {
           line: 2,
           column: 7,
-          message: messages.rejected("$a")
+          message: messages.rejected("$a"),
         },
         {
           line: 4,
           column: 7,
-          message: messages.rejected("$b")
-        }
+          message: messages.rejected("$b"),
+        },
       ],
-      description: "Two dollar variables"
+      description: "Two dollar variables",
     },
     {
       code: `
@@ -59,7 +59,7 @@ testRule({
       line: 3,
       column: 9,
       message: messages.rejected("$a"),
-      description: "A dollar variable inside a class selector"
+      description: "A dollar variable inside a class selector",
     },
     {
       code: `
@@ -70,7 +70,7 @@ testRule({
       line: 3,
       column: 9,
       message: messages.rejected("$a"),
-      description: "A dollar variable inside a placeholder selector"
+      description: "A dollar variable inside a placeholder selector",
     },
     {
       code: `
@@ -81,7 +81,7 @@ testRule({
       line: 3,
       column: 9,
       message: messages.rejected("$a"),
-      description: "A dollar variable inside a @mixin"
+      description: "A dollar variable inside a @mixin",
     },
     {
       code: `
@@ -94,7 +94,7 @@ testRule({
       line: 4,
       column: 11,
       message: messages.rejected("$a"),
-      description: "Nested dollar variable"
-    }
-  ]
+      description: "Nested dollar variable",
+    },
+  ],
 });

--- a/src/rules/no-dollar-variables/index.js
+++ b/src/rules/no-dollar-variables/index.js
@@ -4,24 +4,24 @@ import { namespace, ruleUrl } from "../../utils";
 export const ruleName = namespace("no-dollar-variables");
 
 export const messages = utils.ruleMessages(ruleName, {
-  rejected: variable => `Unexpected dollar variable ${variable}`
+  rejected: (variable) => `Unexpected dollar variable ${variable}`,
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(value) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
-      actual: value
+      actual: value,
     });
 
     if (!validOptions) {
       return;
     }
 
-    root.walkDecls(decl => {
+    root.walkDecls((decl) => {
       if (decl.prop[0] !== "$") {
         return;
       }
@@ -30,7 +30,7 @@ export default function rule(value) {
         message: messages.rejected(decl.prop),
         node: decl,
         result,
-        ruleName
+        ruleName,
       });
     });
   };

--- a/src/rules/no-duplicate-dollar-variables/__tests__/index.js
+++ b/src/rules/no-duplicate-dollar-variables/__tests__/index.js
@@ -10,40 +10,41 @@ testRule({
       code: `
       $a: 1;
     `,
-      description: "A single dollar variable."
+      description: "A single dollar variable.",
     },
     {
       code: `
       $a: 1;
       $b: 2;
     `,
-      description: "Two dollar variables with different names."
+      description: "Two dollar variables with different names.",
     },
     {
       code: `
       $a: 1; $b: 2;
     `,
-      description: "Two dollar variables with different names on the same line."
+      description:
+        "Two dollar variables with different names on the same line.",
     },
     {
       code: "a { $a: 0; $b: $a + 1; }",
       description:
-        "Two dollar variables with different names on the same line and variable assign."
+        "Two dollar variables with different names on the same line and variable assign.",
     },
     {
       code: "a { @less: 0; @less: @less + 1; }",
-      description: "Less variables are ignored"
+      description: "Less variables are ignored",
     },
     {
       code: "a { --custom-property: 0; --custom-property: 1; }",
-      description: "Custom properties are ignored"
+      description: "Custom properties are ignored",
     },
     {
       code: `
       $a: 1;
       $ab: 2;
     `,
-      description: "Two dollar variables with different names."
+      description: "Two dollar variables with different names.",
     },
     {
       code: `
@@ -53,7 +54,7 @@ testRule({
       }
     `,
       description:
-        "Two dollar variables with different names and inside a selector."
+        "Two dollar variables with different names and inside a selector.",
     },
     {
       code: `
@@ -62,7 +63,7 @@ testRule({
         color: black;
       }
     `,
-      description: "A single variable and a normal CSS property."
+      description: "A single variable and a normal CSS property.",
     },
     {
       code: `
@@ -73,7 +74,7 @@ testRule({
         $ab: 2;
       }
     `,
-      description: "Two variables in unrelated scopes."
+      description: "Two variables in unrelated scopes.",
     },
     {
       code: `
@@ -84,7 +85,7 @@ testRule({
         $ab: 2;
       }
     `,
-      description: "Two variables in unrelated at-rule scopes."
+      description: "Two variables in unrelated at-rule scopes.",
     },
     {
       code: `
@@ -95,7 +96,7 @@ testRule({
         $ab: 2;
       }
     `,
-      description: "Two variables in unrelated at-rule scope cases."
+      description: "Two variables in unrelated at-rule scope cases.",
     },
     {
       code: `
@@ -103,7 +104,7 @@ testRule({
       $b: 1;
     `,
       description:
-        "Two dollar variables with different names and one containing a default."
+        "Two dollar variables with different names and one containing a default.",
     },
     {
       code: `
@@ -111,7 +112,7 @@ testRule({
       $a: 1;
     `,
       description:
-        "Two dollar variables with same names and one containing a default."
+        "Two dollar variables with same names and one containing a default.",
     },
     {
       code: `
@@ -121,7 +122,7 @@ testRule({
       $b: 1;
     `,
       description:
-        "Two grouped dollar variables and each group contains a default."
+        "Two grouped dollar variables and each group contains a default.",
     },
     {
       code: `
@@ -134,8 +135,8 @@ testRule({
       $c: $c + 5;
     `,
       description:
-        "Three grouped dollar variables and each group contains a default."
-    }
+        "Three grouped dollar variables and each group contains a default.",
+    },
   ],
 
   reject: [
@@ -147,7 +148,7 @@ testRule({
       line: 3,
       column: 7,
       message: messages.rejected("$a"),
-      description: "Two dollar variables with the same name."
+      description: "Two dollar variables with the same name.",
     },
     {
       code: `
@@ -156,7 +157,7 @@ testRule({
       line: 2,
       column: 14,
       message: messages.rejected("$a"),
-      description: "Two dollar variables with the same name on the same line."
+      description: "Two dollar variables with the same name on the same line.",
     },
     {
       code: `
@@ -168,22 +169,22 @@ testRule({
         {
           line: 3,
           column: 7,
-          message: messages.rejected("$a")
+          message: messages.rejected("$a"),
         },
         {
           line: 4,
           column: 7,
-          message: messages.rejected("$a")
-        }
+          message: messages.rejected("$a"),
+        },
       ],
-      description: "Three dollar variables with the same name."
+      description: "Three dollar variables with the same name.",
     },
     {
       code: "a { $scss: 0; $scss: $scss + 1; }",
       line: 1,
       column: 15,
       message: messages.rejected("$scss"),
-      description: "Two dollar variables with the same name inside a selector."
+      description: "Two dollar variables with the same name inside a selector.",
     },
     {
       code: `
@@ -194,7 +195,7 @@ testRule({
       line: 4,
       column: 7,
       message: messages.rejected("$a"),
-      description: "Two dollar variables with the same name, variable between."
+      description: "Two dollar variables with the same name, variable between.",
     },
     {
       code: `
@@ -208,7 +209,7 @@ testRule({
       column: 7,
       message: messages.rejected("$a"),
       description:
-        "Two dollar variables with the same name, variable and newlines between."
+        "Two dollar variables with the same name, variable and newlines between.",
     },
     {
       code: `
@@ -221,7 +222,7 @@ testRule({
       column: 9,
       message: messages.rejected("$ab"),
       description:
-        "Two dollar variables with the same name and inside a selector."
+        "Two dollar variables with the same name and inside a selector.",
     },
     {
       code: `
@@ -235,7 +236,7 @@ testRule({
       line: 5,
       column: 11,
       message: messages.rejected("$ab"),
-      description: "Two dollar variables with the same name and nested @mixin."
+      description: "Two dollar variables with the same name and nested @mixin.",
     },
     {
       code: `
@@ -250,7 +251,7 @@ testRule({
       column: 11,
       message: messages.rejected("$ab"),
       description:
-        "Two dollar variables with the same name and nesting selector."
+        "Two dollar variables with the same name and nesting selector.",
     },
     {
       code: `
@@ -267,7 +268,7 @@ testRule({
       line: 4,
       column: 9,
       message: messages.rejected("$a"),
-      description: "Two dollar variables with the same name and @mixin."
+      description: "Two dollar variables with the same name and @mixin.",
     },
     {
       code: `
@@ -285,7 +286,7 @@ testRule({
       column: 11,
       message: messages.rejected("$ab"),
       description:
-        "Two dollar variables with the same name and multi-level nesting."
+        "Two dollar variables with the same name and multi-level nesting.",
     },
     {
       code: `
@@ -302,7 +303,7 @@ testRule({
       column: 11,
       message: messages.rejected("$ab"),
       description:
-        "Two dollar variables with the same name and multi-level nesting."
+        "Two dollar variables with the same name and multi-level nesting.",
     },
     {
       code: `
@@ -323,7 +324,7 @@ testRule({
       column: 11,
       message: messages.rejected("$ab"),
       description:
-        "Two dollar variables with the same name and multi-level nesting."
+        "Two dollar variables with the same name and multi-level nesting.",
     },
     {
       code: `
@@ -333,7 +334,7 @@ testRule({
       line: 3,
       column: 7,
       message: messages.rejected("$a"),
-      description: "Two dollar variables with the same name."
+      description: "Two dollar variables with the same name.",
     },
     {
       code: `
@@ -344,7 +345,7 @@ testRule({
       column: 7,
       message: messages.rejected("$a"),
       description:
-        "Two dollar variables with the same name and containing default."
+        "Two dollar variables with the same name and containing default.",
     },
     {
       code: `
@@ -354,7 +355,7 @@ testRule({
       column: 23,
       message: messages.rejected("$a"),
       description:
-        "Two dollar variables with the same name on the same line and containing default."
+        "Two dollar variables with the same name on the same line and containing default.",
     },
     {
       code: `
@@ -364,9 +365,9 @@ testRule({
       column: 30,
       message: messages.rejected("$a"),
       description:
-        "Three dollar variables with the same name on the same line and two contains default."
-    }
-  ]
+        "Three dollar variables with the same name on the same line and two contains default.",
+    },
+  ],
 });
 
 testRule({
@@ -385,7 +386,7 @@ testRule({
         }
       }
     `,
-      description: "Should ignore inside nested @mixin."
+      description: "Should ignore inside nested @mixin.",
     },
     {
       code: `
@@ -394,7 +395,7 @@ testRule({
         $ab: 2;
       }
     `,
-      description: "Two dollar variables with the same name and inside @mixin."
+      description: "Two dollar variables with the same name and inside @mixin.",
     },
     {
       code: `
@@ -408,46 +409,47 @@ testRule({
         }
       }
     `,
-      description: "Should ignore inside nested @media query."
+      description: "Should ignore inside nested @media query.",
     },
     {
       code: `
       $a: 1;
     `,
-      description: "A single dollar variable."
+      description: "A single dollar variable.",
     },
     {
       code: `
       $a: 1;
       $b: 2;
     `,
-      description: "Two dollar variables with different names."
+      description: "Two dollar variables with different names.",
     },
     {
       code: `
       $a: 1; $b: 2;
     `,
-      description: "Two dollar variables with different names on the same line."
+      description:
+        "Two dollar variables with different names on the same line.",
     },
     {
       code: "a { $a: 0; $b: $a + 1; }",
       description:
-        "Two dollar variables with different names on the same line and variable assign."
+        "Two dollar variables with different names on the same line and variable assign.",
     },
     {
       code: "a { @less: 0; @less: @less + 1; }",
-      description: "Less variables are ignored"
+      description: "Less variables are ignored",
     },
     {
       code: "a { --custom-property: 0; --custom-property: 1; }",
-      description: "Custom properties are ignored"
+      description: "Custom properties are ignored",
     },
     {
       code: `
       $a: 1;
       $ab: 2;
     `,
-      description: "Two dollar variables with different names."
+      description: "Two dollar variables with different names.",
     },
     {
       code: `
@@ -456,7 +458,7 @@ testRule({
         $b: 2;
       }
     `,
-      description: "Two dollar variables with different names and nesting."
+      description: "Two dollar variables with different names and nesting.",
     },
     {
       code: `
@@ -465,8 +467,8 @@ testRule({
         color: black;
       }
     `,
-      description: "A single variable and a normal CSS property."
-    }
+      description: "A single variable and a normal CSS property.",
+    },
   ],
 
   reject: [
@@ -483,7 +485,7 @@ testRule({
       line: 6,
       column: 11,
       message: messages.rejected("$a"),
-      description: "Should warn inside nested selector."
+      description: "Should warn inside nested selector.",
     },
     {
       code: `
@@ -498,7 +500,7 @@ testRule({
       line: 6,
       column: 11,
       message: messages.rejected("$a"),
-      description: "Should warn inside nesting selector."
+      description: "Should warn inside nesting selector.",
     },
 
     {
@@ -517,16 +519,16 @@ testRule({
         {
           line: 6,
           column: 9,
-          message: messages.rejected("$b")
+          message: messages.rejected("$b"),
         },
         {
           line: 8,
           column: 11,
-          message: messages.rejected("$a")
-        }
+          message: messages.rejected("$a"),
+        },
       ],
       description:
-        "Should warn for a var inside the selector, but not for nested one."
+        "Should warn for a var inside the selector, but not for nested one.",
     },
     {
       code: `
@@ -536,7 +538,7 @@ testRule({
       line: 3,
       column: 7,
       message: messages.rejected("$a"),
-      description: "Two dollar variables with the same name."
+      description: "Two dollar variables with the same name.",
     },
     {
       code: `
@@ -545,7 +547,7 @@ testRule({
       line: 2,
       column: 14,
       message: messages.rejected("$a"),
-      description: "Two dollar variables with the same name on the same line."
+      description: "Two dollar variables with the same name on the same line.",
     },
     {
       code: `
@@ -557,22 +559,22 @@ testRule({
         {
           line: 3,
           column: 7,
-          message: messages.rejected("$a")
+          message: messages.rejected("$a"),
         },
         {
           line: 4,
           column: 7,
-          message: messages.rejected("$a")
-        }
+          message: messages.rejected("$a"),
+        },
       ],
-      description: "Three dollar variables with the same name."
+      description: "Three dollar variables with the same name.",
     },
     {
       code: "a { $scss: 0; $scss: $scss + 1; }",
       line: 1,
       column: 15,
       message: messages.rejected("$scss"),
-      description: "Two dollar variables with the same name inside a selector."
+      description: "Two dollar variables with the same name inside a selector.",
     },
     {
       code: `
@@ -583,7 +585,7 @@ testRule({
       line: 4,
       column: 7,
       message: messages.rejected("$a"),
-      description: "Two dollar variables with the same name, variable between."
+      description: "Two dollar variables with the same name, variable between.",
     },
     {
       code: `
@@ -597,7 +599,7 @@ testRule({
       column: 7,
       message: messages.rejected("$a"),
       description:
-        "Two dollar variables with the same name, variable and newlines between."
+        "Two dollar variables with the same name, variable and newlines between.",
     },
     {
       code: `
@@ -610,9 +612,9 @@ testRule({
       column: 9,
       message: messages.rejected("$ab"),
       description:
-        "Two dollar variables with the same name and inside a selector."
-    }
-  ]
+        "Two dollar variables with the same name and inside a selector.",
+    },
+  ],
 });
 
 testRule({
@@ -631,7 +633,7 @@ testRule({
         }
       }
     `,
-      description: "Should ignore inside nested @mixin."
+      description: "Should ignore inside nested @mixin.",
     },
     {
       code: `
@@ -645,46 +647,47 @@ testRule({
         }
       }
     `,
-      description: "Should ignore inside nested @media query."
+      description: "Should ignore inside nested @media query.",
     },
     {
       code: `
       $a: 1;
     `,
-      description: "A single dollar variable."
+      description: "A single dollar variable.",
     },
     {
       code: `
       $a: 1;
       $b: 2;
     `,
-      description: "Two dollar variables with different names."
+      description: "Two dollar variables with different names.",
     },
     {
       code: `
       $a: 1; $b: 2;
     `,
-      description: "Two dollar variables with different names on the same line."
+      description:
+        "Two dollar variables with different names on the same line.",
     },
     {
       code: "a { $a: 0; $b: $a + 1; }",
       description:
-        "Two dollar variables with different names on the same line and variable assign."
+        "Two dollar variables with different names on the same line and variable assign.",
     },
     {
       code: "a { @less: 0; @less: @less + 1; }",
-      description: "Less variables are ignored"
+      description: "Less variables are ignored",
     },
     {
       code: "a { --custom-property: 0; --custom-property: 1; }",
-      description: "Custom properties are ignored"
+      description: "Custom properties are ignored",
     },
     {
       code: `
       $a: 1;
       $ab: 2;
     `,
-      description: "Two dollar variables with different names."
+      description: "Two dollar variables with different names.",
     },
     {
       code: `
@@ -693,7 +696,7 @@ testRule({
         $b: 2;
       }
     `,
-      description: "Two dollar variables with different names and nesting."
+      description: "Two dollar variables with different names and nesting.",
     },
     {
       code: `
@@ -702,8 +705,8 @@ testRule({
         color: black;
       }
     `,
-      description: "A single variable and a normal CSS property."
-    }
+      description: "A single variable and a normal CSS property.",
+    },
   ],
 
   reject: [
@@ -720,7 +723,7 @@ testRule({
       line: 6,
       column: 11,
       message: messages.rejected("$a"),
-      description: "Should warn inside nested selector."
+      description: "Should warn inside nested selector.",
     },
     {
       code: `
@@ -735,7 +738,7 @@ testRule({
       line: 6,
       column: 11,
       message: messages.rejected("$a"),
-      description: "Should warn inside nesting selector."
+      description: "Should warn inside nesting selector.",
     },
 
     {
@@ -754,16 +757,16 @@ testRule({
         {
           line: 6,
           column: 9,
-          message: messages.rejected("$b")
+          message: messages.rejected("$b"),
         },
         {
           line: 8,
           column: 11,
-          message: messages.rejected("$a")
-        }
+          message: messages.rejected("$a"),
+        },
       ],
       description:
-        "Should warn for a var inside the selector, but not for nested one."
+        "Should warn for a var inside the selector, but not for nested one.",
     },
     {
       code: `
@@ -773,7 +776,7 @@ testRule({
       line: 3,
       column: 7,
       message: messages.rejected("$a"),
-      description: "Two dollar variables with the same name."
+      description: "Two dollar variables with the same name.",
     },
     {
       code: `
@@ -782,7 +785,7 @@ testRule({
       line: 2,
       column: 14,
       message: messages.rejected("$a"),
-      description: "Two dollar variables with the same name on the same line."
+      description: "Two dollar variables with the same name on the same line.",
     },
     {
       code: `
@@ -794,22 +797,22 @@ testRule({
         {
           line: 3,
           column: 7,
-          message: messages.rejected("$a")
+          message: messages.rejected("$a"),
         },
         {
           line: 4,
           column: 7,
-          message: messages.rejected("$a")
-        }
+          message: messages.rejected("$a"),
+        },
       ],
-      description: "Three dollar variables with the same name."
+      description: "Three dollar variables with the same name.",
     },
     {
       code: "a { $scss: 0; $scss: $scss + 1; }",
       line: 1,
       column: 15,
       message: messages.rejected("$scss"),
-      description: "Two dollar variables with the same name inside a selector."
+      description: "Two dollar variables with the same name inside a selector.",
     },
     {
       code: `
@@ -820,7 +823,7 @@ testRule({
       line: 4,
       column: 7,
       message: messages.rejected("$a"),
-      description: "Two dollar variables with the same name, variable between."
+      description: "Two dollar variables with the same name, variable between.",
     },
     {
       code: `
@@ -834,7 +837,7 @@ testRule({
       column: 7,
       message: messages.rejected("$a"),
       description:
-        "Two dollar variables with the same name, variable and newlines between."
+        "Two dollar variables with the same name, variable and newlines between.",
     },
     {
       code: `
@@ -847,7 +850,7 @@ testRule({
       column: 9,
       message: messages.rejected("$ab"),
       description:
-        "Two dollar variables with the same name and inside a selector."
+        "Two dollar variables with the same name and inside a selector.",
     },
     {
       code: `
@@ -859,9 +862,9 @@ testRule({
       line: 4,
       column: 9,
       message: messages.rejected("$ab"),
-      description: "Two dollar variables with the same name and inside @mixin."
-    }
-  ]
+      description: "Two dollar variables with the same name and inside @mixin.",
+    },
+  ],
 });
 
 testRule({
@@ -878,7 +881,7 @@ testRule({
         $a: 2;
       }
     `,
-      description: "Should ignore inside @mixin."
+      description: "Should ignore inside @mixin.",
     },
     {
       code: `
@@ -893,7 +896,7 @@ testRule({
       }
 
     `,
-      description: "Should ignore inside nested @mixin."
+      description: "Should ignore inside nested @mixin.",
     },
     {
       code: `
@@ -903,46 +906,47 @@ testRule({
         $a: 2;
       }
     `,
-      description: "Should ignore inside @if."
+      description: "Should ignore inside @if.",
     },
     {
       code: `
       $a: 1;
     `,
-      description: "A single dollar variable."
+      description: "A single dollar variable.",
     },
     {
       code: `
       $a: 1;
       $b: 2;
     `,
-      description: "Two dollar variables with different names."
+      description: "Two dollar variables with different names.",
     },
     {
       code: `
       $a: 1; $b: 2;
     `,
-      description: "Two dollar variables with different names on the same line."
+      description:
+        "Two dollar variables with different names on the same line.",
     },
     {
       code: "a { $a: 0; $b: $a + 1; }",
       description:
-        "Two dollar variables with different names on the same line and variable assign."
+        "Two dollar variables with different names on the same line and variable assign.",
     },
     {
       code: "a { @less: 0; @less: @less + 1; }",
-      description: "Less variables are ignored"
+      description: "Less variables are ignored",
     },
     {
       code: "a { --custom-property: 0; --custom-property: 1; }",
-      description: "Custom properties are ignored"
+      description: "Custom properties are ignored",
     },
     {
       code: `
       $a: 1;
       $ab: 2;
     `,
-      description: "Two dollar variables with different names."
+      description: "Two dollar variables with different names.",
     },
     {
       code: `
@@ -952,7 +956,7 @@ testRule({
       }
     `,
       description:
-        "Two dollar variables with different names and inside a selector."
+        "Two dollar variables with different names and inside a selector.",
     },
     {
       code: `
@@ -961,8 +965,8 @@ testRule({
         color: black;
       }
     `,
-      description: "A single variable and a normal CSS property."
-    }
+      description: "A single variable and a normal CSS property.",
+    },
   ],
   reject: [
     {
@@ -976,7 +980,7 @@ testRule({
       line: 5,
       column: 9,
       message: messages.rejected("$c"),
-      description: "Should warn inside @function as it is not ignored."
+      description: "Should warn inside @function as it is not ignored.",
     },
     {
       code: `
@@ -986,7 +990,7 @@ testRule({
       line: 3,
       column: 7,
       message: messages.rejected("$a"),
-      description: "Two dollar variables with the same name."
+      description: "Two dollar variables with the same name.",
     },
     {
       code: `
@@ -995,7 +999,7 @@ testRule({
       line: 2,
       column: 14,
       message: messages.rejected("$a"),
-      description: "Two dollar variables with the same name on the same line."
+      description: "Two dollar variables with the same name on the same line.",
     },
     {
       code: `
@@ -1007,22 +1011,22 @@ testRule({
         {
           line: 3,
           column: 7,
-          message: messages.rejected("$a")
+          message: messages.rejected("$a"),
         },
         {
           line: 4,
           column: 7,
-          message: messages.rejected("$a")
-        }
+          message: messages.rejected("$a"),
+        },
       ],
-      description: "Three dollar variables with the same name."
+      description: "Three dollar variables with the same name.",
     },
     {
       code: "a { $scss: 0; $scss: $scss + 1; }",
       line: 1,
       column: 15,
       message: messages.rejected("$scss"),
-      description: "Two dollar variables with the same name inside a selector."
+      description: "Two dollar variables with the same name inside a selector.",
     },
     {
       code: `
@@ -1033,7 +1037,7 @@ testRule({
       line: 4,
       column: 7,
       message: messages.rejected("$a"),
-      description: "Two dollar variables with the same name, variable between."
+      description: "Two dollar variables with the same name, variable between.",
     },
     {
       code: `
@@ -1047,7 +1051,7 @@ testRule({
       column: 7,
       message: messages.rejected("$a"),
       description:
-        "Two dollar variables with the same name, variable and newlines between."
+        "Two dollar variables with the same name, variable and newlines between.",
     },
     {
       code: `
@@ -1060,7 +1064,7 @@ testRule({
       column: 9,
       message: messages.rejected("$ab"),
       description:
-        "Two dollar variables with the same name and inside a selector."
+        "Two dollar variables with the same name and inside a selector.",
     },
     {
       code: `
@@ -1075,9 +1079,9 @@ testRule({
       column: 11,
       message: messages.rejected("$ab"),
       description:
-        "Two dollar variables with the same name and nesting selector."
-    }
-  ]
+        "Two dollar variables with the same name and nesting selector.",
+    },
+  ],
 });
 
 testRule({
@@ -1092,8 +1096,8 @@ testRule({
       $b: 1;
     `,
       description:
-        "Two dollar variables with different names and one containing a default."
-    }
+        "Two dollar variables with different names and one containing a default.",
+    },
   ],
 
   reject: [
@@ -1105,7 +1109,8 @@ testRule({
       line: 3,
       column: 7,
       message: messages.rejected("$a"),
-      description: "Two dollar variables with the same name containing default."
+      description:
+        "Two dollar variables with the same name containing default.",
     },
     {
       code: `
@@ -1115,7 +1120,7 @@ testRule({
       column: 23,
       message: messages.rejected("$a"),
       description:
-        "Two dollar variables with the same name on the same line and one variable contains a default."
+        "Two dollar variables with the same name on the same line and one variable contains a default.",
     },
     {
       code: `
@@ -1126,9 +1131,9 @@ testRule({
       column: 7,
       message: messages.rejected("$a"),
       description:
-        "Two dollar variables with the same name and one containing default."
-    }
-  ]
+        "Two dollar variables with the same name and one containing default.",
+    },
+  ],
 });
 
 testRule({
@@ -1143,7 +1148,7 @@ testRule({
       $b: 1;
     `,
       description:
-        "Two dollar variables with different names and one containing a default."
+        "Two dollar variables with different names and one containing a default.",
     },
     {
       code: `
@@ -1151,7 +1156,7 @@ testRule({
       $a: 1;
     `,
       description:
-        "Two dollar variables with same names and one containing a default."
+        "Two dollar variables with same names and one containing a default.",
     },
     {
       code: `
@@ -1160,7 +1165,7 @@ testRule({
       $a: 1;
     `,
       description:
-        "Three dollar variables with same names and two containing a default."
+        "Three dollar variables with same names and two containing a default.",
     },
     {
       code: `
@@ -1170,7 +1175,7 @@ testRule({
       $a: 1;
     `,
       description:
-        "Four dollar variables with same names and three containing a default."
+        "Four dollar variables with same names and three containing a default.",
     },
     {
       code: `
@@ -1185,8 +1190,8 @@ testRule({
       $c: $c + 5;
     `,
       description:
-        "Three grouped dollar variables and each group contains a default."
-    }
+        "Three grouped dollar variables and each group contains a default.",
+    },
   ],
 
   reject: [
@@ -1198,7 +1203,7 @@ testRule({
       line: 3,
       column: 7,
       message: messages.rejected("$a"),
-      description: "Two dollar variables with the same name."
+      description: "Two dollar variables with the same name.",
     },
     {
       code: `
@@ -1207,7 +1212,7 @@ testRule({
       line: 2,
       column: 14,
       message: messages.rejected("$a"),
-      description: "Two dollar variables with the same name on the same line."
-    }
-  ]
+      description: "Two dollar variables with the same name on the same line.",
+    },
+  ],
 });

--- a/src/rules/no-duplicate-dollar-variables/index.js
+++ b/src/rules/no-duplicate-dollar-variables/index.js
@@ -5,11 +5,11 @@ import { namespace, ruleUrl } from "../../utils";
 export const ruleName = namespace("no-duplicate-dollar-variables");
 
 export const messages = utils.ruleMessages(ruleName, {
-  rejected: variable => `Unexpected duplicate dollar variable ${variable}`
+  rejected: (variable) => `Unexpected duplicate dollar variable ${variable}`,
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(value, secondaryOptions) {
@@ -18,16 +18,16 @@ export default function rule(value, secondaryOptions) {
       result,
       ruleName,
       {
-        actual: value
+        actual: value,
       },
       {
         actual: secondaryOptions,
         possible: {
           ignoreInside: ["at-rule", "nested-at-rule"],
           ignoreInsideAtRules: [isString],
-          ignoreDefaults: [isBoolean]
+          ignoreDefaults: [isBoolean],
         },
-        optional: true
+        optional: true,
       }
     );
 
@@ -76,7 +76,7 @@ export default function rule(value, secondaryOptions) {
 
       return {
         defaultCount: 0,
-        isDeclared: false
+        isDeclared: false,
       };
     }
 
@@ -114,7 +114,9 @@ export default function rule(value, secondaryOptions) {
           ? ++variableData.defaultCount
           : variableData.defaultCount,
         isDeclared:
-          isDefault && ignoreDefaults !== false ? variableData.isDeclared : true
+          isDefault && ignoreDefaults !== false
+            ? variableData.isDeclared
+            : true,
       };
     }
 
@@ -123,7 +125,7 @@ export default function rule(value, secondaryOptions) {
         ? secondaryOptions.ignoreDefaults
         : 1;
 
-    root.walkDecls(decl => {
+    root.walkDecls((decl) => {
       const isVar = decl.prop[0] === "$";
       const isInsideIgnoredAtRule =
         decl.parent.type === "atrule" &&
@@ -170,7 +172,7 @@ export default function rule(value, secondaryOptions) {
           message: messages.rejected(decl.prop),
           node: decl,
           result,
-          ruleName
+          ruleName,
         });
       }
 

--- a/src/rules/no-duplicate-mixins/__tests__/index.js
+++ b/src/rules/no-duplicate-mixins/__tests__/index.js
@@ -12,7 +12,7 @@ testRule({
         font-size: 16px;
       }
     `,
-      description: "A single mixin."
+      description: "A single mixin.",
     },
     {
       code: `
@@ -23,8 +23,8 @@ testRule({
         font-size: 18px;
       }
     `,
-      description: "Two mixins with different names."
-    }
+      description: "Two mixins with different names.",
+    },
   ],
 
   reject: [
@@ -40,7 +40,7 @@ testRule({
       column: 7,
       line: 5,
       message: messages.rejected("font-size-default"),
-      description: "Two mixins with the same names."
+      description: "Two mixins with the same names.",
     },
     {
       code: `
@@ -57,7 +57,7 @@ testRule({
       column: 7,
       line: 8,
       message: messages.rejected("font-size-default"),
-      description: "Three mixins including two with the same names."
+      description: "Three mixins including two with the same names.",
     },
     {
       code: `
@@ -72,7 +72,7 @@ testRule({
       line: 5,
       message: messages.rejected("font-size"),
       description:
-        "Two mixins with the same names including one accepting arguments."
+        "Two mixins with the same names including one accepting arguments.",
     },
     {
       code: `
@@ -86,7 +86,7 @@ testRule({
       column: 7,
       line: 5,
       message: messages.rejected("font-size"),
-      description: "Two mixins with the same names accepting arguments."
+      description: "Two mixins with the same names accepting arguments.",
     },
     {
       code: `
@@ -104,7 +104,7 @@ testRule({
       column: 9,
       line: 7,
       message: messages.rejected("font-size"),
-      description: "Two mixins with the same names accepting arguments."
-    }
-  ]
+      description: "Two mixins with the same names accepting arguments.",
+    },
+  ],
 });

--- a/src/rules/no-duplicate-mixins/index.js
+++ b/src/rules/no-duplicate-mixins/index.js
@@ -4,17 +4,17 @@ import { atRuleBaseName, namespace, ruleUrl } from "../../utils";
 export const ruleName = namespace("no-duplicate-mixins");
 
 export const messages = utils.ruleMessages(ruleName, {
-  rejected: mixin => `Unexpected duplicate mixin ${mixin}`
+  rejected: (mixin) => `Unexpected duplicate mixin ${mixin}`,
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(value) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
-      actual: value
+      actual: value,
     });
 
     if (!validOptions) {
@@ -23,7 +23,7 @@ export default function rule(value) {
 
     const mixins = {};
 
-    root.walkAtRules(decl => {
+    root.walkAtRules((decl) => {
       const isMixin = decl.name === "mixin";
 
       if (!isMixin) {
@@ -37,7 +37,7 @@ export default function rule(value) {
           message: messages.rejected(mixinName),
           node: decl,
           result,
-          ruleName
+          ruleName,
         });
       }
 

--- a/src/rules/no-global-function-names/__tests__/index.js
+++ b/src/rules/no-global-function-names/__tests__/index.js
@@ -12,7 +12,7 @@ testRule({
        background: rgb(27,224,63);
       }
     `,
-      description: "An allowed global function"
+      description: "An allowed global function",
     },
     {
       code: `
@@ -20,7 +20,7 @@ testRule({
        background: rgba(27,224,63, 0);
       }
     `,
-      description: "An allowed global function"
+      description: "An allowed global function",
     },
     {
       code: `
@@ -28,7 +28,7 @@ testRule({
        background: hsla(27,224,63, 0);
       }
     `,
-      description: "An allowed global function"
+      description: "An allowed global function",
     },
     {
       code: `
@@ -36,7 +36,7 @@ testRule({
        background: hsa(27,224,63);
       }
     `,
-      description: "An allowed global function"
+      description: "An allowed global function",
     },
     {
       code: `
@@ -44,7 +44,7 @@ testRule({
        min-width: min(30vw, 300px);
       }
     `,
-      description: "An allowed global function"
+      description: "An allowed global function",
     },
     {
       code: `
@@ -52,7 +52,7 @@ testRule({
        min-width: max(30vw, 300px);
       }
     `,
-      description: "An allowed global function"
+      description: "An allowed global function",
     },
     {
       code: `
@@ -60,7 +60,7 @@ testRule({
        filter: invert(1);
       }
     `,
-      description: "An allowed global function"
+      description: "An allowed global function",
     },
     {
       code: `
@@ -68,7 +68,7 @@ testRule({
        filter: saturate(140%);
       }
     `,
-      description: "An allowed global function"
+      description: "An allowed global function",
     },
     {
       code: `
@@ -76,7 +76,7 @@ testRule({
        filter: alpha(opacity=50);
       }
     `,
-      description: "An allowed global function"
+      description: "An allowed global function",
     },
     {
       code: `
@@ -85,7 +85,7 @@ testRule({
        background: color.red(#6b717f);
       }
     `,
-      description: "Red function"
+      description: "Red function",
     },
     {
       code: `
@@ -94,7 +94,7 @@ testRule({
        background: color.blue(#6b717f);
       }
     `,
-      description: "Blue function"
+      description: "Blue function",
     },
     {
       code: `
@@ -103,7 +103,7 @@ testRule({
        background: color.green(#6b717f);
       }
     `,
-      description: "color.green function"
+      description: "color.green function",
     },
     {
       code: `
@@ -112,7 +112,7 @@ testRule({
        background: color.mix(#6b717f, #6b717f);
       }
     `,
-      description: "color.mix"
+      description: "color.mix",
     },
     {
       code: `
@@ -121,7 +121,7 @@ testRule({
        background: color.hue(#6b717f);
       }
     `,
-      description: "color.hue"
+      description: "color.hue",
     },
     {
       code: `
@@ -130,7 +130,7 @@ testRule({
        background: color.saturation(#6b717f);
       }
     `,
-      description: "color.saturation"
+      description: "color.saturation",
     },
     {
       code: `
@@ -139,13 +139,13 @@ testRule({
        background: color.lightness(#6b717f);
       }
     `,
-      description: "color.lightness"
+      description: "color.lightness",
     },
     {
       code: `
       @use "sass:color";
       @debug color.alpha(#e1d7d2)`,
-      description: "color.alpha"
+      description: "color.alpha",
     },
     {
       code: `
@@ -154,7 +154,7 @@ testRule({
        background: color.adjust(#6b717f, $red: 15);
       }
     `,
-      description: "color.adjust (not adjust-color)"
+      description: "color.adjust (not adjust-color)",
     },
     {
       code: `
@@ -163,7 +163,7 @@ testRule({
        background: color.scale(#6b717f, $red: 15);
       }
     `,
-      description: "color.scale (not scale-color)"
+      description: "color.scale (not scale-color)",
     },
     {
       code: `
@@ -172,14 +172,14 @@ testRule({
        background: color.ie-hex-str(#6b717f);
       }
     `,
-      description: "color.ie-hex-str"
+      description: "color.ie-hex-str",
     },
     {
       code: `
       @use "sass:map";
       a {b: map.get((), 1)}
     `,
-      description: "map.get()"
+      description: "map.get()",
     },
     {
       code: `
@@ -187,7 +187,7 @@ testRule({
       $font-weights: ("regular": 400, "medium": 500, "bold": 700)
       @debug map.has-key($font-weights, "regular")
     `,
-      description: "map.has-key"
+      description: "map.has-key",
     },
     {
       code: `
@@ -197,7 +197,7 @@ testRule({
 
       @debug map.merge($light-weights, $heavy-weights)
     `,
-      description: "map.merge"
+      description: "map.merge",
     },
     {
       code: `
@@ -206,7 +206,7 @@ testRule({
 
       @debug map.remove($font-weights, "regular")
     `,
-      description: "map.remove"
+      description: "map.remove",
     },
     {
       code: `
@@ -215,7 +215,7 @@ testRule({
 
       @debug map.keys($font-weights)
     `,
-      description: "map.keys"
+      description: "map.keys",
     },
     {
       code: `
@@ -224,71 +224,71 @@ testRule({
 
       @debug map.values($font-weights)
     `,
-      description: "map.values"
+      description: "map.values",
     },
     {
       code: `
       @use "sass:string"
       @debug string.quote(Helvetica);
       `,
-      description: "string.quote"
+      description: "string.quote",
     },
     {
       code: `
       @use "sass:string"
       @debug string.unquote("Helvetica");
       `,
-      description: "string.unquote"
+      description: "string.unquote",
     },
     {
       code: `
       @use "sass:string"
       @debug string.length("Helvetica");
       `,
-      description: "string.length"
+      description: "string.length",
     },
     {
       code: `
       @use "sass:string"
       @debug string.insert("Roboto Bold", " Mono", 7);
       `,
-      description: "string.insert"
+      description: "string.insert",
     },
     {
       code: `
       @use "sass:string"
       @debug string.slice("Helvetica Neue", 11);
       `,
-      description: "string.slice"
+      description: "string.slice",
     },
     {
       code: `
       @use "sass:string"
       @debug string.index("Helvetica Neue", "Helvetica");
       `,
-      description: "string.index"
+      description: "string.index",
     },
     {
       code: `
       @use "sass:string"
       @debug string.to-upper-case("Bold");
       `,
-      description: "string.to-upper-case"
+      description: "string.to-upper-case",
     },
     {
       code: `
       @use "sass:string"
       @debug string.to-lower-case("Bold");
       `,
-      description: "string.to-lower-case"
+      description: "string.to-lower-case",
     },
     {
       code: `
       @use "sass:string"
       @debug string.unique-id()
       `,
-      description: "string.unique-id"
-    }
+      description: "string.unique-id",
+    },
   ],
 
   reject: [
@@ -301,7 +301,7 @@ testRule({
       line: 3,
       column: 21,
       message: messages.rejected("red"),
-      description: "red"
+      description: "red",
     },
     {
       code: `
@@ -312,7 +312,7 @@ testRule({
       line: 3,
       column: 21,
       message: messages.rejected("blue"),
-      description: "blue"
+      description: "blue",
     },
     {
       code: `
@@ -323,7 +323,7 @@ testRule({
       line: 3,
       column: 21,
       message: messages.rejected("green"),
-      description: "green"
+      description: "green",
     },
     {
       code: `
@@ -334,7 +334,7 @@ testRule({
       line: 3,
       column: 21,
       message: messages.rejected("mix"),
-      description: "mix"
+      description: "mix",
     },
     {
       code: `
@@ -345,7 +345,7 @@ testRule({
       line: 3,
       column: 21,
       message: messages.rejected("hue"),
-      description: "hue"
+      description: "hue",
     },
     {
       code: `
@@ -356,7 +356,7 @@ testRule({
       line: 3,
       column: 21,
       message: messages.rejected("saturation"),
-      description: "saturation"
+      description: "saturation",
     },
     {
       code: `
@@ -367,7 +367,7 @@ testRule({
       line: 3,
       column: 21,
       message: messages.rejected("lightness"),
-      description: "lightness"
+      description: "lightness",
     },
     {
       code: `
@@ -378,7 +378,7 @@ testRule({
       line: 3,
       column: 21,
       message: messages.rejected("adjust-color"),
-      description: "adjust-color"
+      description: "adjust-color",
     },
     {
       code: `
@@ -389,7 +389,7 @@ testRule({
       line: 3,
       column: 21,
       message: messages.rejected("scale-color"),
-      description: "scale-color"
+      description: "scale-color",
     },
     {
       code: `
@@ -400,7 +400,7 @@ testRule({
       line: 3,
       column: 21,
       message: messages.rejected("change-color"),
-      description: "change-color"
+      description: "change-color",
     },
     {
       code: `
@@ -411,7 +411,7 @@ testRule({
       line: 3,
       column: 21,
       message: messages.rejected("ie-hex-str"),
-      description: "ie-hex-str"
+      description: "ie-hex-str",
     },
     {
       code: `
@@ -420,7 +420,7 @@ testRule({
       line: 2,
       column: 13,
       message: messages.rejected("map-get"),
-      description: "map-get"
+      description: "map-get",
     },
     {
       code: `
@@ -430,7 +430,7 @@ testRule({
       line: 3,
       column: 14,
       message: messages.rejected("map-has-key"),
-      description: "map-has-key"
+      description: "map-has-key",
     },
     {
       code: `
@@ -440,7 +440,7 @@ testRule({
       line: 3,
       column: 14,
       message: messages.rejected("map-remove"),
-      description: "map-remove"
+      description: "map-remove",
     },
     {
       code: `
@@ -450,7 +450,7 @@ testRule({
       line: 3,
       column: 14,
       message: messages.rejected("map-keys"),
-      description: "map-keys"
+      description: "map-keys",
     },
     {
       code: `
@@ -460,7 +460,7 @@ testRule({
       line: 3,
       column: 14,
       message: messages.rejected("map-values"),
-      description: "map-values"
+      description: "map-values",
     },
     {
       code: `
@@ -471,7 +471,7 @@ testRule({
       line: 3,
       column: 21,
       message: messages.rejected("change-color"),
-      description: "change-color"
+      description: "change-color",
     },
     {
       code: `
@@ -484,7 +484,7 @@ testRule({
       message: messages.rejectedFullMessage(
         "Expected color.adjust($color, $lightness: $amount) instead of lighten($color, $amount)"
       ),
-      description: "lighten"
-    }
-  ]
+      description: "lighten",
+    },
+  ],
 });

--- a/src/rules/no-global-function-names/index.js
+++ b/src/rules/no-global-function-names/index.js
@@ -73,7 +73,7 @@ const rules = {
   darken: "color",
   desaturate: "color",
   opacify: "color",
-  transparentize: "color"
+  transparentize: "color",
 };
 
 const new_rule_names = {
@@ -105,40 +105,40 @@ const new_rule_names = {
   desaturate: "adjust",
   opacify: "adjust",
   saturate: "adjust",
-  transparentize: "adjust"
+  transparentize: "adjust",
 };
 
 const rule_mapping = {
   lighten: ["lighten($color, $amount)", "adjust($color, $lightness: $amount)"],
   "adjust-hue": [
     "adjust-hue($color, $amount)",
-    "adjust($color, $hue: $amount)"
+    "adjust($color, $hue: $amount)",
   ],
   darken: ["darken($color, $amount)", "adjust($color, $lightness: -$amount)"],
   desaturate: [
     "desaturate($color, $amount)",
-    "adjust($color, $saturation: -$amount)"
+    "adjust($color, $saturation: -$amount)",
   ],
   opacify: ["opacify($color, $amount)", "adjust($color, $alpha: -$amount)"],
   saturate: [
     "saturate($color, $amount)",
-    "adjust($color, $saturation: $amount)"
+    "adjust($color, $saturation: $amount)",
   ],
   transparentize: [
     "transparentize($color, $amount)",
-    "adjust($color, $alpha: -$amount)"
-  ]
+    "adjust($color, $alpha: -$amount)",
+  ],
 };
 
 export const ruleName = namespace("no-global-function-names");
 
 export const messages = utils.ruleMessages(ruleName, {
-  rejectedFullMessage: string => string,
-  rejected: name => errorMessage(name)
+  rejectedFullMessage: (string) => string,
+  rejected: (name) => errorMessage(name),
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 function errorMessage(name) {
@@ -162,15 +162,15 @@ function errorMessage(name) {
 export default function rule(value) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
-      actual: value
+      actual: value,
     });
 
     if (!validOptions) {
       return;
     }
 
-    root.walkDecls(decl => {
-      valueParser(decl.value).walk(node => {
+    root.walkDecls((decl) => {
+      valueParser(decl.value).walk((node) => {
         const cleanValue = node.value.replace(interpolationPrefix, "");
 
         // Verify that we're only looking at functions.
@@ -184,7 +184,7 @@ export default function rule(value) {
             node: decl,
             index: declarationValueIndex(decl) + node.sourceIndex,
             result,
-            ruleName
+            ruleName,
           });
         }
       });

--- a/src/rules/operator-no-newline-after/__tests__/index.js
+++ b/src/rules/operator-no-newline-after/__tests__/index.js
@@ -14,11 +14,11 @@ testRule({
   accept: [
     {
       code: "a { width: 1 +1; }",
-      description: "List. width: 1 +1."
+      description: "List. width: 1 +1.",
     },
     {
       code: "a { width: s1- +1; }",
-      description: "List. width: s1- +1."
+      description: "List. width: s1- +1.",
     },
     {
       code: `
@@ -27,7 +27,7 @@ testRule({
           + 1;
       }
     `,
-      description: "Newline before the op: 10px\\n          + 1"
+      description: "Newline before the op: 10px\\n          + 1",
     },
     {
       code: `
@@ -37,7 +37,7 @@ testRule({
       }
     `,
       description:
-        "Newline after a character, that is not an operator: 10px /\\n  1"
+        "Newline after a character, that is not an operator: 10px /\\n  1",
     },
     {
       code: `
@@ -46,7 +46,7 @@ testRule({
           + 1;
       }
     `,
-      description: "Newline after the following op: 10px + 1\\n         + 1"
+      description: "Newline after the following op: 10px + 1\\n         + 1",
     },
     {
       code: `
@@ -56,8 +56,8 @@ testRule({
         unicode-range: U+26;
       }
       `,
-      description: "unicode-range"
-    }
+      description: "unicode-range",
+    },
   ],
 
   reject: [
@@ -71,7 +71,7 @@ testRule({
       description: "Newline-operator-indentation: 10px +\\n1px.",
       message: messages.rejected("+"),
       line: 3,
-      column: 21
+      column: 21,
     },
     {
       code: `
@@ -83,9 +83,9 @@ testRule({
       description: "Newline-operator-operand: 10px +\\n1px.",
       message: messages.rejected("+"),
       line: 3,
-      column: 21
-    }
-  ]
+      column: 21,
+    },
+  ],
 });
 
 testRule({
@@ -108,8 +108,8 @@ a {
     + 1;
 }
 </style>
-`
-    }
+`,
+    },
   ],
 
   reject: [
@@ -128,7 +128,7 @@ a {
 `,
       message: messages.rejected("+"),
       line: 8,
-      column: 15
-    }
-  ]
+      column: 15,
+    },
+  ],
 });

--- a/src/rules/operator-no-newline-after/index.js
+++ b/src/rules/operator-no-newline-after/index.js
@@ -5,11 +5,11 @@ import { calculationOperatorSpaceChecker } from "../operator-no-unspaced";
 export const ruleName = namespace("operator-no-newline-after");
 
 export const messages = utils.ruleMessages(ruleName, {
-  rejected: operator => `Unexpected newline after "${operator}"`
+  rejected: (operator) => `Unexpected newline after "${operator}"`,
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 /**
@@ -21,7 +21,7 @@ function checkNewlineBefore({
   startIndex,
   endIndex,
   node,
-  result
+  result,
 }) {
   const symbol = string.substring(startIndex, endIndex + 1);
   let newLineBefore = false;
@@ -43,7 +43,7 @@ function checkNewlineBefore({
       result,
       node,
       message: messages.rejected(symbol),
-      index: endIndex + globalIndex
+      index: endIndex + globalIndex,
     });
   }
 }
@@ -51,7 +51,7 @@ function checkNewlineBefore({
 export default function rule(expectation) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
-      actual: expectation
+      actual: expectation,
     });
 
     if (!validOptions) {
@@ -64,7 +64,7 @@ export default function rule(expectation) {
       calculationOperatorSpaceChecker({
         root,
         result,
-        checker: checkNewlineBefore
+        checker: checkNewlineBefore,
       });
     }
   };

--- a/src/rules/operator-no-newline-before/__tests__/index.js
+++ b/src/rules/operator-no-newline-before/__tests__/index.js
@@ -14,11 +14,11 @@ testRule({
   accept: [
     {
       code: "a { width: 1 +1; }",
-      description: "List. width: 1 +1."
+      description: "List. width: 1 +1.",
     },
     {
       code: "a { width: s1- +1; }",
-      description: "List. width: s1- +1."
+      description: "List. width: s1- +1.",
     },
     {
       code: `
@@ -27,7 +27,7 @@ testRule({
           1;
       }
     `,
-      description: "Newline after the op: 10px +\\n          1"
+      description: "Newline after the op: 10px +\\n          1",
     },
     {
       code: `
@@ -37,7 +37,7 @@ testRule({
       }
     `,
       description:
-        "Newline before a character, that is not an operator: 10px\\n-1"
+        "Newline before a character, that is not an operator: 10px\\n-1",
     },
     {
       code: `
@@ -46,7 +46,7 @@ testRule({
           1 + 1;
       }
     `,
-      description: "Newline before the preceding op: 10px +\\n          1"
+      description: "Newline before the preceding op: 10px +\\n          1",
     },
     {
       code: `
@@ -54,7 +54,7 @@ testRule({
           --foo: '{{}}';
         }
       `,
-      description: "Custom property"
+      description: "Custom property",
     },
     {
       code: `
@@ -64,8 +64,8 @@ testRule({
         unicode-range: U+26;
       }
       `,
-      description: "unicode-range"
-    }
+      description: "unicode-range",
+    },
   ],
 
   reject: [
@@ -79,7 +79,7 @@ testRule({
       description: "Newline-indentation-operator: 10px\\n        + 1.",
       message: messages.rejected("+"),
       line: 4,
-      column: 9
+      column: 9,
     },
     {
       code: `
@@ -91,9 +91,9 @@ testRule({
       description: "Newline-operator: 10px\\n+ 1.",
       message: messages.rejected("+"),
       line: 4,
-      column: 1
-    }
-  ]
+      column: 1,
+    },
+  ],
 });
 
 testRule({
@@ -116,8 +116,8 @@ a {
     1;
 }
 </style>
-`
-    }
+`,
+    },
   ],
 
   reject: [
@@ -136,7 +136,7 @@ a {
 `,
       message: messages.rejected("+"),
       line: 9,
-      column: 5
-    }
-  ]
+      column: 5,
+    },
+  ],
 });

--- a/src/rules/operator-no-newline-before/index.js
+++ b/src/rules/operator-no-newline-before/index.js
@@ -6,11 +6,11 @@ import { calculationOperatorSpaceChecker } from "../operator-no-unspaced";
 export const ruleName = namespace("operator-no-newline-before");
 
 export const messages = utils.ruleMessages(ruleName, {
-  rejected: operator => `Unexpected newline before "${operator}"`
+  rejected: (operator) => `Unexpected newline before "${operator}"`,
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 /**
@@ -22,7 +22,7 @@ function checkNewlineBefore({
   startIndex,
   endIndex,
   node,
-  result
+  result,
 }) {
   const symbol = string.substring(startIndex, endIndex + 1);
   let newLineBefore = false;
@@ -44,7 +44,7 @@ function checkNewlineBefore({
       result,
       node,
       message: messages.rejected(symbol),
-      index: endIndex + globalIndex
+      index: endIndex + globalIndex,
     });
   }
 }
@@ -52,7 +52,7 @@ function checkNewlineBefore({
 export default function rule(expectation) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
-      actual: expectation
+      actual: expectation,
     });
 
     if (!validOptions) {
@@ -65,7 +65,7 @@ export default function rule(expectation) {
       calculationOperatorSpaceChecker({
         root,
         result,
-        checker: checkNewlineBefore
+        checker: checkNewlineBefore,
       });
     }
   };

--- a/src/rules/operator-no-unspaced/__tests__/index.js
+++ b/src/rules/operator-no-unspaced/__tests__/index.js
@@ -14,31 +14,31 @@ testRule({
   accept: [
     {
       code: "a { width: 1 +1; }",
-      description: "List. width: 1 +1."
+      description: "List. width: 1 +1.",
     },
     {
       code: "a { width: s1- +1; }",
-      description: "List. width: s1- +1."
+      description: "List. width: s1- +1.",
     },
     {
       code: "a { width: abc- +1; }",
-      description: "List. width: abc- +1."
+      description: "List. width: abc- +1.",
     },
     {
       code: "a { width: 1px +1px; }",
-      description: "List. width: 1px +1px."
+      description: "List. width: 1px +1px.",
     },
     {
       code: "a { width: 1px- +1px; }",
-      description: "List. width: 1px- +1px."
+      description: "List. width: 1px- +1px.",
     },
     {
       code: "a { width: #{$var} +1; }",
-      description: "List. width: #{$var} +1."
+      description: "List. width: #{$var} +1.",
     },
     {
       code: ":root { --foo: '{{}}'; }",
-      description: "Custom property"
+      description: "Custom property",
     },
     {
       code: `
@@ -51,7 +51,7 @@ testRule({
         }
       }
       `,
-      description: "issue #561"
+      description: "issue #561",
     },
     {
       code: `
@@ -61,7 +61,7 @@ testRule({
         unicode-range: U+26;
       }
       `,
-      description: "unicode-range"
+      description: "unicode-range",
     },
     {
       code: `
@@ -71,7 +71,7 @@ testRule({
       }
       `,
       description:
-        "background-image with relative path inside url function and interpolation."
+        "background-image with relative path inside url function and interpolation.",
     },
     {
       code: `
@@ -81,18 +81,18 @@ testRule({
       }
       `,
       description:
-        "Op +: background-image with absolute path inside url function and interpolation."
+        "Op +: background-image with absolute path inside url function and interpolation.",
     },
     {
       code: `
       div { background-image: url(https://99-0a.x.y.rackcdn.com/z.jpg); }
       `,
-      description: "Op +: background-image with url that has a hyphen"
+      description: "Op +: background-image with url that has a hyphen",
     },
     {
       code: `div { background: url(data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfMSIgZGF0YS1uYW1lPSJMYXllciAxIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCA0Ljk1IDEwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2ZmZjt9LmNscy0ye2ZpbGw6IzQ0NDt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPmFycm93czwvdGl0bGU+PHJlY3QgY2xhc3M9ImNscy0xIiB3aWR0aD0iNC45NSIgaGVpZ2h0PSIxMCIvPjxwb2x5Z29uIGNsYXNzPSJjbHMtMiIgcG9pbnRzPSIxLjQxIDQuNjcgMi40OCAzLjE4IDMuNTQgNC42NyAxLjQxIDQuNjciLz48cG9seWdvbiBjbGFzcz0iY2xzLTIiIHBvaW50cz0iMy41NCA1LjMzIDIuNDggNi44MiAxLjQxIDUuMzMgMy41NCA1LjMzIi8+PC9zdmc+) }`,
-      description: "background image with base64 data, issue #561"
-    }
+      description: "background image with base64 data, issue #561",
+    },
   ],
 
   reject: [
@@ -104,21 +104,21 @@ testRule({
       description: "Op, -. width: 1- +1.",
       message: messages.expectedBefore("-"),
       line: 2,
-      column: 15
+      column: 15,
     },
     {
       code: "a { width: #{1 +1}; }",
       description: "Op (inside interpolation). width: 1 +1.",
       message: messages.expectedAfter("+"),
       line: 1,
-      column: 16
+      column: 16,
     },
     {
       code: "a { width: (1px +1px); }",
       description: "Op, in braces. width: (1px +1px).",
       message: messages.expectedAfter("+"),
       line: 1,
-      column: 17
+      column: 17,
     },
     {
       code: `
@@ -131,7 +131,7 @@ testRule({
         "background-image with relative path inside url function and interpolation.",
       message: messages.expectedAfter("+"),
       line: 4,
-      column: 62
+      column: 62,
     },
     {
       code: `
@@ -144,9 +144,9 @@ testRule({
         "Op +: background-image with relative path inside url function and interpolation.",
       message: messages.expectedAfter("+"),
       line: 4,
-      column: 86
-    }
-  ]
+      column: 86,
+    },
+  ],
 });
 
 // +, before an interpolation
@@ -161,31 +161,31 @@ testRule({
       code: "a { b: 1 +#{$var}; }",
       description: "Op. b: 1 +#{$var}.",
       message: messages.expectedAfter("+"),
-      column: 10
+      column: 10,
     },
     {
       code: "a { b1: 1- +#{$var}; }",
       description: "b1: 1- +#{$var}.",
       message: messages.expectedBefore("-"),
-      column: 10
+      column: 10,
     },
     {
       code: "a { b2: 1px- +#{$var}; }",
       description: "b2: 1px- +#{$var}.",
       message: messages.expectedAfter("+"),
-      column: 14
+      column: 14,
     },
     {
       code: "a { b3: ss- +#{$var}; }",
       description: "Op. b3: ss- +#{$var}.",
       message: messages.expectedAfter("+"),
-      column: 13
+      column: 13,
     },
     {
       code: "a { b4: ss+ +#{1 + 2}; }",
       description: "Op (ss+). b4: ss+ +#{1 + 2}.",
       message: messages.expectedBefore("+"),
-      column: 11
+      column: 11,
     },
     {
       code: `
@@ -198,9 +198,9 @@ testRule({
         "Op +: background-image with relative path inside url function and interpolation.",
       message: messages.expectedBefore("+"),
       line: 4,
-      column: 85
-    }
-  ]
+      column: 85,
+    },
+  ],
 });
 
 // +, before a variable
@@ -215,27 +215,27 @@ testRule({
       code: "a { b: 1 +$var; }",
       description: "Op. b: 1 +$var.",
       message: messages.expectedAfter("+"),
-      column: 10
+      column: 10,
     },
     {
       code: "a { b1: 1- +$var; }",
       description: "b1: 1- +$var.",
       message: messages.expectedBefore("-"),
-      column: 10
+      column: 10,
     },
     {
       code: "a { b2: 1px- +$var; }",
       description: "b2: 1px- +$var.",
       message: messages.expectedAfter("+"),
-      column: 14
+      column: 14,
     },
     {
       code: "a { b3: ss- +$var; }",
       description: "Op. b3: ss- +$var.",
       message: messages.expectedAfter("+"),
-      column: 13
-    }
-  ]
+      column: 13,
+    },
+  ],
 });
 
 // +, before a string
@@ -248,8 +248,8 @@ testRule({
   accept: [
     {
       code: "a { c4: +ss; }",
-      description: "Symbol: +ss."
-    }
+      description: "Symbol: +ss.",
+    },
   ],
 
   reject: [
@@ -257,32 +257,32 @@ testRule({
       code: "a { c: 1 +c; }",
       description: "Op. c: 1 +c.",
       message: messages.expectedAfter("+"),
-      column: 10
+      column: 10,
     },
     {
       code: "a { c2: 1px- +C; }",
       description: "Op, + (not -). c2: 1px- +C.",
       message: messages.expectedAfter("+"),
-      column: 14
+      column: 14,
     },
     {
       code: "a { c3: ss- +c; }",
       description: "Op, + (not -). c3: ss- +c.",
       message: messages.expectedAfter("+"),
-      column: 13
+      column: 13,
     },
     {
       code: "a { c5: ss+ +c; }",
       description: "Op, the first +. c5: ss+ +c.",
       message: messages.expectedBefore("+"),
-      column: 11
+      column: 11,
     },
     {
       code: "a { c5: 1px +s.1px; }",
       message: messages.expectedAfter("+"),
-      description: "Op (1px + s). c5: 1px +s.1px."
-    }
-  ]
+      description: "Op (1px + s). c5: 1px +s.1px.",
+    },
+  ],
 });
 
 // +, before a color
@@ -296,20 +296,20 @@ testRule({
     {
       code: "a { d2: #{$var} +#ffc; }",
       message: messages.expectedAfter("+"),
-      description: "Op (concatenates at least): #{$var} +#ffc."
+      description: "Op (concatenates at least): #{$var} +#ffc.",
     },
     {
       code: "a { d: 1 +#ffc; }",
       message: messages.expectedAfter("+"),
-      description: "Op: 1 +#ffc."
+      description: "Op: 1 +#ffc.",
     },
     {
       code: "a { d3: ss- +#ffc; }",
       description: "Op (+, not -): ss- +#ffc.",
       message: messages.expectedAfter("+"),
-      column: 13
-    }
-  ]
+      column: 13,
+    },
+  ],
 });
 
 // + after something
@@ -323,103 +323,103 @@ testRule({
     {
       code: "a { plusafter1: 1+ 1; }",
       message: messages.expectedBefore("+"),
-      description: "Op: 1+ 1."
+      description: "Op: 1+ 1.",
     },
     {
       code: "a { plusafter11: 1+ 1px; }",
       message: messages.expectedBefore("+"),
-      description: "Op: 1+ 1px."
+      description: "Op: 1+ 1px.",
     },
     {
       code: "a { plusafter12: 1+ px; }",
       message: messages.expectedBefore("+"),
-      description: "Op: 1+ px."
+      description: "Op: 1+ px.",
     },
     {
       code: "a { plusafter13: 1+ #0ff; }",
       message: messages.expectedBefore("+"),
-      description: "Op: 1+ #0ff."
+      description: "Op: 1+ #0ff.",
     },
     {
       code: "a { plusafter14: 1+ $var; }",
       message: messages.expectedBefore("+"),
-      description: "Op: 1+ $var."
+      description: "Op: 1+ $var.",
     },
     {
       code: "a { plusafter14: 1+ fn(); }",
       message: messages.expectedBefore("+"),
-      description: "Op: 1+ fn()."
+      description: "Op: 1+ fn().",
     },
     {
       code: "a { plusafter2: 1px+ 1; }",
       message: messages.expectedBefore("+"),
-      description: "Op: 1px+ 1."
+      description: "Op: 1px+ 1.",
     },
     {
       code: "a { plusafter21: 1px+ 1px; }",
       message: messages.expectedBefore("+"),
-      description: "Op: 1px+ 1px."
+      description: "Op: 1px+ 1px.",
     },
     {
       code: "a { plusafter22: 1px+ px; }",
       message: messages.expectedBefore("+"),
-      description: "Op: 1px+ px."
+      description: "Op: 1px+ px.",
     },
     {
       code: "a { plusafter24: 1px+ $var; }",
       message: messages.expectedBefore("+"),
-      description: "Op: 1px+ $var."
+      description: "Op: 1px+ $var.",
     },
     {
       code: "a { plusafter14: 1px+ fn(); }",
       message: messages.expectedBefore("+"),
-      description: "Op: 1px+ fn()."
+      description: "Op: 1px+ fn().",
     },
     {
       code: "a { plusafter3: #0f0+ 1; }",
       message: messages.expectedBefore("+"),
-      description: "Op: #0f0+ 1."
+      description: "Op: #0f0+ 1.",
     },
     {
       code: "a { plusafter22: #0f0+ px; }",
       message: messages.expectedBefore("+"),
-      description: "Op: #0f0+ px."
+      description: "Op: #0f0+ px.",
     },
     {
       code: "a { plusafter13: #0f0+ #0ff; }",
       message: messages.expectedBefore("+"),
-      description: "Op: #0f0+ #0ff."
+      description: "Op: #0f0+ #0ff.",
     },
     {
       code: "a { plusafter24: #0f0+ $var1; }",
       message: messages.expectedBefore("+"),
-      description: "Op: #0f0+ $var1."
+      description: "Op: #0f0+ $var1.",
     },
     {
       // Interpolation here was making it a List prior to Sass 4. Now fixed
       code: "a { plusafter24: 1px+ #{1 + 2}; }",
       description: "Op (since Sass 4): 1px+ #{1 + 2}.",
       message: messages.expectedBefore("+"),
-      column: 21
+      column: 21,
     },
     {
       code: "a { plusafter24: 1px+ #{$var}; }",
       description: "Op (since Sass 4): 1px+ #{$var}.",
       message: messages.expectedBefore("+"),
-      column: 21
+      column: 21,
     },
     {
       code: "a { plusafter24: #0f0+ #{1 + 2}; }",
       description: "Op (since Sass 4): #0f0+ #{1 + 2}.",
       message: messages.expectedBefore("+"),
-      column: 22
+      column: 22,
     },
     {
       code: "a { plusafter24: #0f0+ #{$var}; }",
       message: messages.expectedBefore("+"),
-      description: "Op (since Sass 4): #0f0+ #{$var}."
-    }
-  ]
+      description: "Op (since Sass 4): #0f0+ #{$var}.",
+    },
+  ],
 });
 
 // ------------------------------------------------------------------------
@@ -436,53 +436,53 @@ testRule({
   accept: [
     {
       code: "a { a: 1 -1; }",
-      description: "List: 1 -1."
+      description: "List: 1 -1.",
     },
     {
       code: "a { a0: (1 -1); }",
-      description: "List (even though parens): (1 -1)."
+      description: "List (even though parens): (1 -1).",
     },
     {
       code: "a { a11: s1- -1; }",
-      description: "List: s1- -1."
+      description: "List: s1- -1.",
     },
     {
       code: "a { a11: (s1- -1); }",
-      description: "List: (s1- -1)."
+      description: "List: (s1- -1).",
     },
     {
       code: "a { a13: 1px -1; }",
-      description: "List: 1px -1."
+      description: "List: 1px -1.",
     },
     {
       code: "a { a2: 1px -1px; }",
-      description: "List: 1px -1px."
+      description: "List: 1px -1px.",
     },
     {
       code: "a { a20: (1px -1px); }",
-      description: "List: (1px -1px)."
+      description: "List: (1px -1px).",
     },
     {
       code: "a { a21: 1 -1px; }",
-      description: "List: 1 -1px."
+      description: "List: 1 -1px.",
     },
     {
       code: "a { a210: (1 -1px); }",
-      description: "List: (1 -1px)."
+      description: "List: (1 -1px).",
     },
     {
       code: "a { a3: 1px- -1px; }",
-      description: "List: 1px- -1px."
+      description: "List: 1px- -1px.",
     },
     {
       code: "a { a30: (1px- -1px); }",
-      description: "List: (1px- -1px)."
+      description: "List: (1px- -1px).",
     },
     {
       code: "a { a5: s.1px -1px; }",
       description:
-        "List (actually, it gets calculated, but only if with the `s` appendix...): s.1px -1px."
-    }
+        "List (actually, it gets calculated, but only if with the `s` appendix...): s.1px -1px.",
+    },
   ],
 
   reject: [
@@ -490,15 +490,15 @@ testRule({
       code: "a { a1: 1- -1; }",
       description: "Op (1-): 1- -1.",
       message: messages.expectedBefore("-"),
-      column: 10
+      column: 10,
     },
     {
       code: "a { a11: 1+ -1; }",
       description: "Op (1+): 1+ -1.",
       message: messages.expectedBefore("+"),
-      column: 11
-    }
-  ]
+      column: 11,
+    },
+  ],
 });
 
 // - before an interpolation
@@ -511,17 +511,17 @@ testRule({
   accept: [
     {
       code: "a { b: 1 -#{$var}; }",
-      description: "Sign: 1 -#{$var}."
+      description: "Sign: 1 -#{$var}.",
     },
     {
       code: "a { b2: 1px- -#{$var}; }",
       description: "Sign: 1px- -#{$var}.",
       message: messages.expectedAfter("-"),
-      column: 14
+      column: 14,
     },
     {
       code: "a { b3: ss- -#{$var}; }",
-      description: "Sign: ss- -#{$var}."
+      description: "Sign: ss- -#{$var}.",
     },
     {
       code: `
@@ -531,8 +531,8 @@ testRule({
       }
       `,
       description:
-        "Op -: background-image with absolute path inside url function and interpolation."
-    }
+        "Op -: background-image with absolute path inside url function and interpolation.",
+    },
   ],
 
   reject: [
@@ -540,13 +540,13 @@ testRule({
       code: "a { b1: 1- -#{$var}; }",
       description: "op (1-): 1- -#{$var}.",
       message: messages.expectedBefore("-"),
-      column: 10
+      column: 10,
     },
     {
       code: "a { b4: ss+ -#{1 + 2}; }",
       description: "Op (ss+): ss+ -#{1 + 2}.",
       message: messages.expectedBefore("+"),
-      column: 11
+      column: 11,
     },
     {
       code: `
@@ -559,9 +559,9 @@ testRule({
         "Op -: background-image with relative path inside url function and interpolation.",
       message: messages.expectedBefore("-"),
       line: 4,
-      column: 85
-    }
-  ]
+      column: 85,
+    },
+  ],
 });
 
 // - before a string
@@ -574,20 +574,20 @@ testRule({
   accept: [
     {
       code: "a { c: 1 -c; }",
-      description: "Char: 1 -c."
+      description: "Char: 1 -c.",
     },
     {
       code: "a { c2: 1px- -C; }",
-      description: "Char (both): 1px- -C."
+      description: "Char (both): 1px- -C.",
     },
     {
       code: "a { c3: ss- -c; }",
-      description: "Char (both): ss- -c."
+      description: "Char (both): ss- -c.",
     },
     {
       code: "a { c4: -ss; }",
-      description: "Char: -ss."
-    }
+      description: "Char: -ss.",
+    },
   ],
 
   reject: [
@@ -595,15 +595,15 @@ testRule({
       code: "a { c5: ss+ -c; }",
       description: "+ is an op, - is not: ss+ -c.",
       message: messages.expectedBefore("+"),
-      column: 11
+      column: 11,
     },
     {
       code: "a { c1: 1- -c; }",
       description: "1- is op, -c is string: 1- -c.",
       message: messages.expectedBefore("-"),
-      column: 10
-    }
-  ]
+      column: 10,
+    },
+  ],
 });
 
 // - before a variable
@@ -617,52 +617,52 @@ testRule({
     {
       code: "a { b: 1 -$var; }",
       message: messages.expectedAfter("-"),
-      description: "Op: 1 -$var."
+      description: "Op: 1 -$var.",
     },
     {
       code: "a { b1: 1- -$var; }",
       description: "Op: 1- -$var.",
       message: messages.expectedBefore("-"),
-      column: 10
+      column: 10,
     },
     {
       code: "a { b2: 1px -$var; }",
       description: "Op: 1px -$var.",
-      message: messages.expectedAfter("-")
+      message: messages.expectedAfter("-"),
     },
     {
       code: "a { b21: 1px+ -$var; }",
       description: "Op: 1px+ -$var.",
       message: messages.expectedBefore("+"),
-      column: 13
+      column: 13,
     },
     {
       code: "a { b3: ss- -$var; }",
       description: "Op: ss- -$var.",
       message: messages.expectedAfter("-"),
-      column: 13
+      column: 13,
     },
     {
       code: "a { b4: $var+ -$var; }",
       description: "Op: $var+ -$var.",
       message: messages.expectedBefore("+"),
-      column: 13
+      column: 13,
     },
     {
       // The plus gives one warning
       code: "a { b4: #{$var}+ -$var; }",
       description: "Op (the +): #{$var}+ -$var.",
       message: messages.expectedBefore("+"),
-      column: 16
+      column: 16,
     },
     {
       // The plus gives one warning
       code: "a { b4: ss+ -$var; }",
       description: "Op (the +): ss+ -$var.",
       message: messages.expectedBefore("+"),
-      column: 11
-    }
-  ]
+      column: 11,
+    },
+  ],
 });
 
 // - before a HEX-color
@@ -675,12 +675,12 @@ testRule({
   accept: [
     {
       code: "a { d: 1 -#ffc; }",
-      description: "Char (concatenation though): 1 -#ffc."
+      description: "Char (concatenation though): 1 -#ffc.",
     },
     {
       code: "a { d3: ss- -#ffc; }",
-      description: "Char (concatenation though): ss- -#ffc."
-    }
+      description: "Char (concatenation though): ss- -#ffc.",
+    },
   ],
 
   reject: [
@@ -688,20 +688,20 @@ testRule({
       code: "a { d4: ss+ -#ffc; }",
       description: "Char (and + is op): ss+ -#ffc.",
       message: messages.expectedBefore("+"),
-      column: 11
+      column: 11,
     },
     {
       code: "a { d2: #ff4 -#ffc; }",
       message: messages.expectedAfter("-"),
-      description: "Op: #ff4 -#ffc."
+      description: "Op: #ff4 -#ffc.",
     },
     {
       code: "a { d1: 1- -#ffc; }",
       description: "concatenation: 1- -#ffc.",
       message: messages.expectedBefore("-"),
-      column: 10
-    }
-  ]
+      column: 10,
+    },
+  ],
 });
 
 // - after a number
@@ -715,42 +715,42 @@ testRule({
     {
       code: "a { minusafter1: 1- 1; }",
       message: messages.expectedBefore("-"),
-      description: "Op: 1- 1."
+      description: "Op: 1- 1.",
     },
     {
       code: "a { minusafter11: 1- 1px; }",
       message: messages.expectedBefore("-"),
-      description: "Op: 1- 1px."
+      description: "Op: 1- 1px.",
     },
     {
       code: "a { minusafter110: (1- 1px); }",
       message: messages.expectedBefore("-"),
-      description: "Op: (1- 1px)."
+      description: "Op: (1- 1px).",
     },
     {
       code: "a { minusafter12: 1- px; }",
       message: messages.expectedBefore("-"),
-      description: "Op (though concatenated): 1- px."
+      description: "Op (though concatenated): 1- px.",
     },
     {
       code: "a { minusafter13: 1- #0ff; }",
       message: messages.expectedBefore("-"),
-      description: "Op (though concatenated): 1- #0ff."
+      description: "Op (though concatenated): 1- #0ff.",
     },
     {
       code: "a { minusafter15: 1- $var; }",
       message: messages.expectedBefore("-"),
-      description: "Op: 1- $var."
+      description: "Op: 1- $var.",
     },
     {
       code: "a { minusafter16: 1- fn(); }",
       message: messages.expectedBefore("-"),
-      description: "Op: 1- fn()."
+      description: "Op: 1- fn().",
     },
     {
       code: "a { minusafter15: 1- #{$var}; }",
       message: messages.expectedBefore("-"),
-      description: "Op (though concatenated): 1- #{$var}."
+      description: "Op (though concatenated): 1- #{$var}.",
     },
     {
       code: `
@@ -763,9 +763,9 @@ testRule({
         "Op -: background-image with relative path inside url function and interpolation.",
       message: messages.expectedAfter("-"),
       line: 4,
-      column: 86
-    }
-  ]
+      column: 86,
+    },
+  ],
 });
 
 // - after a value with a unit
@@ -778,41 +778,41 @@ testRule({
   accept: [
     {
       code: "a { minusafter2: 1px- 1; }",
-      description: "Sign: 1px- 1."
+      description: "Sign: 1px- 1.",
     },
     {
       code: "a { minusafter20: (1px- 1); }",
-      description: "Sign: (1px- 1)."
+      description: "Sign: (1px- 1).",
     },
     {
       code: "a { minusafter21: 1px- 1px; }",
-      description: "Sign: 1px- 1px."
+      description: "Sign: 1px- 1px.",
     },
     {
       code: "a { minusafter211: 1px- +1px; }",
-      description: "Sign: 1px- +1px."
+      description: "Sign: 1px- +1px.",
     },
     {
       code: "a { minusafter22: 1px- px; }",
-      description: "Sign: 1px- px."
+      description: "Sign: 1px- px.",
     },
     {
       code: "a { minusafter24: 1px- $var; }",
-      description: "Sign: 1px- $var."
+      description: "Sign: 1px- $var.",
     },
     {
       code: "a { minusafter14: 1px- fn(); }",
-      description: "Sign: 1px- fn()."
+      description: "Sign: 1px- fn().",
     },
     {
       code: "a { minusafter24: 1px- #{1 + 2}; }",
-      description: "Sign: 1px- #{1 + 2}."
+      description: "Sign: 1px- #{1 + 2}.",
     },
     {
       code: "a { minusafter24: 1px- #{$var}; }",
-      description: "Sign: 1px- #{$var}."
-    }
-  ]
+      description: "Sign: 1px- #{$var}.",
+    },
+  ],
 });
 
 // - after a HEX color
@@ -826,30 +826,30 @@ testRule({
     {
       code: "a { minusafter3: #0f0- 1; }",
       message: messages.expectedBefore("-"),
-      description: "Op: #0f0- 1."
+      description: "Op: #0f0- 1.",
     },
     {
       code: "a { minusafter22: #0f0- px; }",
       message: messages.expectedBefore("-"),
-      description: "Op (concat): #0f0- px."
+      description: "Op (concat): #0f0- px.",
     },
     {
       code: "a { minusafter13: #0f0- #0ff; }",
       message: messages.expectedBefore("-"),
-      description: "Op: #0f0- #0ff."
+      description: "Op: #0f0- #0ff.",
     },
     {
       code: "a { minusafter24: #0f0- $var1; }",
       message: messages.expectedBefore("-"),
-      description: "Op: #0f0- $var1."
+      description: "Op: #0f0- $var1.",
     },
     {
       code: "a { minusafter34: #0f0- #{1 + 2}; }",
       description: "Op (concat): #0f0- #{1 + 2}.",
       message: messages.expectedBefore("-"),
-      column: 23
-    }
-  ]
+      column: 23,
+    },
+  ],
 });
 
 // - without spaces
@@ -862,51 +862,50 @@ testRule({
   accept: [
     {
       code: "a { nospaces3: px-1px; }",
-      description: "Char: px-1px."
+      description: "Char: px-1px.",
     },
     {
       code: "a { nospaces2: 5px-px; }",
-      description: "Char: 5px-px."
+      description: "Char: 5px-px.",
     },
     {
       code: "a { nospaces9: $var-1; }",
-      description: "Char (actually, part of variable name): $var-1."
+      description: "Char (actually, part of variable name): $var-1.",
     },
     {
       code: "a { nospaces9: $var-1px; }",
-      description: "Char (actually, part of variable name): $var-1px."
+      description: "Char (actually, part of variable name): $var-1px.",
     },
     {
       code: "a { nospaces9: #{$var-1px}; }",
-      description: "Char (actually, part of variable name): $var-1px."
+      description: "Char (actually, part of variable name): $var-1px.",
     },
     {
-      code:
-        'a { background-image: url(if($bootstrap-sass-asset-helper, twbs-image-path("#{$var-1x}"), "#{$var-1x}")); }',
+      code: 'a { background-image: url(if($bootstrap-sass-asset-helper, twbs-image-path("#{$var-1x}"), "#{$var-1x}")); }',
       description:
-        'Char (actually, part of variable name): url(if($bootstrap-sass-asset-helper, twbs-image-path("#{$var-1x}"), "#{$var-1x}"));.'
+        'Char (actually, part of variable name): url(if($bootstrap-sass-asset-helper, twbs-image-path("#{$var-1x}"), "#{$var-1x}"));.',
     },
     {
       code: "a { nospaces102: 1-fn(); }",
-      description: "Char: 1-fn()."
+      description: "Char: 1-fn().",
     },
     {
       code: "a { nospaces71: #{1px}-1; }",
-      description: "??: #{1px}-1."
+      description: "??: #{1px}-1.",
     },
     {
       code: "a { nospaces72: #{1}-1; }",
-      description: "??: #{1}-1."
+      description: "??: #{1}-1.",
     },
     {
       code: "a { nospaces73: 1-#{1}; }",
-      description: "??: 1-#{1}."
+      description: "??: 1-#{1}.",
     },
     {
       code: '@forward "src/list" as list-*;',
-      description: "should ignore @forward"
-    }
-  ]
+      description: "should ignore @forward",
+    },
+  ],
 });
 
 // - next to parens
@@ -922,16 +921,16 @@ testRule({
       description: "10px -(1 + 1).",
       line: 1,
       column: 17,
-      message: messages.expectedAfter("-")
+      message: messages.expectedAfter("-"),
     },
     {
       code: "a { width: (10px)- 1};",
       description: "(10px)- 1.",
       line: 1,
       column: 18,
-      message: messages.expectedBefore("-")
-    }
-  ]
+      message: messages.expectedBefore("-"),
+    },
+  ],
 });
 
 // Mixed cases
@@ -944,9 +943,9 @@ testRule({
   accept: [
     {
       code: "a {transform: translate(-50%, -$no-ui-slider-height);}",
-      description: "translate(-50%, -$no-ui-slider-height)."
-    }
-  ]
+      description: "translate(-50%, -$no-ui-slider-height).",
+    },
+  ],
 });
 
 // ------------------------------------------------------------------------
@@ -962,143 +961,143 @@ testRule({
   accept: [
     {
       code: "a { slash1: 1px/1px; }",
-      description: "Char: 1px/1px."
+      description: "Char: 1px/1px.",
     },
     {
       code: "a { slash12: $var/string; }",
-      description: "CSS slash: $var/string."
+      description: "CSS slash: $var/string.",
     },
     {
       code: "a { slash12: string/$var }",
-      description: "CSS slash: string/$var."
+      description: "CSS slash: string/$var.",
     },
     {
       code: "a { slash12: #{$var}/1; }",
-      description: "Char: #{$var}/1."
+      description: "Char: #{$var}/1.",
     },
     {
       code: "a { slash11: 1px/ 1px; }",
-      description: "Char: 1px/ 1px."
+      description: "Char: 1px/ 1px.",
     },
     {
       code: "a { slash12: 1px /1px; }",
-      description: "Char: 1px /1px."
+      description: "Char: 1px /1px.",
     },
     {
       code: "a { width: 8px/2px +5px; }",
-      description: "width: 8px/2px +5px."
+      description: "width: 8px/2px +5px.",
     },
     {
       code: "a { width: 8px/2px +5; }",
-      description: "width: 8px/2px +5."
+      description: "width: 8px/2px +5.",
     },
     {
       code: "a { width: 8px/2px -5px; }",
-      description: "width: 8px/2px -5px."
+      description: "width: 8px/2px -5px.",
     },
     {
       code: "a { width: 8px/2px -5; }",
-      description: "width: 8px/2px -5."
+      description: "width: 8px/2px -5.",
     },
     {
       code: "a { width: 8px/2px -ss; }",
-      description: "width: 8px/2px -ss."
+      description: "width: 8px/2px -ss.",
     },
     {
       code: "a { width: 8px/2px -fn(); }",
-      description: "width: 8px/2px -fn()."
+      description: "width: 8px/2px -fn().",
     },
     {
       code: "a { width: (8px/2px -5px); }",
-      description: "width: (8px/2px -5px)."
+      description: "width: (8px/2px -5px).",
     },
     {
       code: "a { width: (8px/2px -5); }",
-      description: "width: (8px/2px -5)."
+      description: "width: (8px/2px -5).",
     },
     {
       code: "a { width: 8px/2px-ss; }",
-      description: "width: 8px/2px-ss."
+      description: "width: 8px/2px-ss.",
     },
     {
       code: "a { width: 8px/2px-$var; }",
-      description: "width: 8px/2px-$var."
+      description: "width: 8px/2px-$var.",
     },
     {
       code: "a { width: 8px/2px-fn(); }",
-      description: "width: 8px/2px-fn()."
+      description: "width: 8px/2px-fn().",
     },
     {
       code: "a { width: 8px/2 -5px; }",
-      description: "width: 8px/2 -5px."
+      description: "width: 8px/2 -5px.",
     },
     {
       code: "a { width: 8px/2 -5; }",
-      description: "width: 8px/2 -5."
+      description: "width: 8px/2 -5.",
     },
     {
       code: "a { width: 8px/2 -ss; }",
-      description: "width: 8px/2 -ss."
+      description: "width: 8px/2 -ss.",
     },
     {
       code: "a { width: 8px/2 -#{1}; }",
-      description: "width: 8px/2 -#{1}."
+      description: "width: 8px/2 -#{1}.",
     },
     {
       code: "a { width: 8px/2 -fn(); }",
-      description: "width: 8px/2 -fn()."
+      description: "width: 8px/2 -fn().",
     },
     {
       code: "a { width: (8px/2 -5px); }",
-      description: "width: (8px/2 -5px)."
+      description: "width: (8px/2 -5px).",
     },
     {
       code: "a { width: (8px/2 -5); }",
-      description: "width: (8px/2 -5)."
+      description: "width: (8px/2 -5).",
     },
     {
       code: "a { width: 8px/2-ss; }",
-      description: "width: 8px/2-ss."
+      description: "width: 8px/2-ss.",
     },
     {
       code: "a { width: 8px/2-#{$var}; }",
-      description: "width: 8px/2-#{$var}."
+      description: "width: 8px/2-#{$var}.",
     },
     {
       code: "a { width: 8px/2-fn(); }",
-      description: "width: 8px/2-fn()."
+      description: "width: 8px/2-fn().",
     },
     {
       code: "a { width: 8px/2px- 5px; }",
-      description: "width: 8px/2px- 5px."
+      description: "width: 8px/2px- 5px.",
     },
     {
       code: "a { width: 8px/2px- 5; }",
-      description: "width: 8px/2px- 5."
+      description: "width: 8px/2px- 5.",
     },
     {
       code: "a { width: 8px/2px- 5; }",
-      description: "width: 8px/2px- 5."
+      description: "width: 8px/2px- 5.",
     },
     {
       code: "a { width: 8px/2px- ss; }",
-      description: "width: 8px/2px- ss."
+      description: "width: 8px/2px- ss.",
     },
     {
       code: "a { width: 8px/2px- $var; }",
-      description: "width: 8px/2px- $var."
+      description: "width: 8px/2px- $var.",
     },
     {
       code: "a { width: 8px/2px- fn(); }",
-      description: "width: 8px/2px- fn()."
+      description: "width: 8px/2px- fn().",
     },
     {
       code: "a { width: (8px/2px- 5px); }",
-      description: "width: (8px/2px- 5px)."
+      description: "width: (8px/2px- 5px).",
     },
     {
       code: "a { width: (8px/2px- 5); }",
-      description: "width: (8px/2px- 5)."
+      description: "width: (8px/2px- 5).",
     },
     {
       code: `
@@ -1106,7 +1105,7 @@ testRule({
         background-image: url(../../img/build/svg/arrow-11-down-dark.svg);
       }
       `,
-      description: "background image with relative path inside url function."
+      description: "background image with relative path inside url function.",
     },
     {
       code: `
@@ -1115,7 +1114,7 @@ testRule({
       }
       `,
       description:
-        "multiple background images with relative path inside url function."
+        "multiple background images with relative path inside url function.",
     },
     {
       code: `
@@ -1125,7 +1124,7 @@ testRule({
       }
       `,
       description:
-        "background-image with relative path inside url function and interpolation."
+        "background-image with relative path inside url function and interpolation.",
     },
     {
       code: `
@@ -1135,57 +1134,57 @@ testRule({
       }
       `,
       description:
-        "Op /: background-image with absolute path inside url function and interpolation."
-    }
+        "Op /: background-image with absolute path inside url function and interpolation.",
+    },
   ],
 
   reject: [
     {
       code: "a { slash10: (1px/ 1px); }",
       message: messages.expectedBefore("/"),
-      description: "Op: (1px/ 1px)."
+      description: "Op: (1px/ 1px).",
     },
     {
       code: "a { slash12: 1px /$var; }",
       message: messages.expectedAfter("/"),
-      description: "Op: 1px /$var."
+      description: "Op: 1px /$var.",
     },
     {
       code: "a { slash12: $var/ 1; }",
       description: "Op: $var/ 1.",
       message: messages.expectedBefore("/"),
-      column: 18
+      column: 18,
     },
     {
       code: "a { slash12: $var /-1px; }",
       description: "Op: $var /-1px.",
       message: messages.expectedAfter("/"),
-      column: 19
+      column: 19,
     },
     {
       code: "a { slash12: 2px/ fn(); }",
       description: "Op: 2px/ fn().",
       message: messages.expectedBefore("/"),
-      column: 17
+      column: 17,
     },
     {
       code: "a { slash12: 2px /-fn(); }",
       description: "Op: 2px /-fn().",
       message: messages.expectedAfter("/"),
-      column: 18
+      column: 18,
     },
     {
       code: "a { slash12: 2px /+fn(); }",
       description: "Op: 2px /+fn().",
       message: messages.expectedAfter("/"),
-      column: 18
+      column: 18,
     },
     {
       code: "a { width: 8px/2- ss }",
       description:
         "- does concatenate, so warning. But it's not a math op, so doesn't /: 8px/2- ss.",
       message: messages.expectedBefore("-"),
-      column: 17
+      column: 17,
     },
     {
       code: `
@@ -1198,7 +1197,7 @@ testRule({
         "background-image with relative path inside url function and interpolation.",
       message: messages.expectedAfter("/"),
       line: 4,
-      column: 62
+      column: 62,
     },
     {
       code: `
@@ -1211,7 +1210,7 @@ testRule({
         "Op /: background-image with relative path inside url function and interpolation.",
       message: messages.expectedAfter("/"),
       line: 4,
-      column: 86
+      column: 86,
     },
     {
       code: `
@@ -1224,9 +1223,9 @@ testRule({
         "Op /: background-image with relative path inside url function and interpolation.",
       message: messages.expectedBefore("/"),
       line: 4,
-      column: 85
-    }
-  ]
+      column: 85,
+    },
+  ],
 });
 
 // - next to parens
@@ -1240,20 +1239,20 @@ testRule({
     {
       code: "a { width: (10px) /#{(1 + 1)}};",
       description:
-        "Has parens, but also interpolation; ignored: (10px) /#{(1 + 1)}."
+        "Has parens, but also interpolation; ignored: (10px) /#{(1 + 1)}.",
     },
     {
       code: "a { width: #{10} /(1.2)};",
-      description: "Has parens, but also interpolation; ignored: #{10} /(1.2)."
+      description: "Has parens, but also interpolation; ignored: #{10} /(1.2).",
     },
     {
       code: "a { width: (10px) /normal; };",
-      description: "Has parens, but also a string; ignored: (10px) /normal."
+      description: "Has parens, but also a string; ignored: (10px) /normal.",
     },
     {
       code: "a { width: inherit /(1.1); }",
-      description: "Has parens, but also a string; ignored: inherit /(1.1)."
-    }
+      description: "Has parens, but also a string; ignored: inherit /(1.1).",
+    },
   ],
 
   reject: [
@@ -1262,16 +1261,16 @@ testRule({
       description: "10px /(1 + 1).",
       line: 1,
       column: 17,
-      message: messages.expectedAfter("/")
+      message: messages.expectedAfter("/"),
     },
     {
       code: "a { width: (10px)/ 1};",
       description: "(10px)/ 1.",
       line: 1,
       column: 18,
-      message: messages.expectedBefore("/")
-    }
-  ]
+      message: messages.expectedBefore("/"),
+    },
+  ],
 });
 
 // ------------------------------------------------------------------------
@@ -1295,11 +1294,11 @@ testRule({
       }
       `,
       description:
-        "Op *: background-image with absolute path inside url function and interpolation."
+        "Op *: background-image with absolute path inside url function and interpolation.",
     },
     {
       code: '@use "src/corners" as *;',
-      description: "ignores @use"
+      description: "ignores @use",
     },
     {
       code: `
@@ -1309,8 +1308,8 @@ testRule({
         }
       }
       `,
-      description: "ignores @at-root"
-    }
+      description: "ignores @at-root",
+    },
   ],
 
   reject: [
@@ -1318,13 +1317,13 @@ testRule({
       code: "a { width: 10* 1; }",
       description: "Op: 10* 1.",
       message: messages.expectedBefore("*"),
-      column: 14
+      column: 14,
     },
     {
       code: "a { width: 10 *1; }",
       description: "Op: 10 *1.",
       message: messages.expectedAfter("*"),
-      column: 15
+      column: 15,
     },
     {
       code: `
@@ -1337,7 +1336,7 @@ testRule({
         "Op *: background-image with relative path inside url function and interpolation.",
       message: messages.expectedAfter("*"),
       line: 4,
-      column: 86
+      column: 86,
     },
     {
       code: `
@@ -1350,9 +1349,9 @@ testRule({
         "Op *: background-image with relative path inside url function and interpolation.",
       message: messages.expectedBefore("*"),
       line: 4,
-      column: 85
-    }
-  ]
+      column: 85,
+    },
+  ],
 });
 
 // ------------------------------------------------------------------------
@@ -1368,68 +1367,68 @@ testRule({
   accept: [
     {
       code: "a { width: 10%; }",
-      description: "10%."
+      description: "10%.",
     },
     {
       code: "a { width: 10% 2; }",
-      description: "10% 2."
+      description: "10% 2.",
     },
     {
       code: "a { width: 10% $var; }",
-      description: "10% $var."
+      description: "10% $var.",
     },
     {
       code: "a { width: 10% fn(); }",
-      description: "10% fn()."
+      description: "10% fn().",
     },
     {
       code: "a { width: 10% (1 + 3); }",
-      description: "10% (1 + 3)."
+      description: "10% (1 + 3).",
     },
     {
       code: "a { width: #{$var}% 2; }",
-      description: "#{$var}% 2."
+      description: "#{$var}% 2.",
     },
     {
       code: "a { width: 10% -2; }",
-      description: "10% -2."
+      description: "10% -2.",
     },
     {
       code: "a { width: 10% -fn(); }",
-      description: "10% -fn()."
+      description: "10% -fn().",
     },
     {
       code: "a { width: #{$var}% -2; }",
-      description: "#{$var}% -2."
+      description: "#{$var}% -2.",
     },
     {
       code: "a { width: #{$var}% - 2; }",
-      description: "#{$var}% - 2."
+      description: "#{$var}% - 2.",
     },
     {
       code: "a { width: #{$var} %2; }",
-      description: "#{$var} %2."
+      description: "#{$var} %2.",
     },
     {
       code: "a { width: $var %#{2}; }",
-      description: "$var %#{2}."
+      description: "$var %#{2}.",
     },
     {
       // In these the - is and op, not the %
       code: "a { width: 10% - 2; }",
-      description: "10% - 2."
+      description: "10% - 2.",
     },
     {
       code: "a { width: 10% - $var; }",
-      description: "10% - $var."
+      description: "10% - $var.",
     },
     {
       code: "a { width: 10% - fn(); }",
-      description: "10% - fn()."
+      description: "10% - fn().",
     },
     {
       code: "a { width: 10% - (1 + 3); }",
-      description: "10% - (1 + 3)."
+      description: "10% - (1 + 3).",
     },
     {
       code: `
@@ -1439,91 +1438,91 @@ testRule({
       }
       `,
       description:
-        "Op %: background-image with absolute path inside url function and interpolation."
-    }
+        "Op %: background-image with absolute path inside url function and interpolation.",
+    },
   ],
 
   reject: [
     {
       code: "a { width: $var% 2; }",
       description: "$var% 2.",
-      message: messages.expectedBefore("%")
+      message: messages.expectedBefore("%"),
     },
     {
       code: "a { width: fn()% 2; }",
       description: "fn()% 2.",
-      message: messages.expectedBefore("%")
+      message: messages.expectedBefore("%"),
     },
     {
       code: "a { width: (10 + 1)% 2; }",
       description: "(10 + 1)% 2.",
-      message: messages.expectedBefore("%")
+      message: messages.expectedBefore("%"),
     },
     {
       code: "a { width: $var% -2; }",
       description: "$var% -2.",
-      message: messages.expectedBefore("%")
+      message: messages.expectedBefore("%"),
     },
     {
       code: "a { width: fn()% -2; }",
       description: "fn()% -2.",
-      message: messages.expectedBefore("%")
+      message: messages.expectedBefore("%"),
     },
     {
       code: "a { width: (10 + 1)% -2; }",
       description: "(10 + 1)% -2.",
-      message: messages.expectedBefore("%")
+      message: messages.expectedBefore("%"),
     },
     {
       code: "a { width: $var% - 2; }",
       description: "$var% - 2.",
-      message: messages.expectedBefore("%")
+      message: messages.expectedBefore("%"),
     },
     {
       code: "a { width: fn()% - 2; }",
       description: "fn()% - 2.",
-      message: messages.expectedBefore("%")
+      message: messages.expectedBefore("%"),
     },
     {
       code: "a { width: (10 + 1)% - 2; }",
       description: "(10 + 1)% - 2.",
-      message: messages.expectedBefore("%")
+      message: messages.expectedBefore("%"),
     },
     {
       code: "a { width: 10 %2; }",
       description: "10 %2.",
-      message: messages.expectedAfter("%")
+      message: messages.expectedAfter("%"),
     },
     {
       code: "a { width: 10 %$var; }",
       description: "10 %$var.",
-      message: messages.expectedAfter("%")
+      message: messages.expectedAfter("%"),
     },
     {
       code: "a { width: $var %2; }",
       description: "$var %2.",
-      message: messages.expectedAfter("%")
+      message: messages.expectedAfter("%"),
     },
     {
       code: "a { width: fn() %2; }",
       description: "fn() %2.",
-      message: messages.expectedAfter("%")
+      message: messages.expectedAfter("%"),
     },
     {
       code: "a { width: (10 + 1) %2; }",
       description: "(10 + 1) %2.",
-      message: messages.expectedAfter("%")
+      message: messages.expectedAfter("%"),
     },
     {
       // minus is op in these:
       code: "a { width: 10% -$var; }",
       description: "10% -$var.",
-      message: messages.expectedAfter("-")
+      message: messages.expectedAfter("-"),
     },
     {
       code: "a { width: 10% -(1 + 3); }",
       description: "10% -(1 + 3).",
-      message: messages.expectedAfter("-")
+      message: messages.expectedAfter("-"),
     },
     {
       code: `
@@ -1536,7 +1535,7 @@ testRule({
         "Op %: background-image with relative path inside url function and interpolation.",
       message: messages.expectedAfter("%"),
       line: 4,
-      column: 86
+      column: 86,
     },
     {
       code: `
@@ -1549,9 +1548,9 @@ testRule({
         "Op %: background-image with relative path inside url function and interpolation.",
       message: messages.expectedBefore("%"),
       line: 4,
-      column: 85
-    }
-  ]
+      column: 85,
+    },
+  ],
 });
 
 // ------------------------------------------------------------------------
@@ -1567,25 +1566,25 @@ testRule({
   accept: [
     {
       code: 'a { width: "10*1"; }',
-      description: 'A string: "10*1".'
+      description: 'A string: "10*1".',
     },
     {
       code: "a { width: '10* 1'; }",
-      description: "A string: '10* 1'."
+      description: "A string: '10* 1'.",
     },
     {
       code: 'a { width: "10 \\" 10*1"; }',
-      description: 'A string: "10 \\" 10*1".'
-    }
+      description: 'A string: "10 \\" 10*1".',
+    },
   ],
 
   reject: [
     {
       code: 'a { width: "#{10 %1}"; }',
       message: messages.expectedAfter("%"),
-      description: 'Op (interpolation inside a string): "#{10 %1}".'
-    }
-  ]
+      description: 'Op (interpolation inside a string): "#{10 %1}".',
+    },
+  ],
 });
 
 // double -
@@ -1599,29 +1598,29 @@ testRule({
   accept: [
     {
       code: "a { width: 1 --a; }",
-      description: "Chars: 1 --a."
+      description: "Chars: 1 --a.",
     },
     {
       code: "a { width: 1--a; }",
-      description: "Chars: 1--a."
+      description: "Chars: 1--a.",
     },
     {
       code: "a { width: 1px-- 1px; }",
-      description: "Chars: 1px-- 1px."
+      description: "Chars: 1px-- 1px.",
     },
     {
       code: "a { width: #fac --#365; }",
-      description: "Chars: #fac --#365."
+      description: "Chars: #fac --#365.",
     },
     {
       code: "a { width: #fac -- #365; }",
-      description: "Chars: #fac -- #365."
+      description: "Chars: #fac -- #365.",
     },
     {
       code: "a { width: $var---; }",
-      description: "Variable part: $var---."
-    }
-  ]
+      description: "Variable part: $var---.",
+    },
+  ],
 });
 
 // Newlines, multiple spaces
@@ -1640,7 +1639,7 @@ testRule({
       }
     `,
       description:
-        "operator-newline-indentation (spaces)-operand: 1 -\\n          a."
+        "operator-newline-indentation (spaces)-operand: 1 -\\n          a.",
     },
     {
       code: `
@@ -1649,7 +1648,7 @@ testRule({
 a;
       }
     `,
-      description: "Operator-newline-operand: 1 -\\na."
+      description: "Operator-newline-operand: 1 -\\na.",
     },
     {
       code: `
@@ -1658,7 +1657,7 @@ a;
 - a;
       }
     `,
-      description: "Operand-newline-operator: 1\\n- a."
+      description: "Operand-newline-operator: 1\\n- a.",
     },
     {
       code: `
@@ -1667,7 +1666,7 @@ a;
           - a;
       }
     `,
-      description: "Operand-newline-indentation-operator: 1\\n-          a."
+      description: "Operand-newline-indentation-operator: 1\\n-          a.",
     },
     {
       code: `
@@ -1676,8 +1675,8 @@ a;
 - 1;
       }
     `,
-      description: "Multiple spaces-newline-operator (ignored): 1  \\n- 1."
-    }
+      description: "Multiple spaces-newline-operator (ignored): 1  \\n- 1.",
+    },
   ],
 
   reject: [
@@ -1693,23 +1692,23 @@ a;
       description:
         "Operator-spaces-newline-indentation-operand and a breaching operator: 1 -  \\na+ 1.",
       line: 5,
-      column: 12
+      column: 12,
     },
     {
       code: "a { width: 1 -  1; }",
       message: messages.expectedAfter("-"),
       description: "Two spaces after: 1 -  1.",
       line: 1,
-      column: 14
+      column: 14,
     },
     {
       code: "a { width: 1  - 1; }",
       message: messages.expectedBefore("-"),
       description: "Two spaces before: 1  - 1.",
       line: 1,
-      column: 15
-    }
-  ]
+      column: 15,
+    },
+  ],
 });
 
 // ------------------------------------------------------------------------
@@ -1726,21 +1725,21 @@ testRule({
   accept: [
     {
       code: "p>p { color: red; }",
-      description: "Selector combinator, +."
+      description: "Selector combinator, +.",
     },
     {
       code: "p+p { color: red; }",
-      description: "Selector combinator, >."
+      description: "Selector combinator, >.",
     },
     {
       code: "p { background-color: red; }",
-      description: "Property part, -: background-color: red."
+      description: "Property part, -: background-color: red.",
     },
     {
       code: ".class#{1 + 1}name { color: red; }",
       description:
-        "Interpolation in selector (proper spaces): .class#{1 + 1}name."
-    }
+        "Interpolation in selector (proper spaces): .class#{1 + 1}name.",
+    },
   ],
 
   reject: [
@@ -1748,14 +1747,14 @@ testRule({
       code: ".class#{1 +1}name { color: red; }",
       description: "Interpolation in a selector: .class#{1 +1}name.",
       message: messages.expectedAfter("+"),
-      column: 11
+      column: 11,
     },
     {
       code: "#id, .class#{1 +1}name { color: red; }",
       description:
         "Interpolation in a selector (second in a list): .#id, class#{1 +1}name.",
       message: messages.expectedAfter("+"),
-      column: 16
+      column: 16,
     },
     {
       code: `
@@ -1765,29 +1764,29 @@ testRule({
         "Interpolation in selector, newline and indentation before: .class#{1 +1}name.",
       line: 2,
       column: 17,
-      message: messages.expectedAfter("+")
+      message: messages.expectedAfter("+"),
     },
     {
       code: ".cl#{ $var>= 10 }n { color: red; }",
       description: "Interpolation in selector: .cl#{ $var>= 10 }n.",
       message: messages.expectedBefore(">="),
-      column: 11
+      column: 11,
     },
     {
       code: 'p { background-#{"col" +"or"}: red; }',
       description: 'Interpolation in prop name: background-#{"col" +"or"}.',
       message: messages.expectedAfter("+"),
       // backslashes excluded
-      column: 24
+      column: 24,
     },
     {
       code: 'p { background-#{"col"+ "or"}: red; }',
       description: 'Interpolation in prop name: background-#{"col"+ "or"}.',
       message: messages.expectedBefore("+"),
       // backslashes excluded
-      column: 23
-    }
-  ]
+      column: 23,
+    },
+  ],
 });
 
 // ------------------------------------------------------------------------
@@ -1805,39 +1804,39 @@ testRule({
       code: "a { width: $var !=1; }",
       description: "Op: $var !=1.",
       message: messages.expectedAfter("!="),
-      column: 18
+      column: 18,
     },
     {
       code: "a { width: $var< 1; }",
       description: "Op: $var< 1.",
       message: messages.expectedBefore("<"),
-      column: 16
+      column: 16,
     },
     {
       code: "a { width: $var >1; }",
       description: "Op: $var >1.",
       message: messages.expectedAfter(">"),
-      column: 17
+      column: 17,
     },
     {
       code: "a { width: $var ==1; }",
       description: "Op: $var ==1.",
       message: messages.expectedAfter("=="),
-      column: 18
+      column: 18,
     },
     {
       code: "a { width: string== string; }",
       description: "Op: string== string.",
       message: messages.expectedBefore("=="),
-      column: 18
+      column: 18,
     },
     {
       code: "a { width: string ==string; }",
       description: "Op: string ==string.",
       message: messages.expectedAfter("=="),
-      column: 20
-    }
-  ]
+      column: 20,
+    },
+  ],
 });
 
 // ------------------------------------------------------------------------
@@ -1853,12 +1852,12 @@ testRule({
   accept: [
     {
       code: "/* #{10 + 1} */",
-      description: "/* #{10 + 1} */."
+      description: "/* #{10 + 1} */.",
     },
     {
       code: "// #{10+ 1}",
-      description: "// #{10+ 1}."
-    }
+      description: "// #{10+ 1}.",
+    },
   ],
 
   reject: [
@@ -1866,7 +1865,7 @@ testRule({
       code: "/* #{10+ 1} */",
       description: "/* #{10+ 1} */.",
       message: messages.expectedBefore("+"),
-      column: 8
+      column: 8,
     },
     {
       code: `
@@ -1876,7 +1875,7 @@ testRule({
       description: "Comment after selector.",
       message: messages.expectedBefore("+"),
       line: 2,
-      column: 17
+      column: 17,
     },
     {
       code: `
@@ -1886,9 +1885,9 @@ testRule({
       description: "Comment after selector #2.",
       message: messages.expectedBefore("+"),
       line: 3,
-      column: 16
-    }
-  ]
+      column: 16,
+    },
+  ],
 });
 
 // Operations without whitespaces on any of the sides
@@ -1905,14 +1904,14 @@ testRule({
         {
           line: 1,
           column: 19,
-          message: messages.expectedBefore("+")
+          message: messages.expectedBefore("+"),
         },
         {
           line: 1,
           column: 19,
-          message: messages.expectedAfter("+")
-        }
-      ]
+          message: messages.expectedAfter("+"),
+        },
+      ],
     },
     {
       code: "a { width: 1+1s; }",
@@ -1921,14 +1920,14 @@ testRule({
         {
           line: 1,
           column: 13,
-          message: messages.expectedBefore("+")
+          message: messages.expectedBefore("+"),
         },
         {
           line: 1,
           column: 13,
-          message: messages.expectedAfter("+")
-        }
-      ]
+          message: messages.expectedAfter("+"),
+        },
+      ],
     },
     {
       code: "a { width: 5px-3px; }",
@@ -1937,14 +1936,14 @@ testRule({
         {
           line: 1,
           column: 15,
-          message: messages.expectedBefore("-")
+          message: messages.expectedBefore("-"),
         },
         {
           line: 1,
           column: 15,
-          message: messages.expectedAfter("-")
-        }
-      ]
+          message: messages.expectedAfter("-"),
+        },
+      ],
     },
     {
       code: "a { width: .1px-1px; }",
@@ -1953,14 +1952,14 @@ testRule({
         {
           line: 1,
           column: 16,
-          message: messages.expectedBefore("-")
+          message: messages.expectedBefore("-"),
         },
         {
           line: 1,
           column: 16,
-          message: messages.expectedAfter("-")
-        }
-      ]
+          message: messages.expectedAfter("-"),
+        },
+      ],
     },
     {
       code: "a { width: s.1px-1; }",
@@ -1969,14 +1968,14 @@ testRule({
         {
           line: 1,
           column: 17,
-          message: messages.expectedBefore("-")
+          message: messages.expectedBefore("-"),
         },
         {
           line: 1,
           column: 17,
-          message: messages.expectedAfter("-")
-        }
-      ]
+          message: messages.expectedAfter("-"),
+        },
+      ],
     },
     {
       code: "a { width: fn()-1; }",
@@ -1985,14 +1984,14 @@ testRule({
         {
           line: 1,
           column: 16,
-          message: messages.expectedBefore("-")
+          message: messages.expectedBefore("-"),
         },
         {
           line: 1,
           column: 16,
-          message: messages.expectedAfter("-")
-        }
-      ]
+          message: messages.expectedAfter("-"),
+        },
+      ],
     },
     {
       code: "a { width: fn()/1; }",
@@ -2001,14 +2000,14 @@ testRule({
         {
           line: 1,
           column: 16,
-          message: messages.expectedBefore("/")
+          message: messages.expectedBefore("/"),
         },
         {
           line: 1,
           column: 16,
-          message: messages.expectedAfter("/")
-        }
-      ]
+          message: messages.expectedAfter("/"),
+        },
+      ],
     },
     {
       code: "a { width: $var==1; }",
@@ -2017,14 +2016,14 @@ testRule({
         {
           line: 1,
           column: 16,
-          message: messages.expectedBefore("==")
+          message: messages.expectedBefore("=="),
         },
         {
           line: 1,
           column: 17,
-          message: messages.expectedAfter("==")
-        }
-      ]
+          message: messages.expectedAfter("=="),
+        },
+      ],
     },
     {
       code: "a { width: var==var; }",
@@ -2033,16 +2032,16 @@ testRule({
         {
           line: 1,
           column: 15,
-          message: messages.expectedBefore("==")
+          message: messages.expectedBefore("=="),
         },
         {
           line: 1,
           column: 16,
-          message: messages.expectedAfter("==")
-        }
-      ]
-    }
-  ]
+          message: messages.expectedAfter("=="),
+        },
+      ],
+    },
+  ],
 });
 
 // Equity operators
@@ -2059,14 +2058,14 @@ testRule({
         {
           line: 1,
           column: 16,
-          message: messages.expectedBefore("==")
+          message: messages.expectedBefore("=="),
         },
         {
           line: 1,
           column: 17,
-          message: messages.expectedAfter("==")
-        }
-      ]
+          message: messages.expectedAfter("=="),
+        },
+      ],
     },
     {
       code: "a { width: var==var; }",
@@ -2075,16 +2074,16 @@ testRule({
         {
           line: 1,
           column: 15,
-          message: messages.expectedBefore("==")
+          message: messages.expectedBefore("=="),
         },
         {
           line: 1,
           column: 16,
-          message: messages.expectedAfter("==")
-        }
-      ]
-    }
-  ]
+          message: messages.expectedAfter("=="),
+        },
+      ],
+    },
+  ],
 });
 
 // Slash, another operation after
@@ -2101,19 +2100,19 @@ testRule({
         {
           line: 1,
           column: 15,
-          message: messages.expectedBefore("/")
+          message: messages.expectedBefore("/"),
         },
         {
           line: 1,
           column: 15,
-          message: messages.expectedAfter("/")
+          message: messages.expectedAfter("/"),
         },
         {
           line: 1,
           column: 20,
-          message: messages.expectedAfter("+")
-        }
-      ]
+          message: messages.expectedAfter("+"),
+        },
+      ],
     },
     {
       code: "a { width: #{$var}+8px/2px; }",
@@ -2123,14 +2122,14 @@ testRule({
         {
           line: 1,
           column: 19,
-          message: messages.expectedBefore("+")
+          message: messages.expectedBefore("+"),
         },
         {
           line: 1,
           column: 19,
-          message: messages.expectedAfter("+")
-        }
-      ]
+          message: messages.expectedAfter("+"),
+        },
+      ],
     },
     {
       code: "a { width: 8px/2px+ $var; }",
@@ -2139,19 +2138,19 @@ testRule({
         {
           line: 1,
           column: 15,
-          message: messages.expectedBefore("/")
+          message: messages.expectedBefore("/"),
         },
         {
           line: 1,
           column: 15,
-          message: messages.expectedAfter("/")
+          message: messages.expectedAfter("/"),
         },
         {
           line: 1,
           column: 19,
-          message: messages.expectedBefore("+")
-        }
-      ]
+          message: messages.expectedBefore("+"),
+        },
+      ],
     },
     {
       code: "a { width: 8px/2px +fn(); }",
@@ -2160,19 +2159,19 @@ testRule({
         {
           line: 1,
           column: 15,
-          message: messages.expectedBefore("/")
+          message: messages.expectedBefore("/"),
         },
         {
           line: 1,
           column: 15,
-          message: messages.expectedAfter("/")
+          message: messages.expectedAfter("/"),
         },
         {
           line: 1,
           column: 20,
-          message: messages.expectedAfter("+")
-        }
-      ]
+          message: messages.expectedAfter("+"),
+        },
+      ],
     },
     {
       code: "a { width: 8px/2px+ fn(); }",
@@ -2181,19 +2180,19 @@ testRule({
         {
           line: 1,
           column: 15,
-          message: messages.expectedBefore("/")
+          message: messages.expectedBefore("/"),
         },
         {
           line: 1,
           column: 15,
-          message: messages.expectedAfter("/")
+          message: messages.expectedAfter("/"),
         },
         {
           line: 1,
           column: 19,
-          message: messages.expectedBefore("+")
-        }
-      ]
+          message: messages.expectedBefore("+"),
+        },
+      ],
     },
     {
       code: "a { width: 8px/2px+ 5px; }",
@@ -2202,19 +2201,19 @@ testRule({
         {
           line: 1,
           column: 15,
-          message: messages.expectedBefore("/")
+          message: messages.expectedBefore("/"),
         },
         {
           line: 1,
           column: 15,
-          message: messages.expectedAfter("/")
+          message: messages.expectedAfter("/"),
         },
         {
           line: 1,
           column: 19,
-          message: messages.expectedBefore("+")
-        }
-      ]
+          message: messages.expectedBefore("+"),
+        },
+      ],
     },
     {
       code: "a { width: 8px/2px+ 5; }",
@@ -2223,19 +2222,19 @@ testRule({
         {
           line: 1,
           column: 15,
-          message: messages.expectedBefore("/")
+          message: messages.expectedBefore("/"),
         },
         {
           line: 1,
           column: 15,
-          message: messages.expectedAfter("/")
+          message: messages.expectedAfter("/"),
         },
         {
           line: 1,
           column: 19,
-          message: messages.expectedBefore("+")
-        }
-      ]
+          message: messages.expectedBefore("+"),
+        },
+      ],
     },
     {
       code: "a { width: 8px/2px -$var; }",
@@ -2244,19 +2243,19 @@ testRule({
         {
           line: 1,
           column: 15,
-          message: messages.expectedBefore("/")
+          message: messages.expectedBefore("/"),
         },
         {
           line: 1,
           column: 15,
-          message: messages.expectedAfter("/")
+          message: messages.expectedAfter("/"),
         },
         {
           line: 1,
           column: 20,
-          message: messages.expectedAfter("-")
-        }
-      ]
+          message: messages.expectedAfter("-"),
+        },
+      ],
     },
     {
       code: "a { width: 8px/2-$var; }",
@@ -2265,24 +2264,24 @@ testRule({
         {
           line: 1,
           column: 15,
-          message: messages.expectedBefore("/")
+          message: messages.expectedBefore("/"),
         },
         {
           line: 1,
           column: 15,
-          message: messages.expectedAfter("/")
+          message: messages.expectedAfter("/"),
         },
         {
           line: 1,
           column: 17,
-          message: messages.expectedBefore("-")
+          message: messages.expectedBefore("-"),
         },
         {
           line: 1,
           column: 17,
-          message: messages.expectedAfter("-")
-        }
-      ]
+          message: messages.expectedAfter("-"),
+        },
+      ],
     },
     {
       code: "a { width: 8px/2- $var; }",
@@ -2291,19 +2290,19 @@ testRule({
         {
           line: 1,
           column: 15,
-          message: messages.expectedBefore("/")
+          message: messages.expectedBefore("/"),
         },
         {
           line: 1,
           column: 15,
-          message: messages.expectedAfter("/")
+          message: messages.expectedAfter("/"),
         },
         {
           line: 1,
           column: 17,
-          message: messages.expectedBefore("-")
-        }
-      ]
+          message: messages.expectedBefore("-"),
+        },
+      ],
     },
     {
       code: "a { width: 8px/2- 5px; }",
@@ -2312,19 +2311,19 @@ testRule({
         {
           line: 1,
           column: 15,
-          message: messages.expectedBefore("/")
+          message: messages.expectedBefore("/"),
         },
         {
           line: 1,
           column: 15,
-          message: messages.expectedAfter("/")
+          message: messages.expectedAfter("/"),
         },
         {
           line: 1,
           column: 17,
-          message: messages.expectedBefore("-")
-        }
-      ]
+          message: messages.expectedBefore("-"),
+        },
+      ],
     },
     {
       code: "a { width: 8px/2px-5px; }",
@@ -2333,24 +2332,24 @@ testRule({
         {
           line: 1,
           column: 15,
-          message: messages.expectedBefore("/")
+          message: messages.expectedBefore("/"),
         },
         {
           line: 1,
           column: 15,
-          message: messages.expectedAfter("/")
+          message: messages.expectedAfter("/"),
         },
         {
           line: 1,
           column: 19,
-          message: messages.expectedBefore("-")
+          message: messages.expectedBefore("-"),
         },
         {
           line: 1,
           column: 19,
-          message: messages.expectedAfter("-")
-        }
-      ]
+          message: messages.expectedAfter("-"),
+        },
+      ],
     },
     {
       code: "a { width: 8px/2-5px; }",
@@ -2359,24 +2358,24 @@ testRule({
         {
           line: 1,
           column: 15,
-          message: messages.expectedBefore("/")
+          message: messages.expectedBefore("/"),
         },
         {
           line: 1,
           column: 15,
-          message: messages.expectedAfter("/")
+          message: messages.expectedAfter("/"),
         },
         {
           line: 1,
           column: 17,
-          message: messages.expectedBefore("-")
+          message: messages.expectedBefore("-"),
         },
         {
           line: 1,
           column: 17,
-          message: messages.expectedAfter("-")
-        }
-      ]
+          message: messages.expectedAfter("-"),
+        },
+      ],
     },
     {
       code: "a { width: 8px/2px-5; }",
@@ -2385,24 +2384,24 @@ testRule({
         {
           line: 1,
           column: 15,
-          message: messages.expectedBefore("/")
+          message: messages.expectedBefore("/"),
         },
         {
           line: 1,
           column: 15,
-          message: messages.expectedAfter("/")
+          message: messages.expectedAfter("/"),
         },
         {
           line: 1,
           column: 19,
-          message: messages.expectedBefore("-")
+          message: messages.expectedBefore("-"),
         },
         {
           line: 1,
           column: 19,
-          message: messages.expectedAfter("-")
-        }
-      ]
+          message: messages.expectedAfter("-"),
+        },
+      ],
     },
     {
       code: "a { width: 8px/2-5; }",
@@ -2411,26 +2410,26 @@ testRule({
         {
           line: 1,
           column: 15,
-          message: messages.expectedBefore("/")
+          message: messages.expectedBefore("/"),
         },
         {
           line: 1,
           column: 15,
-          message: messages.expectedAfter("/")
+          message: messages.expectedAfter("/"),
         },
         {
           line: 1,
           column: 17,
-          message: messages.expectedBefore("-")
+          message: messages.expectedBefore("-"),
         },
         {
           line: 1,
           column: 17,
-          message: messages.expectedAfter("-")
-        }
-      ]
-    }
-  ]
+          message: messages.expectedAfter("-"),
+        },
+      ],
+    },
+  ],
 });
 
 // Slash, operation before
@@ -2447,24 +2446,24 @@ testRule({
         {
           line: 1,
           column: 13,
-          message: messages.expectedBefore("+")
+          message: messages.expectedBefore("+"),
         },
         {
           line: 1,
           column: 13,
-          message: messages.expectedAfter("+")
+          message: messages.expectedAfter("+"),
         },
         {
           line: 1,
           column: 17,
-          message: messages.expectedBefore("/")
+          message: messages.expectedBefore("/"),
         },
         {
           line: 1,
           column: 17,
-          message: messages.expectedAfter("/")
-        }
-      ]
+          message: messages.expectedAfter("/"),
+        },
+      ],
     },
     {
       code: "a { width: 5px*8px/2; }",
@@ -2473,24 +2472,24 @@ testRule({
         {
           line: 1,
           column: 15,
-          message: messages.expectedBefore("*")
+          message: messages.expectedBefore("*"),
         },
         {
           line: 1,
           column: 15,
-          message: messages.expectedAfter("*")
+          message: messages.expectedAfter("*"),
         },
         {
           line: 1,
           column: 19,
-          message: messages.expectedBefore("/")
+          message: messages.expectedBefore("/"),
         },
         {
           line: 1,
           column: 19,
-          message: messages.expectedAfter("/")
-        }
-      ]
+          message: messages.expectedAfter("/"),
+        },
+      ],
     },
     {
       code: "a { width: 5px - 8px/2; }",
@@ -2499,16 +2498,16 @@ testRule({
         {
           line: 1,
           column: 21,
-          message: messages.expectedBefore("/")
+          message: messages.expectedBefore("/"),
         },
         {
           line: 1,
           column: 21,
-          message: messages.expectedAfter("/")
-        }
-      ]
-    }
-  ]
+          message: messages.expectedAfter("/"),
+        },
+      ],
+    },
+  ],
 });
 
 // ------------------------------------------------------------------------
@@ -2528,8 +2527,8 @@ testRule({
         a {color: red;}
       }
     `,
-      description: "Media feature value: @media (max-width: 100px + 1)."
-    }
+      description: "Media feature value: @media (max-width: 100px + 1).",
+    },
   ],
 
   reject: [
@@ -2543,7 +2542,7 @@ testRule({
         "Media type as interpolation: @media #{'scr' +'en'} and (color).",
       line: 2,
       column: 22,
-      message: messages.expectedAfter("+")
+      message: messages.expectedAfter("+"),
     },
     {
       code: ` @media
@@ -2555,7 +2554,7 @@ testRule({
         "Media type as interpolation, newlines messed: @media #{'scr' +'en'} and (color).",
       line: 2,
       column: 15,
-      message: messages.expectedAfter("+")
+      message: messages.expectedAfter("+"),
     },
     {
       code: `
@@ -2566,7 +2565,7 @@ testRule({
       description: "Media query as interpolation: @media #{'scr' +'en'}.",
       line: 2,
       column: 22,
-      message: messages.expectedAfter("+")
+      message: messages.expectedAfter("+"),
     },
     {
       code: `
@@ -2578,7 +2577,7 @@ testRule({
         "Media feature expression: @media (#{'max' +'-width': 100px}).",
       line: 2,
       column: 24,
-      message: messages.expectedAfter("+")
+      message: messages.expectedAfter("+"),
     },
     {
       code: `
@@ -2590,7 +2589,7 @@ testRule({
         "Media feature expression: @media (#{'max' +'-width: 100px'}).",
       line: 2,
       column: 23,
-      message: messages.expectedAfter("+")
+      message: messages.expectedAfter("+"),
     },
     {
       code: `
@@ -2601,7 +2600,7 @@ testRule({
       description: "Media feature value: @media (max-width: 100px +1).",
       line: 2,
       column: 32,
-      message: messages.expectedAfter("+")
+      message: messages.expectedAfter("+"),
     },
     {
       code: `
@@ -2613,9 +2612,9 @@ testRule({
         "Value of a non-first media feature: @media (min-width: 10px), (max-width: 100px +1).",
       line: 2,
       column: 51,
-      message: messages.expectedAfter("+")
-    }
-  ]
+      message: messages.expectedAfter("+"),
+    },
+  ],
 });
 
 // ------------------------------------------------------------------------
@@ -2636,7 +2635,7 @@ testRule({
         \\+\\+: 20px,
       );
       `,
-      description: "Map with escaped chars"
+      description: "Map with escaped chars",
     },
     {
       code: `
@@ -2647,9 +2646,9 @@ testRule({
         @extend .h-trans--all\\+;
       }
       `,
-      description: "@extend with escaped char"
-    }
-  ]
+      description: "@extend with escaped char",
+    },
+  ],
 });
 
 // Variables
@@ -2664,8 +2663,8 @@ testRule({
       code: `
       $var: 10px/st;
     `,
-      description: "Variable: $var: 10px/st;"
-    }
+      description: "Variable: $var: 10px/st;",
+    },
   ],
 
   reject: [
@@ -2676,7 +2675,7 @@ testRule({
       description: "Variable (usual breach): $var: 10px+ 1;",
       line: 2,
       column: 17,
-      message: messages.expectedBefore("+")
+      message: messages.expectedBefore("+"),
     },
     {
       code: `
@@ -2685,7 +2684,7 @@ testRule({
       description: "Variable (this is op too): $var: 10px +1;",
       line: 2,
       column: 18,
-      message: messages.expectedAfter("+")
+      message: messages.expectedAfter("+"),
     },
     {
       code: `
@@ -2694,9 +2693,9 @@ testRule({
       description: "Variable (this is op too): $var: 10px /1;",
       line: 2,
       column: 18,
-      message: messages.expectedAfter("/")
-    }
-  ]
+      message: messages.expectedAfter("/"),
+    },
+  ],
 });
 
 // @function definitions
@@ -2717,7 +2716,7 @@ testRule({
         "Function definition, param default (usual breach): @function fn ($a: 10px+ 1).",
       line: 2,
       column: 29,
-      message: messages.expectedBefore("+")
+      message: messages.expectedBefore("+"),
     },
     {
       code: `
@@ -2727,7 +2726,7 @@ testRule({
         "Function definition, param default (special breach): @function fn ($a: 10px +1).",
       line: 2,
       column: 30,
-      message: messages.expectedAfter("+")
+      message: messages.expectedAfter("+"),
     },
     {
       code: `
@@ -2737,9 +2736,9 @@ testRule({
         "Function definition, param default (special breach): @function fn ($b, $a: 10px +1).",
       line: 2,
       column: 43,
-      message: messages.expectedAfter("+")
-    }
-  ]
+      message: messages.expectedAfter("+"),
+    },
+  ],
 });
 
 // @function calls inside interpolation
@@ -2755,22 +2754,22 @@ testRule({
       --my-var: #{scale-color(#fff, $lightness: -75%)};
     `,
       description:
-        "Function call in interpolation, negative unit value parameter: #{scale-color(#fff, $lightness: -75%)}"
+        "Function call in interpolation, negative unit value parameter: #{scale-color(#fff, $lightness: -75%)}",
     },
     {
       code: `
       --my-var: #{math.acos(-0.5)};
     `,
       description:
-        "Function call in interpolation, negative parameter: #{math.acos(-0.5)}"
+        "Function call in interpolation, negative parameter: #{math.acos(-0.5)}",
     },
     {
       code: `
       --my-var: #{math.acos(0.7 - 0.5)};
     `,
       description:
-        "Function call in interpolation, expression parameter: #{math.acos(0.7 - 0.5)}"
-    }
+        "Function call in interpolation, expression parameter: #{math.acos(0.7 - 0.5)}",
+    },
   ],
 
   reject: [
@@ -2784,16 +2783,16 @@ testRule({
         {
           message: messages.expectedBefore("-"),
           line: 2,
-          column: 32
+          column: 32,
         },
         {
           message: messages.expectedAfter("-"),
           line: 2,
-          column: 32
-        }
-      ]
-    }
-  ]
+          column: 32,
+        },
+      ],
+    },
+  ],
 });
 
 // @import
@@ -2805,21 +2804,19 @@ testRule({
 
   accept: [
     {
-      code:
-        "@import url('//fonts.googleapis.com/css?family=Google+Material+Icons');",
-      description: "Import url function w/ single-quoted string."
+      code: "@import url('//fonts.googleapis.com/css?family=Google+Material+Icons');",
+      description: "Import url function w/ single-quoted string.",
     },
     {
-      code:
-        '@import url("//fonts.googleapis.com/css?family=Google+Material+Icons");',
-      description: "Import url function w/ double-quoted string."
+      code: '@import url("//fonts.googleapis.com/css?family=Google+Material+Icons");',
+      description: "Import url function w/ double-quoted string.",
     },
     {
       code: `
       @import url(//fonts.googleapis.com/css?family=Google+Material+Icons);
     `,
-      description: "url function w/ unquoted string, no whitespace."
-    }
+      description: "url function w/ unquoted string, no whitespace.",
+    },
   ],
 
   reject: [
@@ -2828,7 +2825,7 @@ testRule({
       description: "Import w/o a media query: @import url(10px +2).",
       line: 1,
       column: 18,
-      message: messages.expectedAfter("+")
+      message: messages.expectedAfter("+"),
     },
     {
       code: `@import
@@ -2837,9 +2834,9 @@ testRule({
       description: "Import w/o a media query: @import url(10px +2).",
       line: 2,
       column: 16,
-      message: messages.expectedAfter("+")
-    }
-  ]
+      message: messages.expectedAfter("+"),
+    },
+  ],
 });
 
 testRule({
@@ -2860,8 +2857,8 @@ a {
   width: #{$var} + 1;
 }
 </style>
-`
-    }
+`,
+    },
   ],
 
   reject: [
@@ -2878,7 +2875,7 @@ a {
 `,
       message: messages.expectedAfter("+"),
       line: 7,
-      column: 12
-    }
-  ]
+      column: 12,
+    },
+  ],
 });

--- a/src/rules/operator-no-unspaced/index.js
+++ b/src/rules/operator-no-unspaced/index.js
@@ -8,18 +8,18 @@ import {
   findOperators,
   isWhitespace,
   namespace,
-  ruleUrl
+  ruleUrl,
 } from "../../utils";
 
 export const ruleName = namespace("operator-no-unspaced");
 
 export const messages = utils.ruleMessages(ruleName, {
-  expectedAfter: operator => `Expected single space after "${operator}"`,
-  expectedBefore: operator => `Expected single space before "${operator}"`
+  expectedAfter: (operator) => `Expected single space after "${operator}"`,
+  expectedBefore: (operator) => `Expected single space before "${operator}"`,
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 /**
@@ -31,7 +31,7 @@ function checkSpaces({
   startIndex,
   endIndex,
   node,
-  result
+  result,
 }) {
   const symbol = string.substring(startIndex, endIndex + 1);
 
@@ -45,7 +45,7 @@ function checkSpaces({
       result,
       node,
       message: messages.expectedBefore(symbol),
-      index: startIndex + globalIndex
+      index: startIndex + globalIndex,
     });
   }
 
@@ -60,7 +60,7 @@ function checkSpaces({
       result,
       node,
       message: messages.expectedAfter(symbol),
-      index: endIndex + globalIndex
+      index: endIndex + globalIndex,
     });
   }
 }
@@ -80,7 +80,7 @@ function newlineBefore(str, startIndex) {
 export default function rule(expectation) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
-      actual: expectation
+      actual: expectation,
     });
 
     if (!validOptions) {
@@ -99,7 +99,7 @@ export default function rule(expectation) {
       calculationOperatorSpaceChecker({
         root,
         result,
-        checker: checkSpaces
+        checker: checkSpaces,
       });
     }
   };
@@ -147,8 +147,8 @@ export function calculationOperatorSpaceChecker({ root, result, checker }) {
         source: match[0],
         operators: findOperators({
           string: match[0],
-          globalIndex: match.index + startIndex
-        })
+          globalIndex: match.index + startIndex,
+        }),
       });
       match = interpolationRegex.exec(string);
     }
@@ -158,7 +158,7 @@ export function calculationOperatorSpaceChecker({ root, result, checker }) {
 
   const dataURIRegex = /^url\(\s*['"]?data:.+;base64,.+['"]?\s*\)$/;
 
-  root.walk(item => {
+  root.walk((item) => {
     if (item.prop === "unicode-range") {
       return;
     }
@@ -176,8 +176,8 @@ export function calculationOperatorSpaceChecker({ root, result, checker }) {
           string: item.value,
           globalIndex: declarationValueIndex(item),
           // For Sass variable values some special rules apply
-          isAfterColon: item.prop[0] === "$"
-        })
+          isAfterColon: item.prop[0] === "$",
+        }),
       });
     }
 
@@ -203,7 +203,7 @@ export function calculationOperatorSpaceChecker({ root, result, checker }) {
 
       // Media queries
       if (item.name === "media" || item.name === "import") {
-        mediaQueryParser(item.params).walk(node => {
+        mediaQueryParser(item.params).walk((node) => {
           const type = node.type;
 
           if (["keyword", "media-type", "media-feature"].includes(type)) {
@@ -219,8 +219,8 @@ export function calculationOperatorSpaceChecker({ root, result, checker }) {
               operators: findOperators({
                 string: node.value,
                 globalIndex: atRuleParamIndex(item) + node.sourceIndex,
-                isAfterColon: true
-              })
+                isAfterColon: true,
+              }),
             });
           } else if (type === "url") {
             const isQuoted = node.value[0] === '"' || node.value[0] === "'";
@@ -236,8 +236,8 @@ export function calculationOperatorSpaceChecker({ root, result, checker }) {
                 operators: findOperators({
                   string: node.value,
                   globalIndex: atRuleParamIndex(item) + node.sourceIndex,
-                  isAfterColon: true
-                })
+                  isAfterColon: true,
+                }),
               });
             }
           }
@@ -249,24 +249,24 @@ export function calculationOperatorSpaceChecker({ root, result, checker }) {
           operators: findOperators({
             string: item.params,
             globalIndex: atRuleParamIndex(item),
-            isAfterColon: true
-          })
+            isAfterColon: true,
+          }),
         });
       }
     }
 
     // All the strings have been parsed, now run whitespace checking
-    results.forEach(el => {
+    results.forEach((el) => {
       // Only if there are operators within a string
       if (el.operators && el.operators.length > 0) {
-        el.operators.forEach(operator => {
+        el.operators.forEach((operator) => {
           checker({
             string: el.source,
             globalIndex: operator.globalIndex,
             startIndex: operator.startIndex,
             endIndex: operator.endIndex,
             node: item,
-            result
+            result,
           });
         });
       }
@@ -275,7 +275,7 @@ export function calculationOperatorSpaceChecker({ root, result, checker }) {
 
   // Checking interpolation inside comments
   // We have to give up on PostCSS here because it skips some inline comments
-  findCommentsInRaws(root.source.input.css).forEach(comment => {
+  findCommentsInRaws(root.source.input.css).forEach((comment) => {
     const startIndex =
       comment.source.start +
       comment.raws.startToken.length +
@@ -285,17 +285,17 @@ export function calculationOperatorSpaceChecker({ root, result, checker }) {
       return;
     }
 
-    findInterpolation(comment.text).forEach(el => {
+    findInterpolation(comment.text).forEach((el) => {
       // Only if there are operators within a string
       if (el.operators && el.operators.length > 0) {
-        el.operators.forEach(operator => {
+        el.operators.forEach((operator) => {
           checker({
             string: el.source,
             globalIndex: operator.globalIndex + startIndex,
             startIndex: operator.startIndex,
             endIndex: operator.endIndex,
             node: root,
-            result
+            result,
           });
         });
       }

--- a/src/rules/partial-no-import/__tests__/index.js
+++ b/src/rules/partial-no-import/__tests__/index.js
@@ -6,12 +6,12 @@ function logError(err) {
   console.log(err.stack); // eslint-disable-line no-console
 }
 
-test("No file specified", done => {
+test("No file specified", (done) => {
   expect.assertions(2);
 
   postcss([rule()])
     .process("@import 'file.scss';", { from: undefined })
-    .then(result => {
+    .then((result) => {
       const warnings = result.warnings();
 
       expect(warnings).toHaveLength(1);
@@ -23,13 +23,13 @@ test("No file specified", done => {
     .catch(logError);
 });
 
-test("Import a file from non-partial .scss", done => {
+test("Import a file from non-partial .scss", (done) => {
   expect.assertions(1);
   postcss([rule()])
     .process("@import 'file.scss';", {
-      from: path.join(__dirname, "test.scss")
+      from: path.join(__dirname, "test.scss"),
     })
-    .then(result => {
+    .then((result) => {
       const warnings = result.warnings();
 
       expect(warnings).toHaveLength(0);
@@ -37,13 +37,13 @@ test("Import a file from non-partial .scss", done => {
     });
 });
 
-test("Import a file from a partial .scss", done => {
+test("Import a file from a partial .scss", (done) => {
   expect.assertions(1);
   postcss([rule()])
     .process("@import 'file.scss';", {
-      from: path.join(__dirname, "_test.scss")
+      from: path.join(__dirname, "_test.scss"),
     })
-    .then(result => {
+    .then((result) => {
       const warnings = result.warnings();
 
       expect(warnings).toHaveLength(1);
@@ -51,13 +51,13 @@ test("Import a file from a partial .scss", done => {
     });
 });
 
-test("Import a file from a partial .scss 2", done => {
+test("Import a file from a partial .scss 2", (done) => {
   expect.assertions(1);
   postcss([rule()])
     .process('@import "file.scss";', {
-      from: path.join(__dirname, "_test.scss")
+      from: path.join(__dirname, "_test.scss"),
     })
-    .then(result => {
+    .then((result) => {
       const warnings = result.warnings();
 
       expect(warnings).toHaveLength(1);
@@ -65,13 +65,13 @@ test("Import a file from a partial .scss 2", done => {
     });
 });
 
-test("Ignores empty imports (Sass will throw an error instead)", done => {
+test("Ignores empty imports (Sass will throw an error instead)", (done) => {
   expect.assertions(1);
   postcss([rule()])
     .process("@import '';", {
-      from: path.join(__dirname, "_test.scss")
+      from: path.join(__dirname, "_test.scss"),
     })
-    .then(result => {
+    .then((result) => {
       const warnings = result.warnings();
 
       expect(warnings).toHaveLength(0);
@@ -79,13 +79,13 @@ test("Ignores empty imports (Sass will throw an error instead)", done => {
     });
 });
 
-test("Ignores empty imports (Sass will throw an error instead) 2", done => {
+test("Ignores empty imports (Sass will throw an error instead) 2", (done) => {
   expect.assertions(1);
   postcss([rule()])
     .process('@import " ";', {
-      from: path.join(__dirname, "_test.scss")
+      from: path.join(__dirname, "_test.scss"),
     })
-    .then(result => {
+    .then((result) => {
       const warnings = result.warnings();
 
       expect(warnings).toHaveLength(0);
@@ -93,13 +93,13 @@ test("Ignores empty imports (Sass will throw an error instead) 2", done => {
     });
 });
 
-test("Import a file from a partial .scss; omitting extension", done => {
+test("Import a file from a partial .scss; omitting extension", (done) => {
   expect.assertions(1);
   postcss([rule()])
     .process("@import 'file';", {
-      from: path.join(__dirname, "_test.scss")
+      from: path.join(__dirname, "_test.scss"),
     })
-    .then(result => {
+    .then((result) => {
       const warnings = result.warnings();
 
       expect(warnings).toHaveLength(1);
@@ -107,13 +107,13 @@ test("Import a file from a partial .scss; omitting extension", done => {
     });
 });
 
-test("Import comma separated files from a partial .scss; omitting extension", done => {
+test("Import comma separated files from a partial .scss; omitting extension", (done) => {
   expect.assertions(1);
   postcss([rule()])
     .process("@import 'file','file2';", {
-      from: path.join(__dirname, "_test.scss")
+      from: path.join(__dirname, "_test.scss"),
     })
-    .then(result => {
+    .then((result) => {
       const warnings = result.warnings();
 
       expect(warnings).toHaveLength(2);
@@ -121,13 +121,13 @@ test("Import comma separated files from a partial .scss; omitting extension", do
     });
 });
 
-test("Import comma separated files from a partial .scss; omitting extension 2", done => {
+test("Import comma separated files from a partial .scss; omitting extension 2", (done) => {
   expect.assertions(1);
   postcss([rule()])
     .process('@import "file" , "file2";', {
-      from: path.join(__dirname, "_test.scss")
+      from: path.join(__dirname, "_test.scss"),
     })
-    .then(result => {
+    .then((result) => {
       const warnings = result.warnings();
 
       expect(warnings).toHaveLength(2);
@@ -136,13 +136,13 @@ test("Import comma separated files from a partial .scss; omitting extension 2", 
 });
 
 // Exceptions
-test("Import a file from CSS", done => {
+test("Import a file from CSS", (done) => {
   expect.assertions(1);
   postcss([rule()])
     .process("@import 'file.scss';", {
-      from: path.join(__dirname, "_test.css")
+      from: path.join(__dirname, "_test.css"),
     })
-    .then(result => {
+    .then((result) => {
       const warnings = result.warnings();
 
       expect(warnings).toHaveLength(0);
@@ -150,13 +150,13 @@ test("Import a file from CSS", done => {
     });
 });
 
-test("Import a CSS from a partial .scss", done => {
+test("Import a CSS from a partial .scss", (done) => {
   expect.assertions(1);
   postcss([rule()])
     .process("@import 'file.css';", {
-      from: path.join(__dirname, "_test.scss")
+      from: path.join(__dirname, "_test.scss"),
     })
-    .then(result => {
+    .then((result) => {
       const warnings = result.warnings();
 
       expect(warnings).toHaveLength(0);
@@ -164,13 +164,13 @@ test("Import a CSS from a partial .scss", done => {
     });
 });
 
-test("Import a CSS (url) from a partial .scss", done => {
+test("Import a CSS (url) from a partial .scss", (done) => {
   expect.assertions(1);
   postcss([rule()])
     .process("@import url('file.scss');", {
-      from: path.join(__dirname, "_test.scss")
+      from: path.join(__dirname, "_test.scss"),
     })
-    .then(result => {
+    .then((result) => {
       const warnings = result.warnings();
 
       expect(warnings).toHaveLength(0);
@@ -178,13 +178,13 @@ test("Import a CSS (url) from a partial .scss", done => {
     });
 });
 
-test("Import a CSS (with protocol) from a partial .scss", done => {
+test("Import a CSS (with protocol) from a partial .scss", (done) => {
   expect.assertions(1);
   postcss([rule()])
     .process("@import '//file.scss;'", {
-      from: path.join(__dirname, "_test.scss")
+      from: path.join(__dirname, "_test.scss"),
     })
-    .then(result => {
+    .then((result) => {
       const warnings = result.warnings();
 
       expect(warnings).toHaveLength(0);
@@ -192,16 +192,16 @@ test("Import a CSS (with protocol) from a partial .scss", done => {
     });
 });
 
-test("Import a CSS file (font URL with https) from a partial .scss", done => {
+test("Import a CSS file (font URL with https) from a partial .scss", (done) => {
   expect.assertions(1);
   postcss([rule()])
     .process(
       "@import 'https://fonts.googleapis.com/css?family=Quicksand:300,400,500,700';",
       {
-        from: path.join(__dirname, "_test.scss")
+        from: path.join(__dirname, "_test.scss"),
       }
     )
-    .then(result => {
+    .then((result) => {
       const warnings = result.warnings();
 
       expect(warnings).toHaveLength(0);
@@ -209,16 +209,16 @@ test("Import a CSS file (font URL with https) from a partial .scss", done => {
     });
 });
 
-test("Import a local file and a CSS file (font URL with https) from a partial .scss (warn for local file, but not https import)", done => {
+test("Import a local file and a CSS file (font URL with https) from a partial .scss (warn for local file, but not https import)", (done) => {
   expect.assertions(1);
   postcss([rule()])
     .process(
       "@import 'file', 'https://fonts.googleapis.com/css?family=Quicksand:300,400,500,700';",
       {
-        from: path.join(__dirname, "_test.scss")
+        from: path.join(__dirname, "_test.scss"),
       }
     )
-    .then(result => {
+    .then((result) => {
       const warnings = result.warnings();
 
       expect(warnings).toHaveLength(1);
@@ -226,16 +226,16 @@ test("Import a local file and a CSS file (font URL with https) from a partial .s
     });
 });
 
-test("Import a local file and a CSS file (font URL with https) from a partial .scss (warn for local file, but not https import) 2", done => {
+test("Import a local file and a CSS file (font URL with https) from a partial .scss (warn for local file, but not https import) 2", (done) => {
   expect.assertions(1);
   postcss([rule()])
     .process(
       '@import "file", "https://fonts.googleapis.com/css?family=Quicksand:300,400,500,700";',
       {
-        from: path.join(__dirname, "_test.scss")
+        from: path.join(__dirname, "_test.scss"),
       }
     )
-    .then(result => {
+    .then((result) => {
       const warnings = result.warnings();
 
       expect(warnings).toHaveLength(1);
@@ -243,16 +243,16 @@ test("Import a local file and a CSS file (font URL with https) from a partial .s
     });
 });
 
-test("Import a local file and a CSS file (font URL with https) from a partial .scss (warn for local file, but not https import) 3", done => {
+test("Import a local file and a CSS file (font URL with https) from a partial .scss (warn for local file, but not https import) 3", (done) => {
   expect.assertions(1);
   postcss([rule()])
     .process(
       '@import "https://fonts.googleapis.com/css?family=Quicksand:300,400,500,700", "file";',
       {
-        from: path.join(__dirname, "_test.scss")
+        from: path.join(__dirname, "_test.scss"),
       }
     )
-    .then(result => {
+    .then((result) => {
       const warnings = result.warnings();
 
       expect(warnings).toHaveLength(1);
@@ -260,13 +260,13 @@ test("Import a local file and a CSS file (font URL with https) from a partial .s
     });
 });
 
-test("Import a CSS (with media) from a partial .scss", done => {
+test("Import a CSS (with media) from a partial .scss", (done) => {
   expect.assertions(1);
   postcss([rule()])
     .process("@import 'file.scss' screen", {
-      from: path.join(__dirname, "_test.scss")
+      from: path.join(__dirname, "_test.scss"),
     })
-    .then(result => {
+    .then((result) => {
       const warnings = result.warnings();
 
       expect(warnings).toHaveLength(0);
@@ -274,16 +274,16 @@ test("Import a CSS (with media) from a partial .scss", done => {
     });
 });
 
-test("Multiple imports in a partial.", done => {
+test("Multiple imports in a partial.", (done) => {
   expect.assertions(1);
   postcss([rule()])
     .process(
       '@import "_bootstrap/variables";\n@import "_font-awesome/variables";',
       {
-        from: path.join(__dirname, "_variables.scss")
+        from: path.join(__dirname, "_variables.scss"),
       }
     )
-    .then(result => {
+    .then((result) => {
       const warnings = result.warnings();
 
       expect(warnings).toHaveLength(2);
@@ -291,16 +291,16 @@ test("Multiple imports in a partial.", done => {
     });
 });
 
-test("Import from a non-partial SCSS-file.", done => {
+test("Import from a non-partial SCSS-file.", (done) => {
   expect.assertions(1);
   postcss([rule()])
     .process(
       '@import "bootstrap/variables";\n@import "font-awesome/variables";',
       {
-        from: path.join(__dirname, "_der", "variables.scss")
+        from: path.join(__dirname, "_der", "variables.scss"),
       }
     )
-    .then(result => {
+    .then((result) => {
       const warnings = result.warnings();
 
       expect(warnings).toHaveLength(0);

--- a/src/rules/partial-no-import/index.js
+++ b/src/rules/partial-no-import/index.js
@@ -5,17 +5,17 @@ import { namespace, ruleUrl } from "../../utils";
 export const ruleName = namespace("partial-no-import");
 
 export const messages = utils.ruleMessages(ruleName, {
-  expected: "Unexpected @import in a partial"
+  expected: "Unexpected @import in a partial",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(on) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
-      actual: on
+      actual: on,
     });
 
     if (!validOptions) {
@@ -55,7 +55,7 @@ export default function rule(on) {
         node: decl,
         index: decl.params.indexOf(path),
         result,
-        ruleName
+        ruleName,
       });
     }
 
@@ -69,10 +69,10 @@ export default function rule(on) {
       return;
     }
 
-    root.walkAtRules("import", mixinCall => {
+    root.walkAtRules("import", (mixinCall) => {
       // Check if @import is treated as CSS import; report only if not
       // Processing comma-separated lists of import paths
-      mixinCall.params.split(/["']\s*,/).forEach(path => {
+      mixinCall.params.split(/["']\s*,/).forEach((path) => {
         checkImportForCSS(path, mixinCall);
       });
     });

--- a/src/rules/percent-placeholder-pattern/__tests__/index.js
+++ b/src/rules/percent-placeholder-pattern/__tests__/index.js
@@ -9,29 +9,29 @@ testRule({
   accept: [
     {
       code: "%foo { top: 1em; }",
-      description: "Regexp: sequence part. Example: full match."
+      description: "Regexp: sequence part. Example: full match.",
     },
     {
       code: "%_foo { top: 1em; }",
-      description: "Regexp: sequence part. Example: matches at the end."
+      description: "Regexp: sequence part. Example: matches at the end.",
     },
     {
       code: "%food { top: 1em; }",
-      description: "Regexp: sequence part. Example: matches at the beginning."
+      description: "Regexp: sequence part. Example: matches at the beginning.",
     },
     {
       code: " %foo { top: 1em; }",
       description:
-        "Regexp: sequence part. Example: extra space after before placeholder selector."
+        "Regexp: sequence part. Example: extra space after before placeholder selector.",
     },
     {
       code: ".fowdo { top: 1em; }",
-      description: "Not a placeholder extend, skipping."
+      description: "Not a placeholder extend, skipping.",
     },
     {
       code: "%clou#{dstri}fe { top: 1em; }",
-      description: "Regexp: sequence part. Example: interpolation; skipping."
-    }
+      description: "Regexp: sequence part. Example: interpolation; skipping.",
+    },
   ],
 
   reject: [
@@ -39,9 +39,9 @@ testRule({
       code: "%floo { top: 1em; }",
       line: 1,
       message: messages.expected("floo"),
-      description: "Regexp: sequence part. Example: symbol in between."
-    }
-  ]
+      description: "Regexp: sequence part. Example: symbol in between.",
+    },
+  ],
 });
 
 // Testing against a string, sequence part
@@ -53,16 +53,16 @@ testRule({
   accept: [
     {
       code: "%foo { top: 1em; }",
-      description: "String: sequence part. Example: full match."
+      description: "String: sequence part. Example: full match.",
     },
     {
       code: "%_foo { top: 1em; }",
-      description: "String: sequence part. Example: matches at the end."
+      description: "String: sequence part. Example: matches at the end.",
     },
     {
       code: "%food { top: 1em; }",
-      description: "String: sequence part. Example: matches at the beginning."
-    }
+      description: "String: sequence part. Example: matches at the beginning.",
+    },
   ],
 
   reject: [
@@ -70,15 +70,15 @@ testRule({
       code: "%floo { top: 1em; }",
       line: 1,
       message: messages.expected("floo"),
-      description: "String: sequence part. Example: symbol in between."
+      description: "String: sequence part. Example: symbol in between.",
     },
     {
       code: "%fo { top: 1em; }",
       line: 1,
       message: messages.expected("fo"),
-      description: "String: sequence part. Example: not a full sequence."
-    }
-  ]
+      description: "String: sequence part. Example: not a full sequence.",
+    },
+  ],
 });
 
 // Testing against a regex, full match
@@ -90,15 +90,15 @@ testRule({
   accept: [
     {
       code: "%foo { top: 1em; }",
-      description: "Regexp: strict match. Example: matches."
+      description: "Regexp: strict match. Example: matches.",
     },
     {
       code: `%foo
     {
       top: 1em;
     }`,
-      description: "Regexp: strict match. Example: newline after a selector."
-    }
+      description: "Regexp: strict match. Example: newline after a selector.",
+    },
   ],
 
   reject: [
@@ -106,28 +106,28 @@ testRule({
       code: "%_foo { top: 1em; }",
       line: 1,
       message: messages.expected("_foo"),
-      description: "Regexp: strict match. Example: matches at the end."
+      description: "Regexp: strict match. Example: matches at the end.",
     },
     {
       code: "% foo { top: 1em; }",
       line: 1,
       message: messages.expected(""),
       description:
-        "Regexp: strict match. Example: matches, but has a space after '%'."
+        "Regexp: strict match. Example: matches, but has a space after '%'.",
     },
     {
       code: "%food { top: 1em; }",
       line: 1,
       message: messages.expected("food"),
-      description: "Regexp: strict match. Example: matches at the beginning."
+      description: "Regexp: strict match. Example: matches at the beginning.",
     },
     {
       code: "%floo { top: 1em; }",
       line: 1,
       message: messages.expected("floo"),
-      description: "Regexp: strict match. Example: symbol in between."
-    }
-  ]
+      description: "Regexp: strict match. Example: symbol in between.",
+    },
+  ],
 });
 
 // Testing against a regex, match at the beginning
@@ -139,13 +139,13 @@ testRule({
   accept: [
     {
       code: "%foo { top: 1em; }",
-      description: "Regexp: pattern at the beginning. Example: matches."
+      description: "Regexp: pattern at the beginning. Example: matches.",
     },
     {
       code: "%food { top: 1em; }",
       description:
-        "Regexp: pattern at the beginning. Example: matches at the beginning."
-    }
+        "Regexp: pattern at the beginning. Example: matches at the beginning.",
+    },
   ],
 
   reject: [
@@ -154,16 +154,16 @@ testRule({
       line: 1,
       message: messages.expected("_foo"),
       description:
-        "Regexp: pattern at the beginning. Example: matches at the end."
+        "Regexp: pattern at the beginning. Example: matches at the end.",
     },
     {
       code: "%floo { top: 1em; }",
       line: 1,
       message: messages.expected("floo"),
       description:
-        "Regexp: pattern at the beginning. Example: symbol in between."
-    }
-  ]
+        "Regexp: pattern at the beginning. Example: symbol in between.",
+    },
+  ],
 });
 
 // Testing against kinda-SUIT pattern, and nesting
@@ -175,24 +175,24 @@ testRule({
   accept: [
     {
       code: "%Foo-bar {}",
-      description: "Regexp: SUIT component. Example: comply."
+      description: "Regexp: SUIT component. Example: comply.",
     },
     {
       code: "%Foo-barBaz {}",
-      description: "Regexp: SUIT component. Example: comply."
+      description: "Regexp: SUIT component. Example: comply.",
     },
     {
       code: `%Foo-bar {
       &barBaz {}
     }`,
       description:
-        "Regexp: SUIT component. Example: comply, nesting, both levels comply."
+        "Regexp: SUIT component. Example: comply, nesting, both levels comply.",
     },
     {
       code: ".cd { @media print { #de { & + .fg {} } } }",
       description:
-        "Regexp: SUIT component. Example: no placeholder, should skip."
-    }
+        "Regexp: SUIT component. Example: no placeholder, should skip.",
+    },
   ],
 
   reject: [
@@ -201,20 +201,20 @@ testRule({
       line: 1,
       message: messages.expected("boo-Foo-bar"),
       description:
-        "Regexp: SUIT component. Example: starts with lowercase, two elements."
+        "Regexp: SUIT component. Example: starts with lowercase, two elements.",
     },
     {
       code: "%foo-bar {}",
       line: 1,
       message: messages.expected("foo-bar"),
-      description: "Regexp: SUIT component. Example: starts with lowercase."
+      description: "Regexp: SUIT component. Example: starts with lowercase.",
     },
     {
       code: "%Foo-Bar {}",
       line: 1,
       message: messages.expected("Foo-Bar"),
       description:
-        "Regexp: SUIT component. Example: element starts with uppercase."
+        "Regexp: SUIT component. Example: element starts with uppercase.",
     },
     {
       code: `%Foo-bar {
@@ -224,7 +224,7 @@ testRule({
       line: 3,
       message: messages.expected("Foo-bar1oo"),
       description:
-        "Regexp: SUIT component. Example: nesting, only lv1 part comply."
+        "Regexp: SUIT component. Example: nesting, only lv1 part comply.",
     },
     {
       code: `%Fo {
@@ -235,9 +235,9 @@ testRule({
       line: 1,
       message: messages.expected("Fo"),
       description:
-        "Regexp: pattern at the beginning. Example: nesting, with nesting selector; first lv doesn't comply."
-    }
-  ]
+        "Regexp: pattern at the beginning. Example: nesting, with nesting selector; first lv doesn't comply.",
+    },
+  ],
 });
 
 // Testing against a regex, sequence part
@@ -249,11 +249,11 @@ testRule({
   accept: [
     {
       code: "a { .mixin-call(); }",
-      description: "Less mixin call ignored."
+      description: "Less mixin call ignored.",
     },
     {
       code: "a { &:extend(%class); }",
-      description: "Less extends ignored."
-    }
-  ]
+      description: "Less extends ignored.",
+    },
+  ],
 });

--- a/src/rules/percent-placeholder-pattern/index.js
+++ b/src/rules/percent-placeholder-pattern/index.js
@@ -7,25 +7,25 @@ import {
   isStandardSelector,
   parseSelector,
   namespace,
-  ruleUrl
+  ruleUrl,
 } from "../../utils";
 
 export const ruleName = namespace("percent-placeholder-pattern");
 
 export const messages = utils.ruleMessages(ruleName, {
-  expected: placeholder =>
-    `Expected %-placeholder "%${placeholder}" to match specified pattern`
+  expected: (placeholder) =>
+    `Expected %-placeholder "%${placeholder}" to match specified pattern`,
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(pattern) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: pattern,
-      possible: [isRegExp, isString]
+      possible: [isRegExp, isString],
     });
 
     if (!validOptions) {
@@ -37,12 +37,12 @@ export default function rule(pattern) {
       : pattern;
 
     // Checking placeholder definitions (looking among regular rules)
-    root.walkRules(rule => {
+    root.walkRules((rule) => {
       const { selector } = rule;
 
       // Just a shorthand for calling `parseSelector`
       function parse(selector) {
-        parseSelector(selector, result, rule, s => checkSelector(s, rule));
+        parseSelector(selector, result, rule, (s) => checkSelector(s, rule));
       }
 
       // If it's a custom prop or a less mixin
@@ -69,7 +69,7 @@ export default function rule(pattern) {
 
     function checkSelector(fullSelector, rule) {
       // postcss-selector-parser gives %placeholders' nodes a "tag" type
-      fullSelector.walkTags(compoundSelector => {
+      fullSelector.walkTags((compoundSelector) => {
         const { value, sourceIndex } = compoundSelector;
 
         if (value[0] !== "%") {
@@ -87,7 +87,7 @@ export default function rule(pattern) {
           ruleName,
           message: messages.expected(placeholder),
           node: rule,
-          index: sourceIndex
+          index: sourceIndex,
         });
       });
     }

--- a/src/rules/selector-nest-combinators/__tests__/index.js
+++ b/src/rules/selector-nest-combinators/__tests__/index.js
@@ -12,7 +12,7 @@ testRule({
         .bar {}
       }
       `,
-      description: "when child combinators are nested"
+      description: "when child combinators are nested",
     },
     {
       code: `
@@ -20,7 +20,7 @@ testRule({
         &.bar {}
       }
       `,
-      description: "when chained combinators are nested"
+      description: "when chained combinators are nested",
     },
     {
       code: `
@@ -28,7 +28,7 @@ testRule({
         & > .bar {}
       }
       `,
-      description: "when direct descendant combinators are nested"
+      description: "when direct descendant combinators are nested",
     },
     {
       code: `
@@ -39,7 +39,7 @@ testRule({
       }
       `,
       description:
-        "when direct descendant combinators are nested + a nested class"
+        "when direct descendant combinators are nested + a nested class",
     },
     {
       code: `
@@ -48,7 +48,7 @@ testRule({
       }
       `,
       description:
-        "when chained combinators can't be nested due to preceding a parent selector"
+        "when chained combinators can't be nested due to preceding a parent selector",
     },
     {
       code: `
@@ -58,7 +58,7 @@ testRule({
         }
       }
       `,
-      description: "when parent selectors are used for concatenation"
+      description: "when parent selectors are used for concatenation",
     },
     {
       code: `
@@ -68,7 +68,7 @@ testRule({
         }
       }
       `,
-      description: "when parent selectors are used for BEM style concatenation"
+      description: "when parent selectors are used for BEM style concatenation",
     },
     {
       code: `
@@ -76,7 +76,7 @@ testRule({
         &:hover {}
       }
       `,
-      description: "when pseudo classes are nested"
+      description: "when pseudo classes are nested",
     },
     {
       code: `
@@ -84,19 +84,19 @@ testRule({
         &:nth-child(2n - 1) {}
       }
       `,
-      description: "when an nth child selector is used which includes spaces"
+      description: "when an nth child selector is used which includes spaces",
     },
     {
       code: `
       [data-test="foo bar"] {}
       `,
-      description: "when an attribute selector is used with spaces in it"
+      description: "when an attribute selector is used with spaces in it",
     },
     {
       code: `
       :not([class]:last-child) {}
       `,
-      description: "when selectors are chained within a not selector"
+      description: "when selectors are chained within a not selector",
     },
     {
       code: `
@@ -106,7 +106,7 @@ testRule({
 	      }
       }
       `,
-      description: "should support interpolation"
+      description: "should support interpolation",
     },
     {
       code: `
@@ -117,7 +117,7 @@ testRule({
         }
       }
       `,
-      description: "ignores nested properties"
+      description: "ignores nested properties",
     },
     {
       code: `
@@ -130,8 +130,8 @@ testRule({
         }
       }
       `,
-      description: "ignores @keyframes"
-    }
+      description: "ignores @keyframes",
+    },
   ],
 
   reject: [
@@ -142,7 +142,7 @@ testRule({
       description: "when a child combinator is used instead of nesting",
       message: messages.expected(" ", "combinator"),
       line: 2,
-      column: 11
+      column: 11,
     },
     {
       code: `
@@ -151,7 +151,7 @@ testRule({
       description: "when a selector is chained with another",
       message: messages.expected("bar", "class"),
       line: 2,
-      column: 11
+      column: 11,
     },
     {
       code: `
@@ -161,7 +161,7 @@ testRule({
         "when a direct descendant combinator is used without nesting",
       message: messages.expected(">", "combinator"),
       line: 2,
-      column: 12
+      column: 12,
     },
     {
       code: `
@@ -170,7 +170,7 @@ testRule({
       description: "when pseudo classes are used without nesting",
       message: messages.expected(":hover", "pseudo"),
       line: 2,
-      column: 11
+      column: 11,
     },
     {
       code: `
@@ -179,7 +179,7 @@ testRule({
       description: "when universal selectors are used with a combinator",
       message: messages.expected("+", "combinator"),
       line: 2,
-      column: 9
+      column: 9,
     },
     {
       code: `
@@ -188,7 +188,7 @@ testRule({
       description: "when pseudo selectors only are chained",
       message: messages.expected(":last-child", "pseudo"),
       line: 2,
-      column: 25
+      column: 25,
     },
     {
       code: `
@@ -197,9 +197,9 @@ testRule({
       description: "when interpolation is used",
       message: messages.expectedInterpolation,
       line: 2,
-      column: 18
-    }
-  ]
+      column: 18,
+    },
+  ],
 });
 
 testRule({
@@ -212,25 +212,26 @@ testRule({
       code: `
       .foo .bar {}
       `,
-      description: "when a child combinator is used instead of nesting"
+      description: "when a child combinator is used instead of nesting",
     },
     {
       code: `
       .foo.bar {}
       `,
-      description: "when a selector is chained with another"
+      description: "when a selector is chained with another",
     },
     {
       code: `
       .foo > .bar {}
       `,
-      description: "when a direct descendant combinator is used without nesting"
+      description:
+        "when a direct descendant combinator is used without nesting",
     },
     {
       code: `
       .foo:hover {}
       `,
-      description: "when pseudo classes are used without nesting"
+      description: "when pseudo classes are used without nesting",
     },
     {
       code: `
@@ -238,7 +239,7 @@ testRule({
         .foo {}
       }
       `,
-      description: "when selectors are nested inside @media"
+      description: "when selectors are nested inside @media",
     },
     {
       code: `
@@ -247,7 +248,7 @@ testRule({
         100% {}
       }
       `,
-      description: "when a keyframes rule is used"
+      description: "when a keyframes rule is used",
     },
     {
       code: `
@@ -256,25 +257,25 @@ testRule({
       }
       `,
       description:
-        "when selectors are nested in a mixin, e.g. when making use of @content"
+        "when selectors are nested in a mixin, e.g. when making use of @content",
     },
     {
       code: `
       .foo:nth-child(2n-1) {}
       `,
-      description: "when using an nth-child selector"
+      description: "when using an nth-child selector",
     },
     {
       code: `
       #foo:not([class]:last-child) {}
       `,
-      description: "when using a not selector"
+      description: "when using a not selector",
     },
     {
       code: `
       .class-name #{if(&, "&", "")} {}
       `,
-      description: "should support interpolation"
+      description: "should support interpolation",
     },
     {
       code: `
@@ -285,7 +286,7 @@ testRule({
         }
       }
       `,
-      description: "ignores nested properties"
+      description: "ignores nested properties",
     },
     {
       code: `
@@ -298,8 +299,8 @@ testRule({
         }
       }
       `,
-      description: "ignores @keyframes"
-    }
+      description: "ignores @keyframes",
+    },
   ],
 
   reject: [
@@ -314,14 +315,14 @@ testRule({
         {
           message: messages.rejected,
           line: 3,
-          column: 9
+          column: 9,
         },
         {
           message: messages.rejected,
           line: 3,
-          column: 9
-        }
-      ]
+          column: 9,
+        },
+      ],
     },
     {
       code: `
@@ -334,19 +335,19 @@ testRule({
         {
           message: messages.rejected,
           line: 3,
-          column: 9
+          column: 9,
         },
         {
           message: messages.rejected,
           line: 3,
-          column: 9
+          column: 9,
         },
         {
           message: messages.rejected,
           line: 3,
-          column: 10
-        }
-      ]
+          column: 10,
+        },
+      ],
     },
     {
       code: `
@@ -359,24 +360,24 @@ testRule({
         {
           message: messages.rejected,
           line: 3,
-          column: 9
+          column: 9,
         },
         {
           message: messages.rejected,
           line: 3,
-          column: 9
+          column: 9,
         },
         {
           message: messages.rejected,
           line: 3,
-          column: 11
+          column: 11,
         },
         {
           message: messages.rejected,
           line: 3,
-          column: 13
-        }
-      ]
+          column: 13,
+        },
+      ],
     },
     {
       code: `
@@ -391,34 +392,34 @@ testRule({
         {
           message: messages.rejected,
           line: 3,
-          column: 9
+          column: 9,
         },
         {
           message: messages.rejected,
           line: 3,
-          column: 9
+          column: 9,
         },
         {
           message: messages.rejected,
           line: 3,
-          column: 10
+          column: 10,
         },
         {
           message: messages.rejected,
           line: 4,
-          column: 11
+          column: 11,
         },
         {
           message: messages.rejected,
           line: 4,
-          column: 11
+          column: 11,
         },
         {
           message: messages.rejected,
           line: 4,
-          column: 12
-        }
-      ]
+          column: 12,
+        },
+      ],
     },
     {
       code: `
@@ -433,34 +434,34 @@ testRule({
         {
           message: messages.rejected,
           line: 3,
-          column: 9
+          column: 9,
         },
         {
           message: messages.rejected,
           line: 3,
-          column: 9
+          column: 9,
         },
         {
           message: messages.rejected,
           line: 3,
-          column: 10
+          column: 10,
         },
         {
           message: messages.rejected,
           line: 4,
-          column: 11
+          column: 11,
         },
         {
           message: messages.rejected,
           line: 4,
-          column: 11
+          column: 11,
         },
         {
           message: messages.rejected,
           line: 4,
-          column: 12
-        }
-      ]
+          column: 12,
+        },
+      ],
     },
     {
       code: `
@@ -473,19 +474,19 @@ testRule({
         {
           message: messages.rejected,
           line: 3,
-          column: 9
+          column: 9,
         },
         {
           message: messages.rejected,
           line: 3,
-          column: 9
+          column: 9,
         },
         {
           message: messages.rejected,
           line: 3,
-          column: 10
-        }
-      ]
+          column: 10,
+        },
+      ],
     },
     {
       code: `
@@ -500,14 +501,14 @@ testRule({
         {
           message: messages.rejected,
           line: 3,
-          column: 8
+          column: 8,
         },
         {
           message: messages.rejected,
           line: 3,
-          column: 8
-        }
-      ]
-    }
-  ]
+          column: 8,
+        },
+      ],
+    },
+  ],
 });

--- a/src/rules/selector-nest-combinators/index.js
+++ b/src/rules/selector-nest-combinators/index.js
@@ -7,18 +7,18 @@ export const messages = utils.ruleMessages(ruleName, {
   expectedInterpolation: `Expected interpolation to be in a nested form`,
   expected: (combinator, type) =>
     `Expected combinator "${combinator}" of type "${type}" to be in a nested form`,
-  rejected: `Unexpected nesting found in selector`
+  rejected: `Unexpected nesting found in selector`,
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(expectation) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: expectation,
-      possible: ["always", "never"]
+      possible: ["always", "never"],
     });
 
     if (!validOptions) {
@@ -44,12 +44,12 @@ export default function rule(expectation) {
       "id",
       "pseudo",
       "tag",
-      "universal"
+      "universal",
     ];
 
     const interpolationRe = /#{.+?}$/;
 
-    root.walkRules(rule => {
+    root.walkRules((rule) => {
       if (
         rule.parent &&
         rule.parent.type === "atrule" &&
@@ -66,10 +66,10 @@ export default function rule(expectation) {
         }
       }
 
-      parseSelector(rule.selector, result, rule, fullSelector => {
+      parseSelector(rule.selector, result, rule, (fullSelector) => {
         let message;
 
-        fullSelector.walk(node => {
+        fullSelector.walk((node) => {
           if (node.value === "}") {
             return;
           }
@@ -146,7 +146,7 @@ export default function rule(expectation) {
             result,
             node: rule,
             message,
-            index: node.sourceIndex
+            index: node.sourceIndex,
           });
         });
       });

--- a/src/rules/selector-no-redundant-nesting-selector/__tests__/index.js
+++ b/src/rules/selector-no-redundant-nesting-selector/__tests__/index.js
@@ -12,7 +12,7 @@ testRule({
         &.foo {}
       }
     `,
-      description: "when an ampersand is chained with class"
+      description: "when an ampersand is chained with class",
     },
     {
       code: `
@@ -20,7 +20,7 @@ testRule({
         .foo > & {}
       }
     `,
-      description: "when an ampersand follows a direct descendant operator"
+      description: "when an ampersand follows a direct descendant operator",
     },
     {
       code: `
@@ -29,7 +29,7 @@ testRule({
       }
     `,
       description:
-        "when an ampersand follows a direct descendant operator and there are extra spaces"
+        "when an ampersand follows a direct descendant operator and there are extra spaces",
     },
     {
       code: `
@@ -38,7 +38,7 @@ testRule({
       }
     `,
       description:
-        "when an ampersand follows a direct descendant operator and there are no spaces"
+        "when an ampersand follows a direct descendant operator and there are no spaces",
     },
     {
       code: `
@@ -47,7 +47,7 @@ testRule({
         & ~ & {}
       }
     `,
-      description: "when an ampersand precedes a sibling operator"
+      description: "when an ampersand precedes a sibling operator",
     },
     {
       code: `
@@ -55,7 +55,7 @@ testRule({
         & + &:hover {}
       }
     `,
-      description: "when multiple ampersands exist with one concatenated"
+      description: "when multiple ampersands exist with one concatenated",
     },
     {
       code: `
@@ -68,7 +68,7 @@ testRule({
       }
     `,
       description:
-        "when an ampersand is used in a comma sequence to DRY up code"
+        "when an ampersand is used in a comma sequence to DRY up code",
     },
     {
       code: `
@@ -76,7 +76,7 @@ testRule({
         &-small {}
       }
     `,
-      description: "when an ampersand is used in concatenation"
+      description: "when an ampersand is used in concatenation",
     },
     {
       code: `
@@ -84,7 +84,7 @@ testRule({
         & & {}
       }
     `,
-      description: "when an ampersand following an ampersand"
+      description: "when an ampersand following an ampersand",
     },
     {
       code: `
@@ -93,7 +93,7 @@ testRule({
       }
     `,
       description:
-        "when an ampersand is used in concatenation following an ampersand"
+        "when an ampersand is used in concatenation following an ampersand",
     },
     {
       code: `
@@ -101,7 +101,7 @@ testRule({
         &.foo {}
       }
     `,
-      description: "when an ampersand is used in an attribute selector"
+      description: "when an ampersand is used in an attribute selector",
     },
     {
       code: `
@@ -112,7 +112,7 @@ testRule({
       }
     `,
       description:
-        "when an ampersand is used to combine three parts of a classname"
+        "when an ampersand is used to combine three parts of a classname",
     },
     {
       code: `
@@ -121,7 +121,7 @@ testRule({
       }
     `,
       description:
-        "when an ampersand is used to combine two parts of a classname"
+        "when an ampersand is used to combine two parts of a classname",
     },
     {
       code: `
@@ -129,7 +129,7 @@ testRule({
         &__element {}
       }
     `,
-      description: "when BEM syntax element is used"
+      description: "when BEM syntax element is used",
     },
     {
       code: `
@@ -137,8 +137,8 @@ testRule({
         &--modifier {}
       }
     `,
-      description: "when BEM syntax modifier is used"
-    }
+      description: "when BEM syntax modifier is used",
+    },
   ],
 
   reject: [
@@ -150,7 +150,7 @@ testRule({
     `,
       line: 3,
       message: messages.rejected,
-      description: "when an ampersand precedes a direct descendant operator"
+      description: "when an ampersand precedes a direct descendant operator",
     },
     {
       code: `
@@ -161,7 +161,7 @@ testRule({
       line: 3,
       message: messages.rejected,
       description:
-        "when an ampersand precedes a direct descendant operator and there are extra spaces"
+        "when an ampersand precedes a direct descendant operator and there are extra spaces",
     },
     {
       code: `
@@ -172,7 +172,7 @@ testRule({
       line: 3,
       message: messages.rejected,
       description:
-        "when an ampersand precedes a direct descendant operator and there are no spaces"
+        "when an ampersand precedes a direct descendant operator and there are no spaces",
     },
     {
       code: `
@@ -182,7 +182,7 @@ testRule({
     `,
       line: 3,
       message: messages.rejected,
-      description: "when an ampersand precedes an element"
+      description: "when an ampersand precedes an element",
     },
     {
       code: `
@@ -192,7 +192,7 @@ testRule({
     `,
       line: 3,
       message: messages.rejected,
-      description: "when an ampersand precedes a class"
+      description: "when an ampersand precedes a class",
     },
     {
       code: `
@@ -205,7 +205,7 @@ testRule({
       line: 4,
       message: messages.rejected,
       description:
-        "when an ampersand is used to combine two parts of a classname and an ampersand precedes a class"
+        "when an ampersand is used to combine two parts of a classname and an ampersand precedes a class",
     },
     {
       code: `
@@ -215,7 +215,7 @@ testRule({
     `,
       line: 3,
       message: messages.rejected,
-      description: "when an ampersand precedes an element and a class"
+      description: "when an ampersand precedes an element and a class",
     },
     {
       code: `
@@ -226,7 +226,7 @@ testRule({
       line: 3,
       message: messages.rejected,
       description:
-        "when an ampersand precedes an element, a child selector and a class"
+        "when an ampersand precedes an element, a child selector and a class",
     },
     {
       code: `
@@ -236,7 +236,7 @@ testRule({
     `,
       line: 3,
       message: messages.rejected,
-      description: "when an ampersand precedes a sibling operator"
+      description: "when an ampersand precedes a sibling operator",
     },
     {
       code: `
@@ -246,7 +246,7 @@ testRule({
     `,
       line: 3,
       message: messages.rejected,
-      description: "when an ampersand precedes a sibling operator"
+      description: "when an ampersand precedes a sibling operator",
     },
     {
       code: `
@@ -257,7 +257,7 @@ testRule({
       line: 3,
       message: messages.rejected,
       description:
-        "when an ampersand precedes a class and there are extra spaces"
+        "when an ampersand precedes a class and there are extra spaces",
     },
     {
       code: `
@@ -267,7 +267,7 @@ testRule({
     `,
       line: 3,
       message: messages.rejected,
-      description: "ampersand followed by id"
+      description: "ampersand followed by id",
     },
     {
       code: `
@@ -277,7 +277,7 @@ testRule({
     `,
       line: 3,
       message: messages.rejected,
-      description: "ampersand followed by attribute selector"
+      description: "ampersand followed by attribute selector",
     },
     {
       code: `
@@ -287,7 +287,7 @@ testRule({
     `,
       line: 3,
       message: messages.rejected,
-      description: "ampersand followed by %placeholder"
+      description: "ampersand followed by %placeholder",
     },
     {
       code: `
@@ -298,7 +298,7 @@ testRule({
     `,
       line: 3,
       message: messages.rejected,
-      description: "ampersand followed by newline and tag selector"
+      description: "ampersand followed by newline and tag selector",
     },
     {
       code: `
@@ -308,7 +308,7 @@ testRule({
     `,
       line: 3,
       message: messages.rejected,
-      description: "when an ampersand is used by itself"
+      description: "when an ampersand is used by itself",
     },
     {
       code: `
@@ -319,7 +319,7 @@ testRule({
       line: 3,
       message: messages.rejected,
       description:
-        "when an ampersand is used by itself and there are extra spaces"
+        "when an ampersand is used by itself and there are extra spaces",
     },
     {
       code: `
@@ -330,7 +330,7 @@ testRule({
     `,
       line: 4,
       message: messages.rejected,
-      description: "multiple nested selectors"
+      description: "multiple nested selectors",
     },
     {
       code: `
@@ -344,7 +344,7 @@ testRule({
       line: 4,
       message: messages.rejected,
       description:
-        "when an ampersand is used in a comma sequence followed by a class"
+        "when an ampersand is used in a comma sequence followed by a class",
     },
     {
       code: `
@@ -362,17 +362,17 @@ testRule({
         {
           line: 4,
           column: 9,
-          message: messages.rejected
+          message: messages.rejected,
         },
         {
           line: 7,
           column: 9,
-          message: messages.rejected
-        }
+          message: messages.rejected,
+        },
       ],
-      description: "when the ampersand is followed by an unknown keyword"
-    }
-  ]
+      description: "when the ampersand is followed by an unknown keyword",
+    },
+  ],
 });
 
 testRule({
@@ -392,7 +392,7 @@ testRule({
           }
         }
       `,
-      description: "when an ampersand is followed by a keyword"
+      description: "when an ampersand is followed by a keyword",
     },
     {
       code: `
@@ -402,7 +402,7 @@ testRule({
           }
         }
       `,
-      description: "when there are multiple reference nesting"
+      description: "when there are multiple reference nesting",
     },
     {
       code: `
@@ -412,7 +412,7 @@ testRule({
           & regex not (@theme = dark) {}
         }
       `,
-      description: "should support the use of regular option"
-    }
-  ]
+      description: "should support the use of regular option",
+    },
+  ],
 });

--- a/src/rules/selector-no-redundant-nesting-selector/index.js
+++ b/src/rules/selector-no-redundant-nesting-selector/index.js
@@ -6,17 +6,17 @@ import {
   parseSelector,
   hasNestedSibling,
   isType,
-  ruleUrl
+  ruleUrl,
 } from "../../utils";
 
 export const ruleName = namespace("selector-no-redundant-nesting-selector");
 
 export const messages = utils.ruleMessages(ruleName, {
-  rejected: "Unnecessary nesting selector (&)"
+  rejected: "Unnecessary nesting selector (&)",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(actual, options) {
@@ -28,9 +28,9 @@ export default function rule(actual, options) {
       {
         actual: options,
         possible: {
-          ignoreKeywords: [isString, isRegExp]
+          ignoreKeywords: [isString, isRegExp],
         },
-        optional: true
+        optional: true,
       }
     );
 
@@ -38,10 +38,10 @@ export default function rule(actual, options) {
       return;
     }
 
-    root.walkRules(/&/, rule => {
-      parseSelector(rule.selector, result, rule, fullSelector => {
+    root.walkRules(/&/, (rule) => {
+      parseSelector(rule.selector, result, rule, (fullSelector) => {
         // "Ampersand followed by a combinator followed by non-combinator non-ampersand and not the selector end"
-        fullSelector.walkNesting(node => {
+        fullSelector.walkNesting((node) => {
           const prev = node.prev();
 
           if (prev || hasNestedSibling(node)) {
@@ -77,7 +77,7 @@ export default function rule(actual, options) {
             result,
             node: rule,
             message: messages.rejected,
-            index: node.sourceIndex
+            index: node.sourceIndex,
           });
         });
       });

--- a/src/rules/selector-no-union-class-name/__tests__/index.js
+++ b/src/rules/selector-no-union-class-name/__tests__/index.js
@@ -12,7 +12,7 @@ testRule({
         &.foo {}
       }
     `,
-      description: "when an ampersand is chained with another class name"
+      description: "when an ampersand is chained with another class name",
     },
     {
       code: `
@@ -20,7 +20,7 @@ testRule({
         &-union {}
       }
     `,
-      description: "when an ampersand parent is not class name"
+      description: "when an ampersand parent is not class name",
     },
     {
       code: `
@@ -28,7 +28,7 @@ testRule({
         & span {}
       }
     `,
-      description: "when an ampersand is chained with combinator"
+      description: "when an ampersand is chained with combinator",
     },
     {
       code: `
@@ -37,7 +37,7 @@ testRule({
       }
     `,
       description:
-        "when an ampersand is chained with the adjacent sibling combinator"
+        "when an ampersand is chained with the adjacent sibling combinator",
     },
     {
       code: `
@@ -46,7 +46,7 @@ testRule({
       }
     `,
       description:
-        "when an ampersand is chained with the general sibling combinator"
+        "when an ampersand is chained with the general sibling combinator",
     },
     {
       code: `
@@ -54,7 +54,7 @@ testRule({
         & > span {}
       }
     `,
-      description: "when an ampersand is chained with the child combinator "
+      description: "when an ampersand is chained with the child combinator ",
     },
     {
       code: `
@@ -64,7 +64,7 @@ testRule({
         }
       }
       `,
-      description: "ignores an ampersand chained with a pseudo-class"
+      description: "ignores an ampersand chained with a pseudo-class",
     },
     {
       code: `
@@ -74,7 +74,7 @@ testRule({
         }
       }
       `,
-      description: "ignores an ampersand chained with a pseudo-element"
+      description: "ignores an ampersand chained with a pseudo-element",
     },
     {
       code: `
@@ -84,7 +84,7 @@ testRule({
         }
       }
       `,
-      description: "ignores an ampersand chained with an ID"
+      description: "ignores an ampersand chained with an ID",
     },
     {
       code: `
@@ -94,7 +94,7 @@ testRule({
         }
       }
       `,
-      description: "ignores an ampersand chained with an attribute"
+      description: "ignores an ampersand chained with an attribute",
     },
     {
       code: `
@@ -108,8 +108,8 @@ testRule({
           }
         }
       }`,
-      description: "should not throw an error when using nesting (issue #345)"
-    }
+      description: "should not throw an error when using nesting (issue #345)",
+    },
   ],
 
   reject: [
@@ -121,7 +121,8 @@ testRule({
     `,
       line: 3,
       message: messages.rejected,
-      description: "when an ampersand is chained with union class name (hyphen)"
+      description:
+        "when an ampersand is chained with union class name (hyphen)",
     },
     {
       code: `
@@ -132,7 +133,7 @@ testRule({
       line: 3,
       message: messages.rejected,
       description:
-        "when an ampersand is chained with union class name (underscore)"
+        "when an ampersand is chained with union class name (underscore)",
     },
     {
       code: `
@@ -142,9 +143,10 @@ testRule({
 			`,
       line: 3,
       message: messages.rejected,
-      description: "when an ampersand is chained with union class name (direct)"
-    }
-  ]
+      description:
+        "when an ampersand is chained with union class name (direct)",
+    },
+  ],
 });
 
 testRule({
@@ -168,8 +170,8 @@ testRule({
       }
       `,
       description:
-        "verify that the selector parsing does not throw an error when Less is used (issue #471)."
-    }
-  ]
+        "verify that the selector parsing does not throw an error when Less is used (issue #471).",
+    },
+  ],
   /* eslint-enable no-useless-escape */
 });

--- a/src/rules/selector-no-union-class-name/index.js
+++ b/src/rules/selector-no-union-class-name/index.js
@@ -4,7 +4,7 @@ import {
   isCombinator,
   isIdentifier,
   isPseudoClass,
-  isPseudoElement
+  isPseudoElement,
 } from "postcss-selector-parser";
 import { utils } from "stylelint";
 import { namespace, parseSelector, ruleUrl } from "../../utils";
@@ -12,11 +12,11 @@ import { namespace, parseSelector, ruleUrl } from "../../utils";
 export const ruleName = namespace("selector-no-union-class-name");
 
 export const messages = utils.ruleMessages(ruleName, {
-  rejected: "Unexpected union class name with the parent selector (&)"
+  rejected: "Unexpected union class name with the parent selector (&)",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 const validNestingTypes = [
@@ -25,7 +25,7 @@ const validNestingTypes = [
   isAttribute,
   isIdentifier,
   isPseudoClass,
-  isPseudoElement
+  isPseudoElement,
 ];
 
 export default function rule(actual) {
@@ -36,14 +36,14 @@ export default function rule(actual) {
       return;
     }
 
-    root.walkRules(/&/, rule => {
+    root.walkRules(/&/, (rule) => {
       const parentNodes = [];
 
       const selector = getSelectorFromRule(rule.parent);
 
       if (selector) {
-        parseSelector(selector, result, rule, fullSelector => {
-          fullSelector.walk(node => parentNodes.push(node));
+        parseSelector(selector, result, rule, (fullSelector) => {
+          fullSelector.walk((node) => parentNodes.push(node));
         });
       }
 
@@ -53,20 +53,20 @@ export default function rule(actual) {
 
       if (!isClassName(lastParentNode)) return;
 
-      parseSelector(rule.selector, result, rule, fullSelector => {
-        fullSelector.walkNesting(node => {
+      parseSelector(rule.selector, result, rule, (fullSelector) => {
+        fullSelector.walkNesting((node) => {
           const next = node.next();
 
           if (!next) return;
 
-          if (validNestingTypes.some(isType => isType(next))) return;
+          if (validNestingTypes.some((isType) => isType(next))) return;
 
           utils.report({
             ruleName,
             result,
             node: rule,
             message: messages.rejected,
-            index: node.sourceIndex
+            index: node.sourceIndex,
           });
         });
       });

--- a/src/utils/__tests__/findCommentsInRaws.js
+++ b/src/utils/__tests__/findCommentsInRaws.js
@@ -11,7 +11,7 @@ test("// is the first statement in the file", () => {
 
   return postcss()
     .process("// comment", { syntax: scss, from: undefined, parser: scss })
-    .then(result => {
+    .then((result) => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
 
@@ -33,7 +33,7 @@ test("// is the first statement in a string, w/o pre-whs", () => {
 // comment`,
       { syntax: scss, from: undefined, parser: scss }
     )
-    .then(result => {
+    .then((result) => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
 
@@ -51,7 +51,7 @@ test("CSS-comment is the first statement (and the last one) in a file", () => {
 
   return postcss()
     .process("/* comment1 */", { syntax: scss, from: undefined, parser: scss })
-    .then(result => {
+    .then((result) => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
 
@@ -74,7 +74,7 @@ test("CSS-comment is the first statement (and the last one) in a string", () => 
     `,
       { syntax: scss, from: undefined, parser: scss }
     )
-    .then(result => {
+    .then((result) => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
 
@@ -110,7 +110,7 @@ test("Various.", () => {
     `,
       { syntax: scss, from: undefined, parser: scss }
     )
-    .then(result => {
+    .then((result) => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
 
@@ -143,7 +143,7 @@ test("//", () => {
     `,
       { syntax: scss, from: undefined, parser: scss }
     )
-    .then(result => {
+    .then((result) => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
 
@@ -167,7 +167,7 @@ test("// Inline comment, after {.", () => {
     `,
       { syntax: scss, from: undefined, parser: scss }
     )
-    .then(result => {
+    .then((result) => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
 
@@ -188,7 +188,7 @@ test("} // comment", () => {
     `,
       { syntax: scss, from: undefined, parser: scss }
     )
-    .then(result => {
+    .then((result) => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
 
@@ -205,9 +205,9 @@ test("Triple-slash comment", () => {
     .process("a {} /// comment", {
       syntax: scss,
       from: undefined,
-      parser: scss
+      parser: scss,
     })
-    .then(result => {
+    .then((result) => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
 
@@ -233,7 +233,7 @@ test("Some fancy comment", () => {
     `,
       { syntax: scss, from: undefined, parser: scss }
     )
-    .then(result => {
+    .then((result) => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
 
@@ -261,7 +261,7 @@ test("Another fancy comment", () => {
     `,
       { syntax: scss, from: undefined, parser: scss }
     )
-    .then(result => {
+    .then((result) => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
 
@@ -288,7 +288,7 @@ test("Comments inside comments", () => {
     `,
       { syntax: scss, from: undefined, parser: scss }
     )
-    .then(result => {
+    .then((result) => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
 
@@ -319,7 +319,7 @@ test("No comments, but parsing a selector with ().", () => {
     `,
       { syntax: scss, from: undefined, parser: scss }
     )
-    .then(result => {
+    .then((result) => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
 
@@ -339,7 +339,7 @@ test("Double backslash inside a string (issue #294)", () => {
     `,
       { syntax: scss, from: undefined, parser: scss }
     )
-    .then(result => {
+    .then((result) => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
 
@@ -355,9 +355,9 @@ test("//-comment, Unix newlines", () => {
     .process("\n   // comment \n", {
       syntax: scss,
       from: undefined,
-      parser: scss
+      parser: scss,
     })
-    .then(result => {
+    .then((result) => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
 
@@ -374,9 +374,9 @@ test("CSS comment, Unix newlines", () => {
     .process("\n   /* part 1 \n part 2*/ \n", {
       syntax: scss,
       from: undefined,
-      parser: scss
+      parser: scss,
     })
-    .then(result => {
+    .then((result) => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
 
@@ -393,9 +393,9 @@ test("//-comment, Windows-newline", () => {
     .process("\r\n   // comment \r\n", {
       syntax: scss,
       from: undefined,
-      parser: scss
+      parser: scss,
     })
-    .then(result => {
+    .then((result) => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
 
@@ -412,9 +412,9 @@ test("CSS comment, Windows newlines", () => {
     .process("\r\n   /* part 1 \r\n part 2*/ \r\n", {
       syntax: scss,
       from: undefined,
-      parser: scss
+      parser: scss,
     })
-    .then(result => {
+    .then((result) => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
 
@@ -431,9 +431,9 @@ test("No comments; testing a dangerous case in function detection [`@media( ... 
     .process("@media(min-width: 480px) { }", {
       syntax: scss,
       from: undefined,
-      parser: scss
+      parser: scss,
     })
-    .then(result => {
+    .then((result) => {
       const css = result.root.source.input.css;
       const comments = findCommentsInRaws(css);
 

--- a/src/utils/__tests__/isCustomPropertySet.test.js
+++ b/src/utils/__tests__/isCustomPropertySet.test.js
@@ -3,13 +3,13 @@ import postcss from "postcss";
 
 describe("isCustomPropertySet", () => {
   it("accepts custom property set", () => {
-    customPropertySet("--foo: {};", customPropertySet => {
+    customPropertySet("--foo: {};", (customPropertySet) => {
       expect(isCustomPropertySet(customPropertySet)).toBeTruthy();
     });
   });
 
   it("rejects custom property", () => {
-    customPropertySet("--foo: red;", customPropertySet => {
+    customPropertySet("--foo: red;", (customPropertySet) => {
       expect(isCustomPropertySet(customPropertySet)).toBeFalsy();
     });
   });

--- a/src/utils/__tests__/isInlineComment.js
+++ b/src/utils/__tests__/isInlineComment.js
@@ -16,8 +16,8 @@ test("Single-line comment, after ruleset.", () => {
     `,
       { syntax: scss, from: undefined, parser: scss }
     )
-    .then(result => {
-      result.root.walkComments(comment => {
+    .then((result) => {
+      result.root.walkComments((comment) => {
         expect(isInlineComment(comment)).toBe(true);
       });
     })
@@ -34,8 +34,8 @@ test("CSS comment, after ruleset.", () => {
     `,
       { syntax: scss, from: undefined, parser: scss }
     )
-    .then(result => {
-      result.root.walkComments(comment => {
+    .then((result) => {
+      result.root.walkComments((comment) => {
         expect(isInlineComment(comment)).toBe(true);
       });
     })
@@ -54,8 +54,8 @@ test("Single-line comment, after a decl.", () => {
     `,
       { syntax: scss, from: undefined, parser: scss }
     )
-    .then(result => {
-      result.root.walkComments(comment => {
+    .then((result) => {
+      result.root.walkComments((comment) => {
         expect(isInlineComment(comment)).toBe(true);
       });
     })
@@ -74,8 +74,8 @@ test("CSS comment, before a decl.", () => {
     `,
       { syntax: scss, from: undefined, parser: scss }
     )
-    .then(result => {
-      result.root.walkComments(comment => {
+    .then((result) => {
+      result.root.walkComments((comment) => {
         expect(isInlineComment(comment)).toBe(true);
       });
     })
@@ -94,8 +94,8 @@ test("Inline comment, after a {.", () => {
     `,
       { syntax: scss, from: undefined, parser: scss }
     )
-    .then(result => {
-      result.root.walkComments(comment => {
+    .then((result) => {
+      result.root.walkComments((comment) => {
         expect(isInlineComment(comment)).toBe(true);
       });
     })
@@ -115,10 +115,10 @@ test("Inline comment, after a selector (in a list). IGNORED.", () => {
     `,
       { syntax: scss, from: undefined, parser: scss }
     )
-    .then(result => {
+    .then((result) => {
       let res = null;
 
-      result.root.walkComments(comment => {
+      result.root.walkComments((comment) => {
         res = isInlineComment(comment);
       });
       expect(res).toBeNull();
@@ -139,10 +139,10 @@ test("Inline comment, after a selector, comment prior. IGNORED.", () => {
     `,
       { syntax: scss, from: undefined, parser: scss }
     )
-    .then(result => {
+    .then((result) => {
       let res = null;
 
-      result.root.walkComments(comment => {
+      result.root.walkComments((comment) => {
         res = isInlineComment(comment);
       });
       expect(res).toBeNull();
@@ -161,8 +161,8 @@ test("Multi-line comment, after a ruleset (new line).", () => {
     `,
       { syntax: scss, from: undefined, parser: scss }
     )
-    .then(result => {
-      result.root.walkComments(comment => {
+    .then((result) => {
+      result.root.walkComments((comment) => {
         expect(isInlineComment(comment)).toBe(false);
       });
     })
@@ -180,8 +180,8 @@ test("Single-line comment, after a ruleset (new line).", () => {
     `,
       { syntax: scss, from: undefined, parser: scss }
     )
-    .then(result => {
-      result.root.walkComments(comment => {
+    .then((result) => {
+      result.root.walkComments((comment) => {
         expect(isInlineComment(comment)).toBe(false);
       });
     })

--- a/src/utils/__tests__/parseFunctionArguments.js
+++ b/src/utils/__tests__/parseFunctionArguments.js
@@ -1,7 +1,7 @@
 import {
   groupByKeyValue,
   mapToKeyValue,
-  parseFunctionArguments
+  parseFunctionArguments,
 } from "../parseFunctionArguments";
 
 describe("groupByKeyValue", () => {
@@ -14,7 +14,7 @@ describe("groupByKeyValue", () => {
           sourceIndex: 12,
           value: ":",
           before: "",
-          after: " "
+          after: " ",
         },
         { type: "word", sourceIndex: 14, value: "40px" },
         {
@@ -22,17 +22,17 @@ describe("groupByKeyValue", () => {
           sourceIndex: 18,
           value: ",",
           before: "",
-          after: " "
+          after: " ",
         },
-        { type: "word", sourceIndex: 20, value: "10px" }
+        { type: "word", sourceIndex: 20, value: "10px" },
       ])
     ).toEqual([
       [
         { sourceIndex: 6, type: "word", value: "$value" },
         { after: " ", before: "", sourceIndex: 12, type: "div", value: ":" },
-        { sourceIndex: 14, type: "word", value: "40px" }
+        { sourceIndex: 14, type: "word", value: "40px" },
       ],
-      [{ sourceIndex: 20, type: "word", value: "10px" }]
+      [{ sourceIndex: 20, type: "word", value: "10px" }],
     ]);
     expect(
       groupByKeyValue([
@@ -42,7 +42,7 @@ describe("groupByKeyValue", () => {
           sourceIndex: 12,
           value: ":",
           before: "",
-          after: " "
+          after: " ",
         },
         { type: "word", sourceIndex: 14, value: "40px" },
         {
@@ -50,7 +50,7 @@ describe("groupByKeyValue", () => {
           sourceIndex: 18,
           value: ",",
           before: "",
-          after: " "
+          after: " ",
         },
         { type: "word", sourceIndex: 20, value: "$second-value" },
         {
@@ -58,7 +58,7 @@ describe("groupByKeyValue", () => {
           sourceIndex: 33,
           value: ":",
           before: "",
-          after: " "
+          after: " ",
         },
         { type: "word", sourceIndex: 35, value: "10px" },
         {
@@ -66,7 +66,7 @@ describe("groupByKeyValue", () => {
           sourceIndex: 39,
           value: ",",
           before: "",
-          after: " "
+          after: " ",
         },
         { type: "word", sourceIndex: 41, value: "$color" },
         {
@@ -74,26 +74,26 @@ describe("groupByKeyValue", () => {
           sourceIndex: 47,
           value: ":",
           before: "",
-          after: " "
+          after: " ",
         },
-        { type: "string", sourceIndex: 49, quote: "'", value: "black" }
+        { type: "string", sourceIndex: 49, quote: "'", value: "black" },
       ])
     ).toEqual([
       [
         { sourceIndex: 6, type: "word", value: "$value" },
         { after: " ", before: "", sourceIndex: 12, type: "div", value: ":" },
-        { sourceIndex: 14, type: "word", value: "40px" }
+        { sourceIndex: 14, type: "word", value: "40px" },
       ],
       [
         { sourceIndex: 20, type: "word", value: "$second-value" },
         { after: " ", before: "", sourceIndex: 33, type: "div", value: ":" },
-        { sourceIndex: 35, type: "word", value: "10px" }
+        { sourceIndex: 35, type: "word", value: "10px" },
       ],
       [
         { sourceIndex: 41, type: "word", value: "$color" },
         { after: " ", before: "", sourceIndex: 47, type: "div", value: ":" },
-        { quote: "'", sourceIndex: 49, type: "string", value: "black" }
-      ]
+        { quote: "'", sourceIndex: 49, type: "string", value: "black" },
+      ],
     ]);
     expect(
       groupByKeyValue([
@@ -103,7 +103,7 @@ describe("groupByKeyValue", () => {
           sourceIndex: 12,
           value: ":",
           before: "",
-          after: " "
+          after: " ",
         },
         { type: "word", sourceIndex: 14, value: "40px" },
         {
@@ -111,7 +111,7 @@ describe("groupByKeyValue", () => {
           sourceIndex: 18,
           value: ",",
           before: "",
-          after: " "
+          after: " ",
         },
         { type: "word", sourceIndex: 20, value: "$second-value" },
         {
@@ -119,7 +119,7 @@ describe("groupByKeyValue", () => {
           sourceIndex: 33,
           value: ":",
           before: "",
-          after: " "
+          after: " ",
         },
         { type: "word", sourceIndex: 35, value: "10px" },
         {
@@ -127,20 +127,20 @@ describe("groupByKeyValue", () => {
           sourceIndex: 39,
           value: ",",
           before: "",
-          after: " "
-        }
+          after: " ",
+        },
       ])
     ).toEqual([
       [
         { sourceIndex: 6, type: "word", value: "$value" },
         { after: " ", before: "", sourceIndex: 12, type: "div", value: ":" },
-        { sourceIndex: 14, type: "word", value: "40px" }
+        { sourceIndex: 14, type: "word", value: "40px" },
       ],
       [
         { sourceIndex: 20, type: "word", value: "$second-value" },
         { after: " ", before: "", sourceIndex: 33, type: "div", value: ":" },
-        { sourceIndex: 35, type: "word", value: "10px" }
-      ]
+        { sourceIndex: 35, type: "word", value: "10px" },
+      ],
     ]);
   });
 });
@@ -151,7 +151,7 @@ describe("mapToKeyValue", () => {
       mapToKeyValue([
         { sourceIndex: 6, type: "word", value: "$value" },
         { after: " ", before: "", sourceIndex: 12, type: "div", value: ":" },
-        { sourceIndex: 14, type: "word", value: "40px" }
+        { sourceIndex: 14, type: "word", value: "40px" },
       ])
     ).toEqual({ key: "$value", value: "40px" });
     expect(
@@ -176,38 +176,38 @@ describe("parseFunctionArguments", () => {
   it("parses number as the value", () => {
     expect(parseFunctionArguments("func(1)")).toEqual([
       {
-        value: "1"
-      }
+        value: "1",
+      },
     ]);
   });
 
   it("parses calculation as the value", () => {
     expect(parseFunctionArguments("func(30 * 25ms)")).toEqual([
       {
-        value: "30 * 25ms"
-      }
+        value: "30 * 25ms",
+      },
     ]);
   });
 
   it("parses multiple args", () => {
     expect(parseFunctionArguments("func(1, 2)")).toEqual([
       {
-        value: "1"
+        value: "1",
       },
       {
-        value: "2"
-      }
+        value: "2",
+      },
     ]);
   });
 
   it("parses trailing commas", () => {
     expect(parseFunctionArguments("func(1, 2,)")).toEqual([
       {
-        value: "1"
+        value: "1",
       },
       {
-        value: "2"
-      }
+        value: "2",
+      },
     ]);
   });
 
@@ -215,8 +215,8 @@ describe("parseFunctionArguments", () => {
     expect(parseFunctionArguments("func($var: 1)")).toEqual([
       {
         key: "$var",
-        value: "1"
-      }
+        value: "1",
+      },
     ]);
   });
 
@@ -228,8 +228,8 @@ describe("parseFunctionArguments", () => {
     ).toEqual([
       {
         key: "$foo",
-        value: 'url("data:image/svg+xml;charset=utf8,%3C")'
-      }
+        value: 'url("data:image/svg+xml;charset=utf8,%3C")',
+      },
     ]);
   });
 
@@ -237,8 +237,8 @@ describe("parseFunctionArguments", () => {
     expect(parseFunctionArguments("reset($value: #{$other-value})")).toEqual([
       {
         key: "$value",
-        value: "#{$other-value}"
-      }
+        value: "#{$other-value}",
+      },
     ]);
   });
 
@@ -246,8 +246,8 @@ describe("parseFunctionArguments", () => {
     expect(parseFunctionArguments("anim($duration: 30 * 25ms)")).toEqual([
       {
         key: "$duration",
-        value: "30 * 25ms"
-      }
+        value: "30 * 25ms",
+      },
     ]);
   });
 
@@ -255,12 +255,12 @@ describe("parseFunctionArguments", () => {
     expect(parseFunctionArguments("func($var: 1, $foo: bar)")).toEqual([
       {
         key: "$var",
-        value: "1"
+        value: "1",
       },
       {
         key: `$foo`,
-        value: "bar"
-      }
+        value: "bar",
+      },
     ]);
   });
 
@@ -272,16 +272,16 @@ describe("parseFunctionArguments", () => {
     ).toEqual([
       {
         key: "$value",
-        value: "40px"
+        value: "40px",
       },
       {
         key: "$second-value",
-        value: "10px"
+        value: "10px",
       },
       {
         key: "$color",
-        value: "'black'"
-      }
+        value: "'black'",
+      },
     ]);
   });
 
@@ -292,20 +292,20 @@ describe("parseFunctionArguments", () => {
       )
     ).toEqual([
       {
-        value: "to left"
+        value: "to left",
       },
       {
-        value: "#333"
+        value: "#333",
       },
       {
-        value: "#333 50%"
+        value: "#333 50%",
       },
       {
-        value: "#eee 75%"
+        value: "#eee 75%",
       },
       {
-        value: "#333 75%"
-      }
+        value: "#333 75%",
+      },
     ]);
   });
 });

--- a/src/utils/__tests__/parseNestedPropRoot.js
+++ b/src/utils/__tests__/parseNestedPropRoot.js
@@ -12,8 +12,8 @@ test("`background:`", () => {
   expect(result).toEqual({
     propName: {
       value: "background",
-      after: ""
-    }
+      after: "",
+    },
   });
 });
 
@@ -25,13 +25,13 @@ test("`background: red`", () => {
   expect(result).toEqual({
     propName: {
       value: "background",
-      after: ""
+      after: "",
     },
     propValue: {
       value: "red",
       before: " ",
-      sourceIndex: 12
-    }
+      sourceIndex: 12,
+    },
   });
 });
 
@@ -43,13 +43,13 @@ test("`margin:10px`", () => {
   expect(result).toEqual({
     propName: {
       value: "margin",
-      after: ""
+      after: "",
     },
     propValue: {
       value: "10px",
       before: "",
-      sourceIndex: 7
-    }
+      sourceIndex: 7,
+    },
   });
 });
 
@@ -61,13 +61,13 @@ test("`margin:$var`", () => {
   expect(result).toEqual({
     propName: {
       value: "margin",
-      after: ""
+      after: "",
     },
     propValue: {
       value: "$var",
       before: "",
-      sourceIndex: 7
-    }
+      sourceIndex: 7,
+    },
   });
 });
 
@@ -79,13 +79,13 @@ test("`input: -moz-focusring ` -- yes, this IS parsed as 'prop: value' by Sass!"
   expect(result).toEqual({
     propName: {
       value: "input",
-      after: ""
+      after: "",
     },
     propValue: {
       value: "-moz-focusring",
       before: " ",
-      sourceIndex: 7
-    }
+      sourceIndex: 7,
+    },
   });
 });
 
@@ -97,13 +97,13 @@ test("`background  :  red`", () => {
   expect(result).toEqual({
     propName: {
       value: "background",
-      after: "  "
+      after: "  ",
     },
     propValue: {
       value: "red",
       before: "  ",
-      sourceIndex: 15
-    }
+      sourceIndex: 15,
+    },
   });
 });
 
@@ -115,8 +115,8 @@ test("Edge case: function with param `#{fn($a:1)}:`.", () => {
   expect(result).toEqual({
     propName: {
       value: "#{fn($a:1)}",
-      after: ""
-    }
+      after: "",
+    },
   });
 });
 
@@ -128,8 +128,8 @@ test("Edge case: function with param `#{fn($a: 1)}:`.", () => {
   expect(result).toEqual({
     propName: {
       value: "#{fn($a: 1)}",
-      after: ""
-    }
+      after: "",
+    },
   });
 });
 
@@ -141,13 +141,13 @@ test('`input:"prop: value"` (value is a string).', () => {
   expect(result).toEqual({
     propName: {
       value: "input",
-      after: ""
+      after: "",
     },
     propValue: {
       value: '"prop: value"',
       before: "",
-      sourceIndex: 6
-    }
+      sourceIndex: 6,
+    },
   });
 });
 

--- a/src/utils/atRuleBaseName.js
+++ b/src/utils/atRuleBaseName.js
@@ -4,6 +4,6 @@
  * @param {AtRule} atRule
  * @return {string} The name
  */
-export default function(atRule) {
+export default function (atRule) {
   return atRule.params.replace(/\([^)]*\)/, "").trim();
 }

--- a/src/utils/atRuleParamIndex.js
+++ b/src/utils/atRuleParamIndex.js
@@ -4,7 +4,7 @@
  * @param {AtRule} atRule
  * @return {int} The index
  */
-export default function(atRule) {
+export default function (atRule) {
   // Initial 1 is for the `@`
   let index = 1 + atRule.name.length;
 

--- a/src/utils/beforeBlockString.js
+++ b/src/utils/beforeBlockString.js
@@ -10,7 +10,7 @@
  * @param {boolean} [options.noRawBefore] - Leave out the `before` string
  * @return {string}
  */
-export default function(statement, { noRawBefore } = {}) {
+export default function (statement, { noRawBefore } = {}) {
   let result = "";
 
   if (statement.type !== "rule" && statement.type !== "atrule") {

--- a/src/utils/blockString.js
+++ b/src/utils/blockString.js
@@ -11,7 +11,7 @@ import rawNodeString from "./rawNodeString";
  * @param {Rule|AtRule} statement - postcss rule or at-rule node
  * @return {string|undefined}
  */
-export default function(statement) {
+export default function (statement) {
   if (!hasBlock(statement)) {
     return;
   }

--- a/src/utils/configurationError.js
+++ b/src/utils/configurationError.js
@@ -4,7 +4,7 @@
  * @param {string} text
  * @return {Error} - The error, with text and exit code
  */
-export default function(text) {
+export default function (text) {
   const err = new Error(text);
 
   err.code = 78;

--- a/src/utils/declarationValueIndex.js
+++ b/src/utils/declarationValueIndex.js
@@ -4,7 +4,7 @@
  * @param {Decl} decl
  * @return {int} The index
  */
-export default function(decl) {
+export default function (decl) {
   const beforeColon = decl.toString().indexOf(":");
   const afterColon =
     decl.raw("between").length - decl.raw("between").indexOf(":");

--- a/src/utils/eachRoot.js
+++ b/src/utils/eachRoot.js
@@ -4,7 +4,7 @@
  * @param {Root|Document} root - root element of file.
  * @param {function} cb - Function to execute for each CSS block element
  */
-export default function(root, cb) {
+export default function (root, cb) {
   // class `Document` is a part of `postcss-html`,
   // It is collection of roots in HTML File.
   // See: https://github.com/gucong3000/postcss-html/blob/master/lib/document.js

--- a/src/utils/findCommentsInRaws.js
+++ b/src/utils/findCommentsInRaws.js
@@ -33,8 +33,8 @@ export default function findCommentsInRaws(rawString) {
   const modesEntered = [
     {
       mode: "normal",
-      character: null
-    }
+      character: null,
+    },
   ];
   let commentStart = null;
 
@@ -71,7 +71,7 @@ export default function findCommentsInRaws(rawString) {
           // Entering a string
           modesEntered.push({
             mode: "string",
-            character
+            character,
           });
         }
 
@@ -83,15 +83,16 @@ export default function findCommentsInRaws(rawString) {
           break;
         }
 
-        const functionNameRegSearch = /(?:^|[\n\r]|\s-|[:\s,.(){}*+/%])([\w-]*)$/.exec(
-          rawString.substring(0, i)
-        );
+        const functionNameRegSearch =
+          /(?:^|[\n\r]|\s-|[:\s,.(){}*+/%])([\w-]*)$/.exec(
+            rawString.substring(0, i)
+          );
 
         // A `\S(` can be in, say, `@media(`
         if (!functionNameRegSearch) {
           modesEntered.push({
             mode: "parens",
-            character: "("
+            character: "(",
           });
           break;
         }
@@ -100,7 +101,7 @@ export default function findCommentsInRaws(rawString) {
 
         modesEntered.push({
           mode: functionName === "url" ? "url" : "parens",
-          character: "("
+          character: "(",
         });
         break;
       }
@@ -125,14 +126,14 @@ export default function findCommentsInRaws(rawString) {
         if (nextChar === "*") {
           modesEntered.push({
             mode: "comment",
-            character: "/*"
+            character: "/*",
           });
           comment = {
             type: "css",
             source: { start: i + offset },
             // If i is 0 then the file/the line starts with this comment
             inlineAfter:
-              i > 0 && rawString.substring(0, i).search(/\n\s*$/) === -1
+              i > 0 && rawString.substring(0, i).search(/\n\s*$/) === -1,
           };
           commentStart = i;
           // Skip the next iteration as the * is already checked
@@ -145,14 +146,14 @@ export default function findCommentsInRaws(rawString) {
 
           modesEntered.push({
             mode: "comment",
-            character: "//"
+            character: "//",
           });
           comment = {
             type: "double-slash",
             source: { start: i + offset },
             // If i is 0 then the file/the line starts with this comment
             inlineAfter:
-              i > 0 && rawString.substring(0, i).search(/\n\s*$/) === -1
+              i > 0 && rawString.substring(0, i).search(/\n\s*$/) === -1,
           };
           commentStart = i;
           // Skip the next iteration as the second slash in // is already checked
@@ -181,7 +182,7 @@ export default function findCommentsInRaws(rawString) {
             left: matches[2],
             text: commentRaw,
             right: matches[4],
-            endToken: matches[5]
+            endToken: matches[5],
           };
           comment.text = matches[3];
           comment.inlineBefore =
@@ -218,7 +219,7 @@ export default function findCommentsInRaws(rawString) {
               startToken: matches[1],
               left: matches[2],
               text: commentRaw,
-              right: matches[4]
+              right: matches[4],
             };
             comment.text = matches[3];
             comment.inlineBefore = false;

--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -6,7 +6,7 @@ export const GLOBAL_FUNCTIONS = Object.freeze([
   "hsla",
   "if",
   "rgb",
-  "rgba"
+  "rgba",
 ]);
 
 /**
@@ -57,7 +57,7 @@ export const COLOR_FUNCTIONS = Object.freeze([
   "color.red",
   "color.saturation",
   "color.scale",
-  "color.whiteness"
+  "color.whiteness",
 ]);
 
 /**
@@ -84,7 +84,7 @@ export const LIST_FUNCTIONS = Object.freeze([
   "list.separator",
   "list.set-nth",
   "list.slash",
-  "zip"
+  "zip",
 ]);
 
 /**
@@ -107,7 +107,7 @@ export const MAP_FUNCTIONS = Object.freeze([
   "map.merge",
   "map.remove",
   "map.set",
-  "map.values"
+  "map.values",
 ]);
 
 /**
@@ -150,7 +150,7 @@ export const MATH_FUNCTIONS = Object.freeze([
   "math.sin",
   "math.sqrt",
   "math.tan",
-  "math.unit"
+  "math.unit",
 ]);
 
 /**
@@ -184,7 +184,7 @@ export const META_FUNCTIONS = Object.freeze([
   "meta.module-functions",
   "meta.module-variables",
   "meta.type-of",
-  "meta.variable-exists"
+  "meta.variable-exists",
 ]);
 
 /**
@@ -208,7 +208,7 @@ export const SELECTOR_FUNCTIONS = Object.freeze([
   "selector.parse",
   "selector.replace",
   "selector.simple-selectors",
-  "selector.unify"
+  "selector.unify",
 ]);
 
 /**
@@ -234,7 +234,7 @@ export const STRING_FUNCTIONS = Object.freeze([
   "string.to-lower-case",
   "string.to-upper-case",
   "string.unique-id",
-  "string.unquote"
+  "string.unquote",
 ]);
 
 export const ALL_FUNCTIONS = Object.freeze([
@@ -245,5 +245,5 @@ export const ALL_FUNCTIONS = Object.freeze([
   ...MATH_FUNCTIONS,
   ...META_FUNCTIONS,
   ...SELECTOR_FUNCTIONS,
-  ...STRING_FUNCTIONS
+  ...STRING_FUNCTIONS,
 ]);

--- a/src/utils/hasBlock.js
+++ b/src/utils/hasBlock.js
@@ -4,6 +4,6 @@
  * @param {Rule|AtRule} statement - postcss rule or at-rule node
  * @return {boolean} True if `statement` has a block (empty or otherwise)
  */
-export default function(statement) {
+export default function (statement) {
   return statement.nodes !== undefined;
 }

--- a/src/utils/hasEmptyLine.js
+++ b/src/utils/hasEmptyLine.js
@@ -4,6 +4,6 @@
  * @param {string} string
  * @return {boolean}
  */
-export default function(string) {
+export default function (string) {
   return string && (string.includes("\n\n") || string.includes("\n\r\n"));
 }

--- a/src/utils/hasInterpolatingAmpersand.js
+++ b/src/utils/hasInterpolatingAmpersand.js
@@ -7,7 +7,7 @@
  * @param {string} selector
  * @return {boolean} If `true`, the selector has an interpolating ampersand
  */
-export default function(selector) {
+export default function (selector) {
   for (let i = 0; i < selector.length; i++) {
     if (selector[i] !== "&") {
       continue;

--- a/src/utils/hasInterpolation.js
+++ b/src/utils/hasInterpolation.js
@@ -9,7 +9,7 @@ import hasTplInterpolation from "./hasTplInterpolation";
  * @param {string} string
  * @return {boolean} If `true`, a string has interpolation
  */
-export default function(string) {
+export default function (string) {
   // SCSS or Less interpolation
   return !!(
     hasLessInterpolation(string) ||

--- a/src/utils/hasLessInterpolation.js
+++ b/src/utils/hasLessInterpolation.js
@@ -4,6 +4,6 @@
  * @param {string} string
  * @return {boolean} If `true`, a string has less interpolation
  */
-export default function(string) {
+export default function (string) {
   return /@{.+?}/.test(string);
 }

--- a/src/utils/hasNestedSibling.js
+++ b/src/utils/hasNestedSibling.js
@@ -4,8 +4,8 @@
  * @param  {import('postcss').Node} node
  * @return {boolean}
  */
-export default function(node) {
+export default function (node) {
   return (
-    node && node.parent.nodes.some(n => n !== node && n.type === "nesting")
+    node && node.parent.nodes.some((n) => n !== node && n.type === "nesting")
   );
 }

--- a/src/utils/hasPsvInterpolation.js
+++ b/src/utils/hasPsvInterpolation.js
@@ -3,6 +3,6 @@
  *
  * @param {string} string
  */
-export default function(string) {
+export default function (string) {
   return /\$\(.+?\)/.test(string);
 }

--- a/src/utils/hasScssInterpolation.js
+++ b/src/utils/hasScssInterpolation.js
@@ -3,6 +3,6 @@
  *
  * @param {string} string
  */
-export default function(string) {
+export default function (string) {
   return /#{.+?}/.test(string);
 }

--- a/src/utils/hasTplInterpolation.js
+++ b/src/utils/hasTplInterpolation.js
@@ -4,6 +4,6 @@
  * @param {string} string
  * @return {boolean} If `true`, a string has template literal interpolation
  */
-export default function(string) {
+export default function (string) {
   return /{.+?}/.test(string);
 }

--- a/src/utils/isCustomPropertySet.js
+++ b/src/utils/isCustomPropertySet.js
@@ -6,7 +6,7 @@ import { get } from "lodash";
  * @param {import('postcss').Rule} node
  * @returns {boolean}
  */
-export default function(node) {
+export default function (node) {
   const prop = get(node, "raws.prop.raw", node.prop);
   const value = get(node, "raws.value.raw", node.value);
 

--- a/src/utils/isNativeCssFunction.js
+++ b/src/utils/isNativeCssFunction.js
@@ -78,7 +78,7 @@ const nativeCssFunctions = new Set([
   "translateZ",
   "translatez",
   "url",
-  "var"
+  "var",
 ]);
 
 /**

--- a/src/utils/isSingleLineString.js
+++ b/src/utils/isSingleLineString.js
@@ -5,6 +5,6 @@
  * @param {string} input
  * @return {boolean}
  */
-export default function(input) {
+export default function (input) {
   return !/[\n\r]/.test(input);
 }

--- a/src/utils/isStandardRule.js
+++ b/src/utils/isStandardRule.js
@@ -8,7 +8,7 @@ import isStandardSyntaxSelector from "./isStandardSelector";
  * @param {import('postcss').Rule} rule
  * @returns {boolean}
  */
-export default function(rule) {
+export default function (rule) {
   // Get full selector
   const selector = get(rule, "raws.selector.raw", rule.selector);
 

--- a/src/utils/isStandardSelector.js
+++ b/src/utils/isStandardSelector.js
@@ -6,7 +6,7 @@ import hasInterpolation from "./hasInterpolation";
  * @param {string} selector
  * @return {boolean} If `true`, the selector is standard
  */
-export default function(selector) {
+export default function (selector) {
   const standardSyntaxSelector = isStandardSyntaxSelector(selector);
 
   // SCSS placeholder selectors

--- a/src/utils/isStandardSyntaxProperty.js
+++ b/src/utils/isStandardSyntaxProperty.js
@@ -6,7 +6,7 @@ import hasInterpolation from "./hasInterpolation";
  * @param {string} property
  * @returns {boolean}
  */
-export default function(property) {
+export default function (property) {
   // SCSS var (e.g. $var: x), list (e.g. $list: (x)) or map (e.g. $map: (key:value))
   if (property.startsWith("$")) {
     return false;

--- a/src/utils/isStandardSyntaxSelector.js
+++ b/src/utils/isStandardSyntaxSelector.js
@@ -6,7 +6,7 @@ import hasInterpolation from "./hasInterpolation";
  * @param {string} selector
  * @returns {boolean}
  */
-export default function(selector) {
+export default function (selector) {
   // SCSS or Less interpolation
   if (hasInterpolation(selector)) {
     return false;

--- a/src/utils/isType.js
+++ b/src/utils/isType.js
@@ -5,6 +5,6 @@
  * @param  {string} type
  * @return {boolean}
  */
-export default function(node, type) {
+export default function (node, type) {
   return node && node.type === type;
 }

--- a/src/utils/isWhitespace.js
+++ b/src/utils/isWhitespace.js
@@ -4,6 +4,6 @@
  * @param {string} char - A single character
  * @return {boolean}
  */
-export default function(char) {
+export default function (char) {
   return [" ", "\n", "\t", "\r", "\f"].includes(char);
 }

--- a/src/utils/moduleNamespace.js
+++ b/src/utils/moduleNamespace.js
@@ -22,7 +22,7 @@
 export function moduleNamespace(root, module) {
   let moduleNamespace = getDefaultNamespace(module);
 
-  root.walkAtRules("use", rule => {
+  root.walkAtRules("use", (rule) => {
     const customNamespace = getCustomNamespace(module, rule);
 
     switch (customNamespace) {

--- a/src/utils/optionsHaveException.js
+++ b/src/utils/optionsHaveException.js
@@ -7,6 +7,6 @@
  * @param {string} exceptionName
  * @return {boolean}
  */
-export default function(options, exceptionName) {
+export default function (options, exceptionName) {
   return options && options.except && options.except.includes(exceptionName);
 }

--- a/src/utils/optionsHaveIgnored.js
+++ b/src/utils/optionsHaveIgnored.js
@@ -7,6 +7,6 @@
  * @param {string} ignoredName
  * @return {boolean}
  */
-export default function(options, ignoredName) {
+export default function (options, ignoredName) {
   return options && options.ignore && options.ignore.includes(ignoredName);
 }

--- a/src/utils/parseFunctionArguments.js
+++ b/src/utils/parseFunctionArguments.js
@@ -42,14 +42,14 @@ export function mapToKeyValue(nodes) {
     if (isNextNodeColon) {
       acc.push({
         key: valueParser.stringify(nodes[i]),
-        value: valueParser.stringify(nodes.slice(2))
+        value: valueParser.stringify(nodes.slice(2)),
       });
 
       return acc;
     }
 
     acc.push({
-      value: valueParser.stringify(nodes)
+      value: valueParser.stringify(nodes),
     });
 
     return acc;
@@ -65,7 +65,7 @@ export function parseFunctionArguments(value) {
     return [];
   }
 
-  return parsed.nodes.map(node =>
+  return parsed.nodes.map((node) =>
     groupByKeyValue(node.nodes).map(mapToKeyValue)
   )[0];
 }

--- a/src/utils/parseNestedPropRoot.js
+++ b/src/utils/parseNestedPropRoot.js
@@ -8,8 +8,8 @@ export default function parseNestedPropRoot(propString) {
     {
       mode: "normal",
       character: null,
-      isCalculationEnabled: true
-    }
+      isCalculationEnabled: true,
+    },
   ];
   const result = {};
   let lastModeIndex = 0;
@@ -25,7 +25,7 @@ export default function parseNestedPropRoot(propString) {
         modesEntered.push({
           mode: "string",
           isCalculationEnabled: false,
-          character
+          character,
         });
         lastModeIndex++;
       } else if (
@@ -42,7 +42,7 @@ export default function parseNestedPropRoot(propString) {
     if (character === "{") {
       modesEntered.push({
         mode: "interpolation",
-        isCalculationEnabled: true
+        isCalculationEnabled: true,
       });
       lastModeIndex++;
     } else if (character === "}") {
@@ -62,7 +62,7 @@ export default function parseNestedPropRoot(propString) {
       if (propValueStr.length) {
         const propValue = {
           before: /^(\s*)/.exec(propValueStr)[1],
-          value: propValueStr.trim()
+          value: propValueStr.trim(),
         };
 
         // It's a declaration if 1) there is a whitespace after :, or
@@ -81,7 +81,7 @@ export default function parseNestedPropRoot(propString) {
 
       result.propName = {
         after: /(\s*)$/.exec(propName)[1],
-        value: propName.trim()
+        value: propName.trim(),
       };
 
       return result;

--- a/src/utils/parseSelector.js
+++ b/src/utils/parseSelector.js
@@ -1,6 +1,6 @@
 import postCssSelectorParser from "postcss-selector-parser";
 
-export default function(selector, result, node, cb) {
+export default function (selector, result, node, cb) {
   try {
     return postCssSelectorParser(cb).processSync(selector);
   } catch (e) {

--- a/src/utils/rawNodeString.js
+++ b/src/utils/rawNodeString.js
@@ -4,7 +4,7 @@
  * @param {Node} node - Any PostCSS node
  * @return {string}
  */
-export default function(node) {
+export default function (node) {
   let result = "";
 
   if (node.raws.before) {

--- a/src/utils/sassValueParser/index.js
+++ b/src/utils/sassValueParser/index.js
@@ -21,7 +21,7 @@ export default function findOperators({
   string,
   globalIndex,
   isAfterColon,
-  callback
+  callback,
 }) {
   const mathOperators = ["+", "/", "-", "*", "%"];
   // A stack of modes activated for the current char: string, interpolation
@@ -30,8 +30,8 @@ export default function findOperators({
     {
       mode: "normal",
       isCalculationEnabled: true,
-      character: null
-    }
+      character: null,
+    },
   ];
   const result = [];
   let lastModeIndex = 0;
@@ -47,7 +47,7 @@ export default function findOperators({
         modesEntered.push({
           mode: "string",
           isCalculationEnabled: false,
-          character
+          character,
         });
         lastModeIndex++;
       } else if (
@@ -70,7 +70,7 @@ export default function findOperators({
     ) {
       modesEntered.push({
         mode: "interpolation",
-        isCalculationEnabled: true
+        isCalculationEnabled: true,
       });
       lastModeIndex++;
     } else if (character === "}") {
@@ -94,7 +94,7 @@ export default function findOperators({
         symbol: string[i],
         globalIndex,
         startIndex: i,
-        endIndex: i
+        endIndex: i,
       });
 
       if (callback) {
@@ -108,7 +108,7 @@ export default function findOperators({
         symbol: string[i],
         globalIndex,
         startIndex: i,
-        endIndex: i + 1
+        endIndex: i + 1,
       });
 
       if (callback) {

--- a/src/utils/whitespaceChecker.js
+++ b/src/utils/whitespaceChecker.js
@@ -30,7 +30,7 @@ import configurationError from "./configurationError";
  * @param {function} [messages.rejectedBeforeMultiLine]
  * @return {object} The checker, with its exposed checking functions
  */
-export default function(targetWhitespace, expectation, messages) {
+export default function (targetWhitespace, expectation, messages) {
   // Keep track of active arguments in order to avoid passing
   // too much stuff around, making signatures long and confusing.
   // This variable gets reset anytime a checking function is called.
@@ -68,7 +68,7 @@ export default function(targetWhitespace, expectation, messages) {
     errTarget,
     lineCheckStr,
     onlyOneChar = false,
-    allowIndentation = false
+    allowIndentation = false,
   }) {
     activeArgs = {
       source,
@@ -76,7 +76,7 @@ export default function(targetWhitespace, expectation, messages) {
       err,
       errTarget,
       onlyOneChar,
-      allowIndentation
+      allowIndentation,
     };
 
     switch (expectation) {
@@ -131,7 +131,7 @@ export default function(targetWhitespace, expectation, messages) {
     err,
     errTarget,
     lineCheckStr,
-    onlyOneChar = false
+    onlyOneChar = false,
   }) {
     activeArgs = { source, index, err, errTarget, onlyOneChar };
 
@@ -327,7 +327,7 @@ export default function(targetWhitespace, expectation, messages) {
     before,
     beforeAllowingIndentation,
     after,
-    afterOneOnly
+    afterOneOnly,
   };
 }
 


### PR DESCRIPTION
Related to https://github.com/stylelint-scss/stylelint-scss/pull/625: (prettier upgrade from 1.19.1 to 2.7.1.)

- Fixes prettier code style.
- Make reviewing PR easier without the prettier code style overhead in older code.
