### PR TITLE
Fix `at-each-key-value-single-line` end positions

### DIFF
--- a/src/rules/at-each-key-value-single-line/__tests__/index.js
+++ b/src/rules/at-each-key-value-single-line/__tests__/index.js
@@ -7,162 +7,162 @@ testRule({
 
   accept: [
     {
-      code: `
+      code: dedent`
         $font-weights: ("regular": 400, "medium": 500, "bold": 700);
         @each $key, $value in $font-weights {}
       `,
-      description: "Proper map loop that gets both keys + values"
+      description: "Proper map loop that gets both keys + values",
     },
     {
-      code: `
+      code: dedent`
         $font-weights: ("regular": 400, "medium": 500, "bold": 700);
         @each $key in map-keys($font-weights) {}
       `,
       description:
-        "Loop that just gets keys + has no need for values when using global function"
+        "Loop that just gets keys + has no need for values when using global function",
     },
     {
-      code: `
+      code: dedent`
         @use "sass:map";
         $font-weights: ("regular": 400, "medium": 500, "bold": 700);
         @each $key in map.keys($font-weights) {}
       `,
       description:
-        "Loop that just gets keys + has no need for values when loading sass module with default namespace"
+        "Loop that just gets keys + has no need for values when loading sass module with default namespace",
     },
     {
-      code: `
+      code: dedent`
         @use "sass:map";
         $font-weights: ("regular": 400, "medium": 500, "bold": 700);
         @each $key in map-keys($font-weights) {}
       `,
       description:
-        "Loop that just gets keys + has no need for values when loading sass module with default namespace but using global function"
+        "Loop that just gets keys + has no need for values when loading sass module with default namespace but using global function",
     },
     {
-      code: `
+      code: dedent`
         @use "sass:map" as *;
         $font-weights: ("regular": 400, "medium": 500, "bold": 700);
         @each $key in keys($font-weights) {}
       `,
       description:
-        "Loop that just gets keys + has no need for values when loading sass module with no namespace"
+        "Loop that just gets keys + has no need for values when loading sass module with no namespace",
     },
     {
-      code: `
+      code: dedent`
         @use "sass:map" as *;
         $font-weights: ("regular": 400, "medium": 500, "bold": 700);
         @each $key in map-keys($font-weights) {}
       `,
       description:
-        "Loop that just gets keys + has no need for values when loading sass module with no namespace but using global function"
+        "Loop that just gets keys + has no need for values when loading sass module with no namespace but using global function",
     },
     {
-      code: `
+      code: dedent`
         @use "sass:map" as ns;
         $font-weights: ("regular": 400, "medium": 500, "bold": 700);
         @each $key in ns.keys($font-weights) {}
       `,
       description:
-        "Loop that just gets keys + has no need for values when loading sass module with custom namespace"
+        "Loop that just gets keys + has no need for values when loading sass module with custom namespace",
     },
     {
-      code: `
+      code: dedent`
         @use "sass:map" as ns;
         $font-weights: ("regular": 400, "medium": 500, "bold": 700);
         @each $key in map-keys($font-weights) {}
       `,
       description:
-        "Loop that just gets keys + has no need for values when loading sass module with custom namespace but using global function"
+        "Loop that just gets keys + has no need for values when loading sass module with custom namespace but using global function",
     },
     {
-      code: `
+      code: dedent`
         $font-weights: ("regular": 400, "medium": 500, "bold": 700);
         $other-weights: ("regular": 400, "medium": 500, "bold": 700);
         @each $key, $value in map-keys($font-weights) {
-         $value: map-get($other-weights, $key);
+          $value: map-get($other-weights, $key);
         }
       `,
       description:
-        "map-get pattern used with different hash than loop when using global function"
+        "map-get pattern used with different hash than loop when using global function",
     },
     {
-      code: `
+      code: dedent`
         @use "sass:map";
         $font-weights: ("regular": 400, "medium": 500, "bold": 700);
         $other-weights: ("regular": 400, "medium": 500, "bold": 700);
         @each $key, $value in map.keys($font-weights) {
-         $value: map.get($other-weights, $key);
+          $value: map.get($other-weights, $key);
         }
       `,
       description:
-        "map.get pattern used with different hash than loop when loading sass module with default namespace"
+        "map.get pattern used with different hash than loop when loading sass module with default namespace",
     },
     {
-      code: `
+      code: dedent`
         @use "sass:map";
         $font-weights: ("regular": 400, "medium": 500, "bold": 700);
         $other-weights: ("regular": 400, "medium": 500, "bold": 700);
         @each $key, $value in map-keys($font-weights) {
-         $value: map-get($other-weights, $key);
+          $value: map-get($other-weights, $key);
         }
       `,
       description:
-        "map.get pattern used with different hash than loop when loading sass module with default namespace but using global function"
+        "map.get pattern used with different hash than loop when loading sass module with default namespace but using global function",
     },
     {
-      code: `
+      code: dedent`
         @use "sass:map" as *;
         $font-weights: ("regular": 400, "medium": 500, "bold": 700);
         $other-weights: ("regular": 400, "medium": 500, "bold": 700);
         @each $key, $value in keys($font-weights) {
-         $value: get($other-weights, $key);
+          $value: get($other-weights, $key);
         }
       `,
       description:
-        "map.get pattern used with different hash than loop when loading sass module with no namespace"
+        "map.get pattern used with different hash than loop when loading sass module with no namespace",
     },
     {
-      code: `
+      code: dedent`
         @use "sass:map" as *;
         $font-weights: ("regular": 400, "medium": 500, "bold": 700);
         $other-weights: ("regular": 400, "medium": 500, "bold": 700);
         @each $key, $value in map-keys($font-weights) {
-         $value: map-get($other-weights, $key);
+          $value: map-get($other-weights, $key);
         }
       `,
       description:
-        "map.get pattern used with different hash than loop when loading sass module with no namespace but using global function"
+        "map.get pattern used with different hash than loop when loading sass module with no namespace but using global function",
     },
     {
-      code: `
+      code: dedent`
         @use "sass:map" as ns;
         $font-weights: ("regular": 400, "medium": 500, "bold": 700);
         $other-weights: ("regular": 400, "medium": 500, "bold": 700);
         @each $key, $value in ns.keys($font-weights) {
-         $value: ns.get($other-weights, $key);
+          $value: ns.get($other-weights, $key);
         }
       `,
       description:
-        "map.get pattern used with different hash than loop when loading sass module with custom namespace"
+        "map.get pattern used with different hash than loop when loading sass module with custom namespace",
     },
     {
-      code: `
+      code: dedent`
         @use "sass:map" as ns;
         $font-weights: ("regular": 400, "medium": 500, "bold": 700);
         $other-weights: ("regular": 400, "medium": 500, "bold": 700);
         @each $key, $value in map-keys($font-weights) {
-         $value: map-get($other-weights, $key);
+          $value: map-get($other-weights, $key);
         }
       `,
       description:
-        "map.get pattern used with different hash than loop when loading sass module with custom namespace but using global function"
-    }
+        "map.get pattern used with different hash than loop when loading sass module with custom namespace but using global function",
+    },
   ],
 
   reject: [
     {
-      code: `
+      code: dedent`
         $font-weights: ("regular": 400, "medium": 500, "bold": 700);
         @each $key in map-keys($font-weights) {
           $value: map-get($font-weights, $key);
@@ -171,10 +171,13 @@ testRule({
       description:
         "Loop that gets keys + then grabs values inside the map when using global function",
       message: messages.expected,
-      line: 3
+      line: 2,
+      column: 7,
+      endLine: 2,
+      endColumn: 38,
     },
     {
-      code: `
+      code: dedent`
         @use "sass:map";
         $font-weights: ("regular": 400, "medium": 500, "bold": 700);
         @each $key in map.keys($font-weights) {
@@ -184,10 +187,13 @@ testRule({
       description:
         "Loop that gets keys + then grabs values inside the map when loading sass module with default namespace",
       message: messages.expected,
-      line: 4
+      line: 3,
+      column: 7,
+      endLine: 3,
+      endColumn: 38,
     },
     {
-      code: `
+      code: dedent`
         @use "sass:map";
         $font-weights: ("regular": 400, "medium": 500, "bold": 700);
         @each $key in map-keys($font-weights) {
@@ -197,10 +203,13 @@ testRule({
       description:
         "Loop that gets keys + then grabs values inside the map when loading sass module with default namespace but using global function",
       message: messages.expected,
-      line: 4
+      line: 3,
+      column: 7,
+      endLine: 3,
+      endColumn: 38,
     },
     {
-      code: `
+      code: dedent`
         @use "sass:map" as *;
         $font-weights: ("regular": 400, "medium": 500, "bold": 700);
         @each $key in keys($font-weights) {
@@ -210,10 +219,13 @@ testRule({
       description:
         "Loop that gets keys + then grabs values inside the map when loading sass module with no namespace",
       message: messages.expected,
-      line: 4
+      line: 3,
+      column: 7,
+      endLine: 3,
+      endColumn: 34,
     },
     {
-      code: `
+      code: dedent`
         @use "sass:map" as *;
         $font-weights: ("regular": 400, "medium": 500, "bold": 700);
         @each $key in map-keys($font-weights) {
@@ -223,10 +235,13 @@ testRule({
       description:
         "Loop that gets keys + then grabs values inside the map when loading sass module with no namespace but using global function",
       message: messages.expected,
-      line: 4
+      line: 3,
+      column: 7,
+      endLine: 3,
+      endColumn: 38,
     },
     {
-      code: `
+      code: dedent`
         @use "sass:map" as ns;
         $font-weights: ("regular": 400, "medium": 500, "bold": 700);
         @each $key in ns.keys($font-weights) {
@@ -236,10 +251,13 @@ testRule({
       description:
         "Loop that gets keys + then grabs values inside the map when loading sass module with custom namespace",
       message: messages.expected,
-      line: 4
+      line: 3,
+      column: 7,
+      endLine: 3,
+      endColumn: 37,
     },
     {
-      code: `
+      code: dedent`
         @use "sass:map" as ns;
         $font-weights: ("regular": 400, "medium": 500, "bold": 700);
         @each $key in map-keys($font-weights) {
@@ -249,7 +267,10 @@ testRule({
       description:
         "Loop that gets keys + then grabs values inside the map when loading sass module with custom namespace but using global function",
       message: messages.expected,
-      line: 4
-    }
-  ]
+      line: 3,
+      column: 7,
+      endLine: 3,
+      endColumn: 38,
+    },
+  ],
 });

--- a/src/rules/at-each-key-value-single-line/index.js
+++ b/src/rules/at-each-key-value-single-line/index.js
@@ -5,17 +5,17 @@ export const ruleName = namespace("at-each-key-value-single-line");
 
 export const messages = utils.ruleMessages(ruleName, {
   expected:
-    "Use @each $key, $value in $map syntax instead of $value: map-get($map, $key)"
+    "Use @each $key, $value in $map syntax instead of $value: map-get($map, $key)",
 });
 
 export const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
 };
 
 export default function rule(primary) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
-      actual: primary
+      actual: primary,
     });
 
     if (!validOptions) {
@@ -24,7 +24,7 @@ export default function rule(primary) {
 
     const mapNamespace = moduleNamespace(root, "sass:map");
 
-    root.walkAtRules("each", rule => {
+    root.walkAtRules("each", (rule) => {
       const parts = separateEachParams(rule.params);
 
       // If loop is fetching both key + value, return
@@ -38,7 +38,7 @@ export default function rule(primary) {
       }
 
       // Loop over decls inside of each statement and loop for variable assignments.
-      rule.walkDecls(innerDecl => {
+      rule.walkDecls((innerDecl) => {
         // Check that this decl is a map-get call
         if (innerDecl.prop[0] !== "$") {
           return;
@@ -65,7 +65,8 @@ export default function rule(primary) {
           message: messages.expected,
           node: rule,
           result,
-          ruleName
+          ruleName,
+          word: rule.params,
         });
       });
     });
@@ -81,7 +82,7 @@ rule.meta = meta;
 function separateEachParams(paramString) {
   const parts = paramString.split("in");
 
-  return [parts[0].split(",").map(s => s.trim()), parts[1].trim()];
+  return [parts[0].split(",").map((s) => s.trim()), parts[1].trim()];
 }
 
 function didCallMapKeys(mapDecl, mapNamespace) {


### PR DESCRIPTION
Part of #652

See the following example to be reported:

```scss
@each $key in map-keys($font-weights) {
/*    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 *    Use @each $key, $value in $map syntax instead of $value: map-get($map, $key)
 */
  $value: map-get($font-weights, $key);
}
```