### PR TITLE
Add Node.js 18 to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [14, 16]
+        node: [14, 16, 18]
         os: [ubuntu-latest, windows-latest]
 
     steps:


### PR DESCRIPTION
Node.js 18 will be LTS soon. See also the release schedule:
https://github.com/nodejs/release#release-schedule
