### PR TITLE
Add failing test for function-no-unknown with negative values

### DIFF
--- a/src/rules/function-no-unknown/__tests__/index.js
+++ b/src/rules/function-no-unknown/__tests__/index.js
@@ -1,41 +1,47 @@
-import { ruleName, messages } from "..";
+import { ruleName, messages } from '..';
 
 testRule({
   ruleName,
   config: [true],
-  customSyntax: "postcss-scss",
+  customSyntax: 'postcss-scss',
 
   accept: [
     {
-      code: "a { color: hwb(240 100% 50%); }",
-      description: "Normal CSS function"
+      code: 'a { color: hwb(240 100% 50%); }',
+      description: 'Normal CSS function'
     },
     {
-      code: "a { color: hsl(240 100% 50%); }",
-      description: "Function both in CSS and SCSS"
+      code: 'a { color: hsl(240 100% 50%); }',
+      description: 'Function both in CSS and SCSS'
     },
     {
-      code: "a { color: if(true, green, red); }",
-      description: "SCSS function"
+      code: 'a { color: if(true, green, red); }',
+      description: 'SCSS function'
     },
     {
-      code: "a { color: adjust-color(#6b717f, $red: 15); }"
+      code: 'a { color: adjust-color(#6b717f, $red: 15); }'
     },
     {
-      code: "a { color: color.adjust(#6b717f, $red: 15); }"
+      code: 'a { color: color.adjust(#6b717f, $red: 15); }'
+    },
+    {
+      code: 'a { margin: -#{math.div(10, 2)} }'
+    },
+    {
+      code: 'a { margin: -($value) }'
     }
   ],
 
   reject: [
     {
-      code: "a { color: unknown(1); }",
-      message: messages.rejected("unknown"),
+      code: 'a { color: unknown(1); }',
+      message: messages.rejected('unknown'),
       line: 1,
       column: 12
     },
     {
-      code: "a { color: color.unknown(#6b717f, $red: 15); }",
-      message: messages.rejected("color.unknown"),
+      code: 'a { color: color.unknown(#6b717f, $red: 15); }',
+      message: messages.rejected('color.unknown'),
       line: 1,
       column: 12
     }
@@ -44,40 +50,40 @@ testRule({
 
 testRule({
   ruleName,
-  config: [true, { ignoreFunctions: ["/^my-/i", /foo$/, "bar"] }],
-  customSyntax: "postcss-scss",
+  config: [true, { ignoreFunctions: ['/^my-/i', /foo$/, 'bar'] }],
+  customSyntax: 'postcss-scss',
 
   accept: [
     {
-      code: "a { color: my-func(1); }"
+      code: 'a { color: my-func(1); }'
     },
     {
-      code: "a { color: MY-FUNC(1); }"
+      code: 'a { color: MY-FUNC(1); }'
     },
     {
-      code: "a { color: func-foo(1); }"
+      code: 'a { color: func-foo(1); }'
     },
     {
-      code: "a { color: bar(1); }"
+      code: 'a { color: bar(1); }'
     }
   ],
 
   reject: [
     {
-      code: "a { color: my(1); }",
-      message: messages.rejected("my"),
+      code: 'a { color: my(1); }',
+      message: messages.rejected('my'),
       line: 1,
       column: 12
     },
     {
-      code: "a { color: foo-func(1); }",
-      message: messages.rejected("foo-func"),
+      code: 'a { color: foo-func(1); }',
+      message: messages.rejected('foo-func'),
       line: 1,
       column: 12
     },
     {
-      code: "a { color: barrr(1); }",
-      message: messages.rejected("barrr"),
+      code: 'a { color: barrr(1); }',
+      message: messages.rejected('barrr'),
       line: 1,
       column: 12
     }


### PR DESCRIPTION
stylelint-scss seems to be detecting `-` as a function name.

<hr>

Please note that my PR automatically swapped double quotes for single quotes with a pre-commit hook. I believe it ran prettier, but since there is no prettier config in this repo, it used my default config. Let me know what to do and I'll fix it up.