### PR TITLE
Use import-lazy for rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
+        "import-lazy": "^4.0.0",
         "postcss-media-query-parser": "^0.2.3",
         "postcss-resolve-nested-selector": "^0.1.1",
         "postcss-selector-parser": "^6.0.13",
@@ -4204,7 +4205,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
       "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -13831,8 +13831,7 @@
     "import-lazy": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
-      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
-      "dev": true
+      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw=="
     },
     "import-local": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "stylelint": "^14.5.1 || ^15.0.0"
   },
   "dependencies": {
+    "import-lazy": "^4.0.0",
     "postcss-media-query-parser": "^0.2.3",
     "postcss-resolve-nested-selector": "^0.1.1",
     "postcss-selector-parser": "^6.0.13",

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -1,65 +1,161 @@
 "use strict";
 
+const importLazy = require("import-lazy");
+
 const rules = {
-  "at-each-key-value-single-line": require("./at-each-key-value-single-line"),
-  "at-else-closing-brace-newline-after": require("./at-else-closing-brace-newline-after"),
-  "at-else-closing-brace-space-after": require("./at-else-closing-brace-space-after"),
-  "at-else-empty-line-before": require("./at-else-empty-line-before"),
-  "at-else-if-parentheses-space-before": require("./at-else-if-parentheses-space-before"),
-  "at-extend-no-missing-placeholder": require("./at-extend-no-missing-placeholder"),
-  "at-function-named-arguments": require("./at-function-named-arguments"),
-  "at-function-parentheses-space-before": require("./at-function-parentheses-space-before"),
-  "at-function-pattern": require("./at-function-pattern"),
-  "at-if-closing-brace-newline-after": require("./at-if-closing-brace-newline-after"),
-  "at-if-closing-brace-space-after": require("./at-if-closing-brace-space-after"),
-  "at-if-no-null": require("./at-if-no-null"),
-  "at-import-no-partial-leading-underscore": require("./at-import-no-partial-leading-underscore"),
-  "at-import-partial-extension-blacklist": require("./at-import-partial-extension-blacklist"),
-  "at-import-partial-extension-whitelist": require("./at-import-partial-extension-whitelist"),
-  "at-import-partial-extension": require("./at-import-partial-extension"),
-  "at-mixin-argumentless-call-parentheses": require("./at-mixin-argumentless-call-parentheses"),
-  "at-mixin-named-arguments": require("./at-mixin-named-arguments"),
-  "at-mixin-parentheses-space-before": require("./at-mixin-parentheses-space-before"),
-  "at-mixin-pattern": require("./at-mixin-pattern"),
-  "at-rule-conditional-no-parentheses": require("./at-rule-conditional-no-parentheses"),
-  "at-rule-no-unknown": require("./at-rule-no-unknown"),
-  "at-use-no-unnamespaced": require("./at-use-no-unnamespaced"),
-  "comment-no-empty": require("./comment-no-empty"),
-  "comment-no-loud": require("./comment-no-loud"),
-  "declaration-nested-properties-no-divided-groups": require("./declaration-nested-properties-no-divided-groups"),
-  "declaration-nested-properties": require("./declaration-nested-properties"),
-  "dimension-no-non-numeric-values": require("./dimension-no-non-numeric-values"),
-  "dollar-variable-colon-newline-after": require("./dollar-variable-colon-newline-after"),
-  "dollar-variable-colon-space-after": require("./dollar-variable-colon-space-after"),
-  "dollar-variable-colon-space-before": require("./dollar-variable-colon-space-before"),
-  "dollar-variable-default": require("./dollar-variable-default"),
-  "dollar-variable-empty-line-after": require("./dollar-variable-empty-line-after"),
-  "dollar-variable-empty-line-before": require("./dollar-variable-empty-line-before"),
-  "dollar-variable-first-in-block": require("./dollar-variable-first-in-block"),
-  "dollar-variable-no-missing-interpolation": require("./dollar-variable-no-missing-interpolation"),
-  "dollar-variable-no-namespaced-assignment": require("./dollar-variable-no-namespaced-assignment"),
-  "dollar-variable-pattern": require("./dollar-variable-pattern"),
-  "double-slash-comment-empty-line-before": require("./double-slash-comment-empty-line-before"),
-  "double-slash-comment-inline": require("./double-slash-comment-inline"),
-  "double-slash-comment-whitespace-inside": require("./double-slash-comment-whitespace-inside"),
-  "function-color-relative": require("./function-color-relative"),
-  "function-no-unknown": require("./function-no-unknown"),
-  "function-quote-no-quoted-strings-inside": require("./function-quote-no-quoted-strings-inside"),
-  "function-unquote-no-unquoted-strings-inside": require("./function-unquote-no-unquoted-strings-inside"),
-  "map-keys-quotes": require("./map-keys-quotes"),
-  "media-feature-value-dollar-variable": require("./media-feature-value-dollar-variable"),
-  "no-dollar-variables": require("./no-dollar-variables"),
-  "no-duplicate-dollar-variables": require("./no-duplicate-dollar-variables"),
-  "no-duplicate-mixins": require("./no-duplicate-mixins"),
-  "no-global-function-names": require("./no-global-function-names"),
-  "operator-no-newline-after": require("./operator-no-newline-after"),
-  "operator-no-newline-before": require("./operator-no-newline-before"),
-  "operator-no-unspaced": require("./operator-no-unspaced"),
-  "partial-no-import": require("./partial-no-import"),
-  "percent-placeholder-pattern": require("./percent-placeholder-pattern"),
-  "selector-nest-combinators": require("./selector-nest-combinators"),
-  "selector-no-redundant-nesting-selector": require("./selector-no-redundant-nesting-selector"),
-  "selector-no-union-class-name": require("./selector-no-union-class-name")
+  "at-each-key-value-single-line": importLazy(() =>
+    require("./at-each-key-value-single-line")
+  )(),
+  "at-else-closing-brace-newline-after": importLazy(() =>
+    require("./at-else-closing-brace-newline-after")
+  )(),
+  "at-else-closing-brace-space-after": importLazy(() =>
+    require("./at-else-closing-brace-space-after")
+  )(),
+  "at-else-empty-line-before": importLazy(() =>
+    require("./at-else-empty-line-before")
+  )(),
+  "at-else-if-parentheses-space-before": importLazy(() =>
+    require("./at-else-if-parentheses-space-before")
+  )(),
+  "at-extend-no-missing-placeholder": importLazy(() =>
+    require("./at-extend-no-missing-placeholder")
+  )(),
+  "at-function-named-arguments": importLazy(() =>
+    require("./at-function-named-arguments")
+  )(),
+  "at-function-parentheses-space-before": importLazy(() =>
+    require("./at-function-parentheses-space-before")
+  )(),
+  "at-function-pattern": importLazy(() => require("./at-function-pattern"))(),
+  "at-if-closing-brace-newline-after": importLazy(() =>
+    require("./at-if-closing-brace-newline-after")
+  )(),
+  "at-if-closing-brace-space-after": importLazy(() =>
+    require("./at-if-closing-brace-space-after")
+  )(),
+  "at-if-no-null": importLazy(() => require("./at-if-no-null"))(),
+  "at-import-no-partial-leading-underscore": importLazy(() =>
+    require("./at-import-no-partial-leading-underscore")
+  )(),
+  "at-import-partial-extension-blacklist": importLazy(() =>
+    require("./at-import-partial-extension-blacklist")
+  )(),
+  "at-import-partial-extension-whitelist": importLazy(() =>
+    require("./at-import-partial-extension-whitelist")
+  )(),
+  "at-import-partial-extension": importLazy(() =>
+    require("./at-import-partial-extension")
+  )(),
+  "at-mixin-argumentless-call-parentheses": importLazy(() =>
+    require("./at-mixin-argumentless-call-parentheses")
+  )(),
+  "at-mixin-named-arguments": importLazy(() =>
+    require("./at-mixin-named-arguments")
+  )(),
+  "at-mixin-parentheses-space-before": importLazy(() =>
+    require("./at-mixin-parentheses-space-before")
+  )(),
+  "at-mixin-pattern": importLazy(() => require("./at-mixin-pattern"))(),
+  "at-rule-conditional-no-parentheses": importLazy(() =>
+    require("./at-rule-conditional-no-parentheses")
+  )(),
+  "at-rule-no-unknown": importLazy(() => require("./at-rule-no-unknown"))(),
+  "at-use-no-unnamespaced": importLazy(() =>
+    require("./at-use-no-unnamespaced")
+  )(),
+  "comment-no-empty": importLazy(() => require("./comment-no-empty"))(),
+  "comment-no-loud": importLazy(() => require("./comment-no-loud"))(),
+  "declaration-nested-properties-no-divided-groups": importLazy(() =>
+    require("./declaration-nested-properties-no-divided-groups")
+  )(),
+  "declaration-nested-properties": importLazy(() =>
+    require("./declaration-nested-properties")
+  )(),
+  "dimension-no-non-numeric-values": importLazy(() =>
+    require("./dimension-no-non-numeric-values")
+  )(),
+  "dollar-variable-colon-newline-after": importLazy(() =>
+    require("./dollar-variable-colon-newline-after")
+  )(),
+  "dollar-variable-colon-space-after": importLazy(() =>
+    require("./dollar-variable-colon-space-after")
+  )(),
+  "dollar-variable-colon-space-before": importLazy(() =>
+    require("./dollar-variable-colon-space-before")
+  )(),
+  "dollar-variable-default": importLazy(() =>
+    require("./dollar-variable-default")
+  )(),
+  "dollar-variable-empty-line-after": importLazy(() =>
+    require("./dollar-variable-empty-line-after")
+  )(),
+  "dollar-variable-empty-line-before": importLazy(() =>
+    require("./dollar-variable-empty-line-before")
+  )(),
+  "dollar-variable-first-in-block": importLazy(() =>
+    require("./dollar-variable-first-in-block")
+  )(),
+  "dollar-variable-no-missing-interpolation": importLazy(() =>
+    require("./dollar-variable-no-missing-interpolation")
+  )(),
+  "dollar-variable-no-namespaced-assignment": importLazy(() =>
+    require("./dollar-variable-no-namespaced-assignment")
+  )(),
+  "dollar-variable-pattern": importLazy(() =>
+    require("./dollar-variable-pattern")
+  )(),
+  "double-slash-comment-empty-line-before": importLazy(() =>
+    require("./double-slash-comment-empty-line-before")
+  )(),
+  "double-slash-comment-inline": importLazy(() =>
+    require("./double-slash-comment-inline")
+  )(),
+  "double-slash-comment-whitespace-inside": importLazy(() =>
+    require("./double-slash-comment-whitespace-inside")
+  )(),
+  "function-color-relative": importLazy(() =>
+    require("./function-color-relative")
+  )(),
+  "function-no-unknown": importLazy(() => require("./function-no-unknown"))(),
+  "function-quote-no-quoted-strings-inside": importLazy(() =>
+    require("./function-quote-no-quoted-strings-inside")
+  )(),
+  "function-unquote-no-unquoted-strings-inside": importLazy(() =>
+    require("./function-unquote-no-unquoted-strings-inside")
+  )(),
+  "map-keys-quotes": importLazy(() => require("./map-keys-quotes"))(),
+  "media-feature-value-dollar-variable": importLazy(() =>
+    require("./media-feature-value-dollar-variable")
+  )(),
+  "no-dollar-variables": importLazy(() => require("./no-dollar-variables"))(),
+  "no-duplicate-dollar-variables": importLazy(() =>
+    require("./no-duplicate-dollar-variables")
+  )(),
+  "no-duplicate-mixins": importLazy(() => require("./no-duplicate-mixins"))(),
+  "no-global-function-names": importLazy(() =>
+    require("./no-global-function-names")
+  )(),
+  "operator-no-newline-after": importLazy(() =>
+    require("./operator-no-newline-after")
+  )(),
+  "operator-no-newline-before": importLazy(() =>
+    require("./operator-no-newline-before")
+  )(),
+  "operator-no-unspaced": importLazy(() => require("./operator-no-unspaced"))(),
+  "partial-no-import": importLazy(() => require("./partial-no-import"))(),
+  "percent-placeholder-pattern": importLazy(() =>
+    require("./percent-placeholder-pattern")
+  )(),
+  "selector-nest-combinators": importLazy(() =>
+    require("./selector-nest-combinators")
+  )(),
+  "selector-no-redundant-nesting-selector": importLazy(() =>
+    require("./selector-no-redundant-nesting-selector")
+  )(),
+  "selector-no-union-class-name": importLazy(() =>
+    require("./selector-no-union-class-name")
+  )()
 };
 
 module.exports = rules;


### PR DESCRIPTION
```
C:\Users\xmr\Desktop\stylelint-scss>git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.

C:\Users\xmr\Desktop\stylelint-scss>hyperfine "node load-time.js"
Benchmark 1: node load-time.js
  Time (mean ± σ):     174.5 ms ±   3.7 ms    [User: 0.8 ms, System: 2.5 ms]
  Range (min … max):   171.1 ms … 185.3 ms    17 runs

C:\Users\xmr\Desktop\stylelint-scss>git checkout -
Switched to branch 'xmr/import-lazy'

C:\Users\xmr\Desktop\stylelint-scss>hyperfine "node load-time.js"
Benchmark 1: node load-time.js
  Time (mean ± σ):     123.5 ms ±   5.9 ms    [User: 2.5 ms, System: 2.9 ms]
  Range (min … max):   116.4 ms … 140.6 ms    23 runs
```

load-time.js:

```js
"use strict";

console.log("Load time");
console.time("Module");

exports.m = require(".");

console.timeEnd("Module");
```

Approximately 28% faster load time on my machine.