### PR TITLE
Fix incorrect links to `function-no-unknown` on Stylelint website

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Please also see the [example configs](./docs/examples/) for special cases.
 ### Function
 
 - [`function-color-relative`](./src/rules/function-color-relative/README.md): Encourage the use of the [scale-color](https://sass-lang.com/documentation/modules/color#scale-color) function over regular color functions.
-- [`function-no-unknown`](./src/rules/function-no-unknown/README.md): Disallow unknown functions. Should be used **instead of** Stylelint's [function-no-unknown](https://stylelint.io/user-guide/rules/list/at-rule-no-unknown).
+- [`function-no-unknown`](./src/rules/function-no-unknown/README.md): Disallow unknown functions. Should be used **instead of** Stylelint's [function-no-unknown](https://stylelint.io/user-guide/rules/function-no-unknown).
 - [`function-quote-no-quoted-strings-inside`](./src/rules/function-quote-no-quoted-strings-inside/README.md): Disallow quoted strings inside the [quote function](https://sass-lang.com/documentation/modules/string#quote) (Autofixable).
 - [`function-unquote-no-unquoted-strings-inside`](./src/rules/function-unquote-no-unquoted-strings-inside/README.md): Disallow unquoted strings inside the [unquote function](https://sass-lang.com/documentation/modules/string#unquote) (Autofixable).
 

--- a/src/rules/function-no-unknown/README.md
+++ b/src/rules/function-no-unknown/README.md
@@ -1,6 +1,6 @@
 # function-no-unknown
 
-Disallow unknown functions. Should be used **instead of** Stylelint's [function-no-unknown](https://stylelint.io/user-guide/rules/list/at-rule-no-unknown).
+Disallow unknown functions. Should be used **instead of** Stylelint's [function-no-unknown](https://stylelint.io/user-guide/rules/function-no-unknown).
 
 ```css
 a { color: unknown(1); }


### PR DESCRIPTION
This PR fixes just Markdown documents.
