### PR TITLE
Add `stylelintType: "parseError"` when `parseSelector` fails

### DIFF
--- a/src/utils/parseSelector.js
+++ b/src/utils/parseSelector.js
@@ -6,6 +6,6 @@ module.exports = function (selector, result, node, cb) {
   try {
     return postCssSelectorParser(cb).processSync(selector);
   } catch (e) {
-    result.warn("Cannot parse selector", { node });
+    result.warn("Cannot parse selector", { node, stylelintType: "parseError" });
   }
 };


### PR DESCRIPTION
Without this, I believe parse errors are being treated as warnings by `stylelint`. Updating this to match e.g. the [`parseSelector`](https://github.com/stylelint/stylelint/blob/74425d19a58449471498a83da519346290defee5/lib/utils/parseSelector.js#L16) function in `stylelint` causes them to be treated as errors.

## To reproduce

- `git clone git@github.com:wlewis-formative/stylelint-scss-min-repro.git`
- Run `npm lint`
- Run `echo $?`

The exit code is `0`, even though errors were reported:

```shell
$ npm run lint

> stylelint-scss-min-repro@0.0.1 lint
> stylelint Bad.tsx


Bad.tsx
 4:3  ✖  Cannot parse selector

1 problem (1 error, 0 warnings)

$ echo $?
0
```

This issue occurs because `postcss-styled-syntax` is parsing inline comments as selectors instead of reporting an error. The error is only discovered later (here).