### PR TITLE
Check selector list for parent selectors in `at-root-no-redundant`

### DIFF
--- a/src/rules/at-root-no-redundant/__tests__/index.js
+++ b/src/rules/at-root-no-redundant/__tests__/index.js
@@ -74,6 +74,12 @@ testRule({
       `,
       description:
         "@at-root is followed by a nested selector containing`&` outside interpolation."
+    },
+    {
+      code: `
+      .a { @at-root c &, .a#{&}.b { c: d } }
+      `,
+      description: "selector list, contains interpolation"
     }
   ],
   reject: [
@@ -158,6 +164,15 @@ testRule({
       message: messages.rejected,
       description:
         "@at-root is followed by selectors all containing `&` outside interpolation."
+    },
+    {
+      code: `
+      .a { @at-root .a & .b, .c & { c: d } }
+      `,
+      line: 2,
+      column: 12,
+      message: messages.rejected,
+      description: "selector list, all redundant"
     }
   ]
 });

--- a/src/rules/at-root-no-redundant/index.js
+++ b/src/rules/at-root-no-redundant/index.js
@@ -39,9 +39,8 @@ function rule(actual, _, context) {
       if (
         node.parent.type === "root" ||
         node.params
-          .replace(/#{.*}/g, "")
           .split(",")
-          .every(param => param.includes("&")) ||
+          .every(elem => elem.replace(/#{.*}/g, "").includes("&")) ||
         isWithinKeyframes(node)
       ) {
         if (context.fix) {


### PR DESCRIPTION
Fix false positive of redundant `@at-root` in selector list. 
This example is identified as redundant, even though @at-root is useful for the second selector `.a#{&}b `.
```
@at-root .c &,
  .a#{&}b {
     color: black;
}
```
Here's a [SCSS demo](https://sass-lang.com/playground/#eJwzNNRLrUjMLchJVajmUlBwSCzRLcrPL1HQS1SuVqvVS9IBCuolK6gp6KWAFYBAcn5OfpGVQlJOYnK2NVCsFoiJUV6aClFdCwAwQx5O) with examples.