### PR TITLE
Fix compatibility with Stylelint 16.0.0

### DIFF
--- a/src/rules/at-rule-no-unknown/index.js
+++ b/src/rules/at-rule-no-unknown/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { rules, utils } = require("stylelint");
+const { utils } = require("stylelint");
 const { isRegExp, isString } = require("../../utils/validateTypes");
 const namespace = require("../../utils/namespace");
 const ruleUrl = require("../../utils/ruleUrl");
@@ -33,11 +33,7 @@ const ruleToCheckAgainst = "at-rule-no-unknown";
 const ruleName = namespace(ruleToCheckAgainst);
 
 const messages = utils.ruleMessages(ruleName, {
-  rejected: (...args) => {
-    return rules[ruleToCheckAgainst].messages
-      .rejected(...args)
-      .replace(` (${ruleToCheckAgainst})`, "");
-  }
+  rejected: atRule => `Unexpected unknown at-rule "${atRule}"`
 });
 
 const meta = {

--- a/src/rules/comment-no-empty/index.js
+++ b/src/rules/comment-no-empty/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const { rules, utils } = require("stylelint");
+const { utils } = require("stylelint");
 const namespace = require("../../utils/namespace");
 const ruleUrl = require("../../utils/ruleUrl");
 
@@ -9,10 +9,7 @@ const coreRuleName = "comment-no-empty";
 const ruleName = namespace(coreRuleName);
 
 const messages = utils.ruleMessages(ruleName, {
-  rejected: rules[coreRuleName].messages.rejected.replace(
-    ` (${coreRuleName})`,
-    ""
-  )
+  rejected: "Unexpected empty comment"
 });
 
 const meta = {

--- a/src/rules/function-no-unknown/index.js
+++ b/src/rules/function-no-unknown/index.js
@@ -1,7 +1,7 @@
 "use strict";
 
 const valueParser = require("postcss-value-parser");
-const { rules, utils } = require("stylelint");
+const { utils } = require("stylelint");
 const { ALL_FUNCTIONS } = require("../../utils/functions");
 const namespace = require("../../utils/namespace");
 const { isRegExp, isString } = require("../../utils/validateTypes");
@@ -12,11 +12,7 @@ const ruleToCheckAgainst = "function-no-unknown";
 const ruleName = namespace(ruleToCheckAgainst);
 
 const messages = utils.ruleMessages(ruleName, {
-  rejected: (...args) => {
-    return rules[ruleToCheckAgainst].messages
-      .rejected(...args)
-      .replace(` (${ruleToCheckAgainst})`, "");
-  }
+  rejected: name => `Unexpected unknown function "${name}"`
 });
 
 const meta = {


### PR DESCRIPTION
Since Stylelint 16.0.0, the `stylelint.rules` object has `Promise` values. See the [migration guide](https://stylelint.io/migration-guide/to-16#changed-nodejs-api-stylelintrules-object).

Currently, this breaking change causes a `TypeError` in `stylelint-scss` because a few rules depend on `stylelint.rules` to construct rule messages.

This Pull Request removes the dependency to avoid the error.

To confirm compatibility with Stylelint 16.0.0, run:

```shell
# Update Stylelint
npm i 'stylelint@latest'

# Run tests
NODE_OPTIONS=--experimental-vm-modules npm t
```

Ref #895

---

Another way to check the changed rules' messages:

`.stylelintrc.json`:

```json
{
  "customSyntax": "postcss-scss",
  "plugins": ["./src/index.js"],
  "rules": {
    "scss/at-rule-no-unknown": true,
    "scss/comment-no-empty": true,
    "scss/function-no-unknown": true
  }
}
```

Run:

```sh-session
$ echo '@foo { color: foo(1); } //' | npx stylelint

<input css SkIaYT>
 1:1   ✖  Unexpected unknown at-rule "@foo"  scss/at-rule-no-unknown
 1:15  ✖  Unexpected unknown function "foo"  scss/function-no-unknown
 1:25  ✖  Unexpected empty comment           scss/comment-no-empty

3 problems (3 errors, 0 warnings)
```