### PR TITLE
Fix `at-mixin-argumentless-call-parentheses` end positions

### DIFF
--- a/src/rules/at-mixin-argumentless-call-parentheses/__tests__/index.js
+++ b/src/rules/at-mixin-argumentless-call-parentheses/__tests__/index.js
@@ -38,6 +38,9 @@ testRule({
       @include foo ;
     `,
       line: 2,
+      column: 16,
+      endLine: 2,
+      endColumn: 19,
       message: messages.rejected("foo"),
       description: "With parens, no space between them."
     },
@@ -121,6 +124,9 @@ testRule({
       @include foo ();
     `,
       line: 2,
+      column: 16,
+      endLine: 2,
+      endColumn: 19,
       message: messages.expected("foo"),
       description: "No parens."
     },

--- a/src/rules/at-mixin-argumentless-call-parentheses/index.js
+++ b/src/rules/at-mixin-argumentless-call-parentheses/index.js
@@ -55,7 +55,8 @@ function rule(value, _, context) {
           messages[value === "never" ? "rejected" : "expected"](mixinName),
         node: mixinCall,
         result,
-        ruleName
+        ruleName,
+        word: mixinName
       });
     });
   };


### PR DESCRIPTION
Part of #652
