### PR TITLE
Fix `double-slash-comment-inline` end positions

### DIFF
--- a/src/rules/double-slash-comment-inline/__tests__/index.js
+++ b/src/rules/double-slash-comment-inline/__tests__/index.js
@@ -50,7 +50,9 @@ testRule({
       description: "Non-inline comment (after a ruleset)",
       message: messages.expected,
       line: 3,
-      column: 7
+      column: 7,
+      endLine: 3,
+      endColumn: 46
     },
     {
       code: `
@@ -61,7 +63,9 @@ testRule({
       description: "Non-inline comment between selectors.",
       message: messages.expected,
       line: 3,
-      column: 7
+      column: 7,
+      endLine: 3,
+      endColumn: 46
     },
     {
       code: `
@@ -73,7 +77,9 @@ testRule({
       description: "Non-inline comment (before a decl)",
       message: messages.expected,
       line: 3,
-      column: 9
+      column: 9,
+      endLine: 3,
+      endColumn: 46
     }
   ]
 });
@@ -189,7 +195,9 @@ testRule({
       message: messages.rejected,
       description: "Inline comment, inside a ruleset.",
       line: 3,
-      column: 34
+      column: 34,
+      endLine: 3,
+      endColumn: 70
     },
     {
       code: `
@@ -201,7 +209,9 @@ testRule({
       message: messages.rejected,
       description: "Inline comment, between selectors.",
       line: 2,
-      column: 10
+      column: 10,
+      endLine: 2,
+      endColumn: 47
     }
   ]
 });

--- a/src/rules/double-slash-comment-inline/index.js
+++ b/src/rules/double-slash-comment-inline/index.js
@@ -82,6 +82,7 @@ function rule(expectation, options) {
           message,
           node: root,
           index: comment.source.start,
+          endIndex: comment.source.end + 1,
           result,
           ruleName
         });


### PR DESCRIPTION
Part of #652
