### PR TITLE
Fix `operator-no-newline-after` end positions

### DIFF
--- a/src/rules/operator-no-newline-after/__tests__/index.js
+++ b/src/rules/operator-no-newline-after/__tests__/index.js
@@ -73,7 +73,9 @@ testRule({
       description: "Newline-operator-indentation: 10px +\\n1px.",
       message: messages.rejected("+"),
       line: 3,
-      column: 21
+      column: 21,
+      endLine: 3,
+      endColumn: 22
     },
     {
       code: `

--- a/src/rules/operator-no-newline-after/index.js
+++ b/src/rules/operator-no-newline-after/index.js
@@ -43,12 +43,14 @@ function checkNewlineBefore({
   }
 
   if (newLineBefore) {
+    const index = globalIndex + startIndex;
     utils.report({
       ruleName,
       result,
       node,
       message: messages.rejected(symbol),
-      index: endIndex + globalIndex
+      index,
+      endIndex: index + symbol.length
     });
   }
 }


### PR DESCRIPTION
Part of #652
