### PR TITLE
Fix `operator-no-newline-before` end positions

### DIFF
--- a/src/rules/operator-no-newline-before/__tests__/index.js
+++ b/src/rules/operator-no-newline-before/__tests__/index.js
@@ -81,7 +81,9 @@ testRule({
       description: "Newline-indentation-operator: 10px\\n        + 1.",
       message: messages.rejected("+"),
       line: 4,
-      column: 9
+      column: 9,
+      endLine: 4,
+      endColumn: 10
     },
     {
       code: `

--- a/src/rules/operator-no-newline-before/index.js
+++ b/src/rules/operator-no-newline-before/index.js
@@ -43,12 +43,14 @@ function checkNewlineBefore({
   }
 
   if (newLineBefore) {
+    const index = globalIndex + startIndex;
     utils.report({
       ruleName,
       result,
       node,
       message: messages.rejected(symbol),
-      index: endIndex + globalIndex
+      index,
+      endIndex: index + symbol.length
     });
   }
 }


### PR DESCRIPTION
Part of #652
