### PR TITLE
Fix `at-function-named-arguments` end positions

### DIFF
--- a/src/rules/at-function-named-arguments/__tests__/index.js
+++ b/src/rules/at-function-named-arguments/__tests__/index.js
@@ -188,7 +188,9 @@ testRule({
       }
     `,
       line: 3,
-      column: 9,
+      column: 23,
+      endLine: 3,
+      endColumn: 27,
       message: messages.expected,
       description: "Always. Example: single argument that is not named."
     },
@@ -201,12 +203,16 @@ testRule({
       warnings: [
         {
           line: 3,
-          column: 9,
+          column: 23,
+          endLine: 3,
+          endColumn: 27,
           message: messages.expected
         },
         {
           line: 3,
-          column: 9,
+          column: 29,
+          endLine: 3,
+          endColumn: 33,
           message: messages.expected
         }
       ],
@@ -223,13 +229,17 @@ testRule({
     `,
       warnings: [
         {
-          line: 3,
-          column: 9,
+          line: 4,
+          column: 11,
+          endLine: 4,
+          endColumn: 15,
           message: messages.expected
         },
         {
-          line: 3,
-          column: 9,
+          line: 5,
+          column: 11,
+          endLine: 5,
+          endColumn: 15,
           message: messages.expected
         }
       ],
@@ -243,7 +253,9 @@ testRule({
       }
     `,
       line: 3,
-      column: 9,
+      column: 23,
+      endLine: 3,
+      endColumn: 32,
       message: messages.expected,
       description:
         "Always. Example: single argument is a variable but is not named."
@@ -255,7 +267,9 @@ testRule({
       }
     `,
       line: 3,
-      column: 9,
+      column: 23,
+      endLine: 3,
+      endColumn: 32,
       message: messages.expected,
       description:
         "Always. Example: single argument is a calculated value but is not named."
@@ -269,12 +283,16 @@ testRule({
       warnings: [
         {
           line: 3,
-          column: 9,
+          column: 37,
+          endLine: 3,
+          endColumn: 41,
           message: messages.expected
         },
         {
           line: 3,
-          column: 9,
+          column: 43,
+          endLine: 3,
+          endColumn: 50,
           message: messages.expected
         }
       ],
@@ -290,12 +308,16 @@ testRule({
       warnings: [
         {
           line: 3,
-          column: 9,
+          column: 23,
+          endLine: 3,
+          endColumn: 27,
           message: messages.expected
         },
         {
           line: 3,
-          column: 9,
+          column: 43,
+          endLine: 3,
+          endColumn: 50,
           message: messages.expected
         }
       ],
@@ -308,7 +330,9 @@ testRule({
       }
       `,
       line: 3,
-      column: 9,
+      column: 32,
+      endLine: 3,
+      endColumn: 74,
       message: messages.expected,
       description:
         "Always. Example: native CSS function inside a function call."
@@ -325,18 +349,24 @@ testRule({
       `,
       warnings: [
         {
-          line: 4,
-          column: 7,
+          line: 5,
+          column: 18,
+          endLine: 5,
+          endColumn: 24,
           message: messages.expected
         },
         {
-          line: 4,
-          column: 7,
+          line: 6,
+          column: 20,
+          endLine: 6,
+          endColumn: 26,
           message: messages.expected
         },
         {
-          line: 4,
-          column: 7,
+          line: 7,
+          column: 19,
+          endLine: 7,
+          endColumn: 25,
           message: messages.expected
         }
       ],
@@ -481,7 +511,9 @@ testRule({
       }
       `,
       line: 3,
-      column: 9,
+      column: 23,
+      endLine: 3,
+      endColumn: 35,
       message: messages.rejected,
       description: "Never. Example: single argument is named."
     },
@@ -492,7 +524,9 @@ testRule({
       }
       `,
       line: 3,
-      column: 9,
+      column: 23,
+      endLine: 3,
+      endColumn: 43,
       message: messages.rejected,
       description: "Never. Example: single argument is a variable."
     },
@@ -503,7 +537,9 @@ testRule({
       }
       `,
       line: 3,
-      column: 9,
+      column: 23,
+      endLine: 3,
+      endColumn: 46,
       message: messages.rejected,
       description: "Never. Example: single argument is an interpolated value."
     },
@@ -514,7 +550,9 @@ testRule({
       }
       `,
       line: 3,
-      column: 9,
+      column: 25,
+      endLine: 3,
+      endColumn: 45,
       message: messages.rejected,
       description: "Never. Example: single argument is a calculated value."
     },
@@ -525,7 +563,9 @@ testRule({
       }
       `,
       line: 3,
-      column: 9,
+      column: 23,
+      endLine: 3,
+      endColumn: 38,
       message: messages.rejected,
       description: "Never. Example: single argument is a quoted string."
     },
@@ -536,7 +576,9 @@ testRule({
       }
       `,
       line: 3,
-      column: 9,
+      column: 25,
+      endLine: 3,
+      endColumn: 45,
       message: messages.rejected,
       description: "Never. Example: single argument is an unquoted string."
     },
@@ -549,17 +591,23 @@ testRule({
       warnings: [
         {
           line: 3,
-          column: 9,
+          column: 23,
+          endLine: 3,
+          endColumn: 35,
           message: messages.rejected
         },
         {
           line: 3,
-          column: 9,
+          column: 37,
+          endLine: 3,
+          endColumn: 56,
           message: messages.rejected
         },
         {
           line: 3,
-          column: 9,
+          column: 58,
+          endLine: 3,
+          endColumn: 73,
           message: messages.rejected
         }
       ],
@@ -577,18 +625,24 @@ testRule({
       `,
       warnings: [
         {
-          line: 3,
-          column: 9,
+          line: 4,
+          column: 11,
+          endLine: 4,
+          endColumn: 23,
           message: messages.rejected
         },
         {
-          line: 3,
-          column: 9,
+          line: 5,
+          column: 11,
+          endLine: 5,
+          endColumn: 30,
           message: messages.rejected
         },
         {
-          line: 3,
-          column: 9,
+          line: 6,
+          column: 11,
+          endLine: 6,
+          endColumn: 26,
           message: messages.rejected
         }
       ],
@@ -602,7 +656,9 @@ testRule({
       }
     `,
       line: 3,
-      column: 9,
+      column: 23,
+      endLine: 3,
+      endColumn: 35,
       message: messages.rejected,
       description:
         "Never. Example: first argument is named but remaining are not."
@@ -614,7 +670,9 @@ testRule({
       }
     `,
       line: 3,
-      column: 9,
+      column: 29,
+      endLine: 3,
+      endColumn: 41,
       message: messages.rejected,
       description: "Never. Example: mixed named arguments."
     },
@@ -625,7 +683,9 @@ testRule({
       }
       `,
       line: 3,
-      column: 9,
+      column: 32,
+      endLine: 3,
+      endColumn: 82,
       message: messages.rejected,
       description: "Never. Example: native CSS function inside a function call."
     },
@@ -641,18 +701,24 @@ testRule({
       `,
       warnings: [
         {
-          line: 4,
-          column: 7,
+          line: 5,
+          column: 18,
+          endLine: 5,
+          endColumn: 30,
           message: messages.rejected
         },
         {
-          line: 4,
-          column: 7,
+          line: 6,
+          column: 20,
+          endLine: 6,
+          endColumn: 34,
           message: messages.rejected
         },
         {
-          line: 4,
-          column: 7,
+          line: 7,
+          column: 19,
+          endLine: 7,
+          endColumn: 33,
           message: messages.rejected
         }
       ],
@@ -809,8 +875,10 @@ testRule({
         );
       }
     `,
-      line: 3,
-      column: 9,
+      line: 5,
+      column: 11,
+      endLine: 5,
+      endColumn: 15,
       message: messages.expected,
       description:
         "Always and ignore single argument. Example: first argument is named but remaining are not in multiline function call."
@@ -824,12 +892,16 @@ testRule({
       warnings: [
         {
           line: 3,
-          column: 9,
+          column: 23,
+          endLine: 3,
+          endColumn: 27,
           message: messages.expected
         },
         {
           line: 3,
-          column: 9,
+          column: 43,
+          endLine: 3,
+          endColumn: 50,
           message: messages.expected
         }
       ],
@@ -845,12 +917,16 @@ testRule({
       warnings: [
         {
           line: 3,
-          column: 9,
+          column: 37,
+          endLine: 3,
+          endColumn: 41,
           message: messages.expected
         },
         {
           line: 3,
-          column: 9,
+          column: 43,
+          endLine: 3,
+          endColumn: 50,
           message: messages.expected
         }
       ],
@@ -866,12 +942,16 @@ testRule({
       warnings: [
         {
           line: 3,
-          column: 9,
+          column: 23,
+          endLine: 3,
+          endColumn: 27,
           message: messages.expected
         },
         {
           line: 3,
-          column: 9,
+          column: 43,
+          endLine: 3,
+          endColumn: 50,
           message: messages.expected
         }
       ],
@@ -1055,17 +1135,23 @@ testRule({
       warnings: [
         {
           line: 3,
-          column: 9,
+          column: 23,
+          endLine: 3,
+          endColumn: 35,
           message: messages.rejected
         },
         {
           line: 3,
-          column: 9,
+          column: 37,
+          endLine: 3,
+          endColumn: 56,
           message: messages.rejected
         },
         {
           line: 3,
-          column: 9,
+          column: 58,
+          endLine: 3,
+          endColumn: 73,
           message: messages.rejected
         }
       ],
@@ -1084,18 +1170,24 @@ testRule({
       `,
       warnings: [
         {
-          line: 3,
-          column: 9,
+          line: 4,
+          column: 11,
+          endLine: 4,
+          endColumn: 23,
           message: messages.rejected
         },
         {
-          line: 3,
-          column: 9,
+          line: 5,
+          column: 11,
+          endLine: 5,
+          endColumn: 30,
           message: messages.rejected
         },
         {
-          line: 3,
-          column: 9,
+          line: 6,
+          column: 11,
+          endLine: 6,
+          endColumn: 26,
           message: messages.rejected
         }
       ],
@@ -1109,7 +1201,9 @@ testRule({
       }
     `,
       line: 3,
-      column: 9,
+      column: 23,
+      endLine: 3,
+      endColumn: 35,
       message: messages.rejected,
       description:
         "Never and ignore single argument. Example: first argument is named but remaining are not."
@@ -1121,7 +1215,9 @@ testRule({
       }
     `,
       line: 3,
-      column: 9,
+      column: 29,
+      endLine: 3,
+      endColumn: 41,
       message: messages.rejected,
       description:
         "Never and ignore single argument. Example: mixed named arguments."
@@ -1186,7 +1282,9 @@ testRule({
       }
     `,
       line: 3,
-      column: 9,
+      column: 23,
+      endLine: 3,
+      endColumn: 27,
       message: messages.expected,
       description:
         "Always and ignore function. Example: single argument that is not named."
@@ -1200,12 +1298,16 @@ testRule({
       warnings: [
         {
           line: 3,
-          column: 9,
+          column: 25,
+          endLine: 3,
+          endColumn: 29,
           message: messages.expected
         },
         {
           line: 3,
-          column: 9,
+          column: 31,
+          endLine: 3,
+          endColumn: 34,
           message: messages.expected
         }
       ],
@@ -1221,12 +1323,16 @@ testRule({
       warnings: [
         {
           line: 3,
-          column: 9,
+          column: 27,
+          endLine: 3,
+          endColumn: 31,
           message: messages.expected
         },
         {
           line: 3,
-          column: 9,
+          column: 33,
+          endLine: 3,
+          endColumn: 36,
           message: messages.expected
         }
       ],
@@ -1292,7 +1398,9 @@ testRule({
       }
       `,
       line: 3,
-      column: 9,
+      column: 23,
+      endLine: 3,
+      endColumn: 35,
       message: messages.rejected,
       description: "Never. Example: single argument is named."
     }

--- a/src/utils/__tests__/parseFunctionArguments.js
+++ b/src/utils/__tests__/parseFunctionArguments.js
@@ -155,10 +155,10 @@ describe("mapToKeyValue", () => {
         { after: " ", before: "", sourceIndex: 12, type: "div", value: ":" },
         { sourceIndex: 14, type: "word", value: "40px" }
       ])
-    ).toEqual({ key: "$value", value: "40px" });
+    ).toEqual({ key: "$value", value: "40px", index: 6 });
     expect(
       mapToKeyValue([{ sourceIndex: 20, type: "word", value: "10px" }])
-    ).toEqual({ value: "10px" });
+    ).toEqual({ value: "10px", index: 20 });
   });
 });
 
@@ -178,7 +178,9 @@ describe("parseFunctionArguments", () => {
   it("parses number as the value", () => {
     expect(parseFunctionArguments("func(1)")).toEqual([
       {
-        value: "1"
+        value: "1",
+        index: 5,
+        endIndex: 6
       }
     ]);
   });
@@ -186,7 +188,9 @@ describe("parseFunctionArguments", () => {
   it("parses calculation as the value", () => {
     expect(parseFunctionArguments("func(30 * 25ms)")).toEqual([
       {
-        value: "30 * 25ms"
+        value: "30 * 25ms",
+        index: 5,
+        endIndex: 14
       }
     ]);
   });
@@ -194,10 +198,14 @@ describe("parseFunctionArguments", () => {
   it("parses multiple args", () => {
     expect(parseFunctionArguments("func(1, 2)")).toEqual([
       {
-        value: "1"
+        value: "1",
+        index: 5,
+        endIndex: 6
       },
       {
-        value: "2"
+        value: "2",
+        index: 8,
+        endIndex: 9
       }
     ]);
   });
@@ -205,10 +213,14 @@ describe("parseFunctionArguments", () => {
   it("parses trailing commas", () => {
     expect(parseFunctionArguments("func(1, 2,)")).toEqual([
       {
-        value: "1"
+        value: "1",
+        index: 5,
+        endIndex: 6
       },
       {
-        value: "2"
+        value: "2",
+        index: 8,
+        endIndex: 9
       }
     ]);
   });
@@ -217,7 +229,9 @@ describe("parseFunctionArguments", () => {
     expect(parseFunctionArguments("func($var: 1)")).toEqual([
       {
         key: "$var",
-        value: "1"
+        value: "1",
+        index: 5,
+        endIndex: 12
       }
     ]);
   });
@@ -230,7 +244,9 @@ describe("parseFunctionArguments", () => {
     ).toEqual([
       {
         key: "$foo",
-        value: 'url("data:image/svg+xml;charset=utf8,%3C")'
+        value: 'url("data:image/svg+xml;charset=utf8,%3C")',
+        index: 5,
+        endIndex: 53
       }
     ]);
   });
@@ -239,7 +255,9 @@ describe("parseFunctionArguments", () => {
     expect(parseFunctionArguments("reset($value: #{$other-value})")).toEqual([
       {
         key: "$value",
-        value: "#{$other-value}"
+        value: "#{$other-value}",
+        index: 6,
+        endIndex: 29
       }
     ]);
   });
@@ -248,7 +266,9 @@ describe("parseFunctionArguments", () => {
     expect(parseFunctionArguments("anim($duration: 30 * 25ms)")).toEqual([
       {
         key: "$duration",
-        value: "30 * 25ms"
+        value: "30 * 25ms",
+        index: 5,
+        endIndex: 25
       }
     ]);
   });
@@ -257,11 +277,15 @@ describe("parseFunctionArguments", () => {
     expect(parseFunctionArguments("func($var: 1, $foo: bar)")).toEqual([
       {
         key: "$var",
-        value: "1"
+        value: "1",
+        index: 5,
+        endIndex: 12
       },
       {
         key: `$foo`,
-        value: "bar"
+        value: "bar",
+        index: 14,
+        endIndex: 23
       }
     ]);
   });
@@ -274,15 +298,21 @@ describe("parseFunctionArguments", () => {
     ).toEqual([
       {
         key: "$value",
-        value: "40px"
+        value: "40px",
+        index: 6,
+        endIndex: 18
       },
       {
         key: "$second-value",
-        value: "10px"
+        value: "10px",
+        index: 20,
+        endIndex: 39
       },
       {
         key: "$color",
-        value: "'black'"
+        value: "'black'",
+        index: 41,
+        endIndex: 56
       }
     ]);
   });
@@ -294,19 +324,29 @@ describe("parseFunctionArguments", () => {
       )
     ).toEqual([
       {
-        value: "to left"
+        value: "to left",
+        index: 16,
+        endIndex: 23
       },
       {
-        value: "#333"
+        value: "#333",
+        index: 25,
+        endIndex: 29
       },
       {
-        value: "#333 50%"
+        value: "#333 50%",
+        index: 31,
+        endIndex: 39
       },
       {
-        value: "#eee 75%"
+        value: "#eee 75%",
+        index: 41,
+        endIndex: 49
       },
       {
-        value: "#333 75%"
+        value: "#333 75%",
+        index: 51,
+        endIndex: 59
       }
     ]);
   });

--- a/src/utils/parseFunctionArguments.js
+++ b/src/utils/parseFunctionArguments.js
@@ -32,7 +32,7 @@ function groupByKeyValue(nodes) {
 }
 
 function mapToKeyValue(nodes) {
-  const keyVal = nodes.reduce((acc, curr, i) => {
+  const keyVal = nodes.reduce((acc, currentNode, i) => {
     if (acc.length === 1) {
       return acc;
     }
@@ -43,15 +43,19 @@ function mapToKeyValue(nodes) {
 
     if (isNextNodeColon) {
       acc.push({
-        key: valueParser.stringify(nodes[i]),
-        value: valueParser.stringify(nodes.slice(2))
+        key: valueParser.stringify(currentNode),
+        value: valueParser.stringify(nodes.slice(2)),
+        index: currentNode.sourceIndex,
+        endIndex: nodes.at(-1).sourceEndIndex
       });
 
       return acc;
     }
 
     acc.push({
-      value: valueParser.stringify(nodes)
+      value: valueParser.stringify(nodes),
+      index: currentNode.sourceIndex,
+      endIndex: nodes.at(-1).sourceEndIndex
     });
 
     return acc;
@@ -61,15 +65,14 @@ function mapToKeyValue(nodes) {
 }
 
 function parseFunctionArguments(value) {
-  const parsed = valueParser(value);
+  const { nodes } = valueParser(value);
+  const [firstNode] = nodes;
 
-  if (!parsed.nodes[0] || parsed.nodes[0].type !== "function") {
+  if (!firstNode || firstNode.type !== "function") {
     return [];
   }
 
-  return parsed.nodes.map(node =>
-    groupByKeyValue(node.nodes).map(mapToKeyValue)
-  )[0];
+  return nodes.map(node => groupByKeyValue(node.nodes).map(mapToKeyValue))[0];
 }
 
 module.exports = {


### PR DESCRIPTION
Part of #652

This PR changes the `parseFunctionArguments()` utility, which is used only by the `at-function-named-arguments` rule.
