### PR TITLE
Fix `at-mixin-named-arguments` end positions

### DIFF
--- a/src/rules/at-mixin-named-arguments/__tests__/index.js
+++ b/src/rules/at-mixin-named-arguments/__tests__/index.js
@@ -113,7 +113,9 @@ testRule({
       }
     `,
       line: 3,
-      column: 9,
+      column: 24,
+      endLine: 3,
+      endColumn: 28,
       message: messages.expected,
       description: "Always. Example: single argument that is not named."
     },
@@ -126,12 +128,16 @@ testRule({
       warnings: [
         {
           line: 3,
-          column: 9,
+          column: 24,
+          endLine: 3,
+          endColumn: 28,
           message: messages.expected
         },
         {
           line: 3,
-          column: 9,
+          column: 30,
+          endLine: 3,
+          endColumn: 34,
           message: messages.expected
         }
       ],
@@ -148,13 +154,17 @@ testRule({
     `,
       warnings: [
         {
-          line: 3,
-          column: 9,
+          line: 4,
+          column: 11,
+          endLine: 4,
+          endColumn: 15,
           message: messages.expected
         },
         {
-          line: 3,
-          column: 9,
+          line: 5,
+          column: 11,
+          endLine: 5,
+          endColumn: 15,
           message: messages.expected
         }
       ],
@@ -168,7 +178,9 @@ testRule({
       }
     `,
       line: 3,
-      column: 9,
+      column: 24,
+      endLine: 3,
+      endColumn: 33,
       message: messages.expected,
       description:
         "Always. Example: single argument is a variable but is not named."
@@ -180,7 +192,9 @@ testRule({
       }
     `,
       line: 3,
-      column: 9,
+      column: 24,
+      endLine: 3,
+      endColumn: 33,
       message: messages.expected,
       description:
         "Always. Example: single argument is a calculated value but is not named."
@@ -194,12 +208,16 @@ testRule({
       warnings: [
         {
           line: 3,
-          column: 9,
+          column: 38,
+          endLine: 3,
+          endColumn: 42,
           message: messages.expected
         },
         {
           line: 3,
-          column: 9,
+          column: 44,
+          endLine: 3,
+          endColumn: 51,
           message: messages.expected
         }
       ],
@@ -215,12 +233,16 @@ testRule({
       warnings: [
         {
           line: 3,
-          column: 9,
+          column: 24,
+          endLine: 3,
+          endColumn: 28,
           message: messages.expected
         },
         {
           line: 3,
-          column: 9,
+          column: 44,
+          endLine: 3,
+          endColumn: 51,
           message: messages.expected
         }
       ],
@@ -231,7 +253,9 @@ testRule({
       @include reset(40px);
     `,
       line: 2,
-      column: 7,
+      column: 22,
+      endLine: 2,
+      endColumn: 26,
       message: messages.expected,
       description:
         "Always. Example: single argument is not named in standalone mixin."
@@ -243,12 +267,16 @@ testRule({
       warnings: [
         {
           line: 2,
-          column: 7,
+          column: 22,
+          endLine: 2,
+          endColumn: 26,
           message: messages.expected
         },
         {
           line: 2,
-          column: 7,
+          column: 28,
+          endLine: 2,
+          endColumn: 32,
           message: messages.expected
         }
       ],
@@ -378,7 +406,9 @@ testRule({
       }
       `,
       line: 3,
-      column: 9,
+      column: 24,
+      endLine: 3,
+      endColumn: 36,
       message: messages.rejected,
       description: "Never. Example: single argument is named."
     },
@@ -389,7 +419,9 @@ testRule({
       }
       `,
       line: 3,
-      column: 9,
+      column: 24,
+      endLine: 3,
+      endColumn: 44,
       message: messages.rejected,
       description: "Never. Example: single argument is a variable."
     },
@@ -400,7 +432,9 @@ testRule({
       }
       `,
       line: 3,
-      column: 9,
+      column: 24,
+      endLine: 3,
+      endColumn: 47,
       message: messages.rejected,
       description: "Never. Example: single argument is an interpolated value."
     },
@@ -411,7 +445,9 @@ testRule({
       }
       `,
       line: 3,
-      column: 9,
+      column: 28,
+      endLine: 3,
+      endColumn: 48,
       message: messages.rejected,
       description: "Never. Example: single argument is a calculated value."
     },
@@ -422,7 +458,9 @@ testRule({
       }
       `,
       line: 3,
-      column: 9,
+      column: 24,
+      endLine: 3,
+      endColumn: 39,
       message: messages.rejected,
       description: "Never. Example: single argument is a quoted string."
     },
@@ -433,7 +471,9 @@ testRule({
       }
       `,
       line: 3,
-      column: 9,
+      column: 28,
+      endLine: 3,
+      endColumn: 48,
       message: messages.rejected,
       description: "Never. Example: single argument is an unquoted string."
     },
@@ -442,7 +482,9 @@ testRule({
       @include reset($value: 40px);
       `,
       line: 2,
-      column: 7,
+      column: 22,
+      endLine: 2,
+      endColumn: 34,
       message: messages.rejected,
       description: "Never. Example: standalone mixin."
     },
@@ -455,17 +497,23 @@ testRule({
       warnings: [
         {
           line: 3,
-          column: 9,
+          column: 24,
+          endLine: 3,
+          endColumn: 36,
           message: messages.rejected
         },
         {
           line: 3,
-          column: 9,
+          column: 38,
+          endLine: 3,
+          endColumn: 57,
           message: messages.rejected
         },
         {
           line: 3,
-          column: 9,
+          column: 59,
+          endLine: 3,
+          endColumn: 74,
           message: messages.rejected
         }
       ],
@@ -483,18 +531,24 @@ testRule({
       `,
       warnings: [
         {
-          line: 3,
-          column: 9,
+          line: 4,
+          column: 11,
+          endLine: 4,
+          endColumn: 23,
           message: messages.rejected
         },
         {
-          line: 3,
-          column: 9,
+          line: 5,
+          column: 11,
+          endLine: 5,
+          endColumn: 30,
           message: messages.rejected
         },
         {
-          line: 3,
-          column: 9,
+          line: 6,
+          column: 11,
+          endLine: 6,
+          endColumn: 26,
           message: messages.rejected
         }
       ],
@@ -508,7 +562,9 @@ testRule({
       }
     `,
       line: 3,
-      column: 9,
+      column: 24,
+      endLine: 3,
+      endColumn: 36,
       message: messages.rejected,
       description:
         "Never. Example: first argument is named but remaining are not."
@@ -520,7 +576,9 @@ testRule({
       }
     `,
       line: 3,
-      column: 9,
+      column: 30,
+      endLine: 3,
+      endColumn: 42,
       message: messages.rejected,
       description: "Never. Example: mixed named arguments."
     }
@@ -668,12 +726,16 @@ testRule({
       warnings: [
         {
           line: 2,
-          column: 7,
+          column: 22,
+          endLine: 2,
+          endColumn: 26,
           message: messages.expected
         },
         {
           line: 2,
-          column: 7,
+          column: 28,
+          endLine: 2,
+          endColumn: 32,
           message: messages.expected
         }
       ],
@@ -687,7 +749,9 @@ testRule({
       }
     `,
       line: 3,
-      column: 9,
+      column: 38,
+      endLine: 3,
+      endColumn: 42,
       message: messages.expected,
       description:
         "Always and ignore single argument. Example: first argument is named but remaining are not."
@@ -701,8 +765,10 @@ testRule({
         );
       }
     `,
-      line: 3,
-      column: 9,
+      line: 5,
+      column: 11,
+      endLine: 5,
+      endColumn: 15,
       message: messages.expected,
       description:
         "Always and ignore single argument. Example: first argument is named but remaining are not in multiline mixin call."
@@ -716,12 +782,16 @@ testRule({
       warnings: [
         {
           line: 3,
-          column: 9,
+          column: 24,
+          endLine: 3,
+          endColumn: 28,
           message: messages.expected
         },
         {
           line: 3,
-          column: 9,
+          column: 44,
+          endLine: 3,
+          endColumn: 51,
           message: messages.expected
         }
       ],
@@ -737,12 +807,16 @@ testRule({
       warnings: [
         {
           line: 3,
-          column: 9,
+          column: 38,
+          endLine: 3,
+          endColumn: 42,
           message: messages.expected
         },
         {
           line: 3,
-          column: 9,
+          column: 44,
+          endLine: 3,
+          endColumn: 51,
           message: messages.expected
         }
       ],
@@ -758,12 +832,16 @@ testRule({
       warnings: [
         {
           line: 3,
-          column: 9,
+          column: 24,
+          endLine: 3,
+          endColumn: 28,
           message: messages.expected
         },
         {
           line: 3,
-          column: 9,
+          column: 44,
+          endLine: 3,
+          endColumn: 51,
           message: messages.expected
         }
       ],
@@ -949,17 +1027,23 @@ testRule({
       warnings: [
         {
           line: 3,
-          column: 9,
+          column: 24,
+          endLine: 3,
+          endColumn: 36,
           message: messages.rejected
         },
         {
           line: 3,
-          column: 9,
+          column: 38,
+          endLine: 3,
+          endColumn: 57,
           message: messages.rejected
         },
         {
           line: 3,
-          column: 9,
+          column: 59,
+          endLine: 3,
+          endColumn: 74,
           message: messages.rejected
         }
       ],
@@ -978,18 +1062,24 @@ testRule({
       `,
       warnings: [
         {
-          line: 3,
-          column: 9,
+          line: 4,
+          column: 11,
+          endLine: 4,
+          endColumn: 23,
           message: messages.rejected
         },
         {
-          line: 3,
-          column: 9,
+          line: 5,
+          column: 11,
+          endLine: 5,
+          endColumn: 30,
           message: messages.rejected
         },
         {
-          line: 3,
-          column: 9,
+          line: 6,
+          column: 11,
+          endLine: 6,
+          endColumn: 26,
           message: messages.rejected
         }
       ],
@@ -1003,7 +1093,9 @@ testRule({
       }
     `,
       line: 3,
-      column: 9,
+      column: 24,
+      endLine: 3,
+      endColumn: 36,
       message: messages.rejected,
       description:
         "Never and ignore single argument. Example: first argument is named but remaining are not."
@@ -1015,7 +1107,9 @@ testRule({
       }
     `,
       line: 3,
-      column: 9,
+      column: 30,
+      endLine: 3,
+      endColumn: 42,
       message: messages.rejected,
       description:
         "Never and ignore single argument. Example: mixed named arguments."

--- a/src/utils/__tests__/parseFunctionArguments.js
+++ b/src/utils/__tests__/parseFunctionArguments.js
@@ -155,10 +155,10 @@ describe("mapToKeyValue", () => {
         { after: " ", before: "", sourceIndex: 12, type: "div", value: ":" },
         { sourceIndex: 14, type: "word", value: "40px" }
       ])
-    ).toEqual({ key: "$value", value: "40px" });
+    ).toEqual({ key: "$value", value: "40px", index: 6 });
     expect(
       mapToKeyValue([{ sourceIndex: 20, type: "word", value: "10px" }])
-    ).toEqual({ value: "10px" });
+    ).toEqual({ value: "10px", index: 20 });
   });
 });
 
@@ -178,7 +178,9 @@ describe("parseFunctionArguments", () => {
   it("parses number as the value", () => {
     expect(parseFunctionArguments("func(1)")).toEqual([
       {
-        value: "1"
+        value: "1",
+        index: 5,
+        endIndex: 6
       }
     ]);
   });
@@ -186,7 +188,9 @@ describe("parseFunctionArguments", () => {
   it("parses calculation as the value", () => {
     expect(parseFunctionArguments("func(30 * 25ms)")).toEqual([
       {
-        value: "30 * 25ms"
+        value: "30 * 25ms",
+        index: 5,
+        endIndex: 14
       }
     ]);
   });
@@ -194,10 +198,14 @@ describe("parseFunctionArguments", () => {
   it("parses multiple args", () => {
     expect(parseFunctionArguments("func(1, 2)")).toEqual([
       {
-        value: "1"
+        value: "1",
+        index: 5,
+        endIndex: 6
       },
       {
-        value: "2"
+        value: "2",
+        index: 8,
+        endIndex: 9
       }
     ]);
   });
@@ -205,10 +213,14 @@ describe("parseFunctionArguments", () => {
   it("parses trailing commas", () => {
     expect(parseFunctionArguments("func(1, 2,)")).toEqual([
       {
-        value: "1"
+        value: "1",
+        index: 5,
+        endIndex: 6
       },
       {
-        value: "2"
+        value: "2",
+        index: 8,
+        endIndex: 9
       }
     ]);
   });
@@ -217,7 +229,9 @@ describe("parseFunctionArguments", () => {
     expect(parseFunctionArguments("func($var: 1)")).toEqual([
       {
         key: "$var",
-        value: "1"
+        value: "1",
+        index: 5,
+        endIndex: 12
       }
     ]);
   });
@@ -230,7 +244,9 @@ describe("parseFunctionArguments", () => {
     ).toEqual([
       {
         key: "$foo",
-        value: 'url("data:image/svg+xml;charset=utf8,%3C")'
+        value: 'url("data:image/svg+xml;charset=utf8,%3C")',
+        index: 5,
+        endIndex: 53
       }
     ]);
   });
@@ -239,7 +255,9 @@ describe("parseFunctionArguments", () => {
     expect(parseFunctionArguments("reset($value: #{$other-value})")).toEqual([
       {
         key: "$value",
-        value: "#{$other-value}"
+        value: "#{$other-value}",
+        index: 6,
+        endIndex: 29
       }
     ]);
   });
@@ -248,7 +266,9 @@ describe("parseFunctionArguments", () => {
     expect(parseFunctionArguments("anim($duration: 30 * 25ms)")).toEqual([
       {
         key: "$duration",
-        value: "30 * 25ms"
+        value: "30 * 25ms",
+        index: 5,
+        endIndex: 25
       }
     ]);
   });
@@ -257,11 +277,15 @@ describe("parseFunctionArguments", () => {
     expect(parseFunctionArguments("func($var: 1, $foo: bar)")).toEqual([
       {
         key: "$var",
-        value: "1"
+        value: "1",
+        index: 5,
+        endIndex: 12
       },
       {
         key: `$foo`,
-        value: "bar"
+        value: "bar",
+        index: 14,
+        endIndex: 23
       }
     ]);
   });
@@ -274,15 +298,21 @@ describe("parseFunctionArguments", () => {
     ).toEqual([
       {
         key: "$value",
-        value: "40px"
+        value: "40px",
+        index: 6,
+        endIndex: 18
       },
       {
         key: "$second-value",
-        value: "10px"
+        value: "10px",
+        index: 20,
+        endIndex: 39
       },
       {
         key: "$color",
-        value: "'black'"
+        value: "'black'",
+        index: 41,
+        endIndex: 56
       }
     ]);
   });
@@ -294,19 +324,29 @@ describe("parseFunctionArguments", () => {
       )
     ).toEqual([
       {
-        value: "to left"
+        value: "to left",
+        index: 16,
+        endIndex: 23
       },
       {
-        value: "#333"
+        value: "#333",
+        index: 25,
+        endIndex: 29
       },
       {
-        value: "#333 50%"
+        value: "#333 50%",
+        index: 31,
+        endIndex: 39
       },
       {
-        value: "#eee 75%"
+        value: "#eee 75%",
+        index: 41,
+        endIndex: 49
       },
       {
-        value: "#333 75%"
+        value: "#333 75%",
+        index: 51,
+        endIndex: 59
       }
     ]);
   });

--- a/src/utils/parseFunctionArguments.js
+++ b/src/utils/parseFunctionArguments.js
@@ -32,7 +32,7 @@ function groupByKeyValue(nodes) {
 }
 
 function mapToKeyValue(nodes) {
-  const keyVal = nodes.reduce((acc, curr, i) => {
+  const keyVal = nodes.reduce((acc, currentNode, i) => {
     if (acc.length === 1) {
       return acc;
     }
@@ -43,15 +43,19 @@ function mapToKeyValue(nodes) {
 
     if (isNextNodeColon) {
       acc.push({
-        key: valueParser.stringify(nodes[i]),
-        value: valueParser.stringify(nodes.slice(2))
+        key: valueParser.stringify(currentNode),
+        value: valueParser.stringify(nodes.slice(2)),
+        index: currentNode.sourceIndex,
+        endIndex: nodes.at(-1).sourceEndIndex
       });
 
       return acc;
     }
 
     acc.push({
-      value: valueParser.stringify(nodes)
+      value: valueParser.stringify(nodes),
+      index: currentNode.sourceIndex,
+      endIndex: nodes.at(-1).sourceEndIndex
     });
 
     return acc;
@@ -61,15 +65,14 @@ function mapToKeyValue(nodes) {
 }
 
 function parseFunctionArguments(value) {
-  const parsed = valueParser(value);
+  const { nodes } = valueParser(value);
+  const [firstNode] = nodes;
 
-  if (!parsed.nodes[0] || parsed.nodes[0].type !== "function") {
+  if (!firstNode || firstNode.type !== "function") {
     return [];
   }
 
-  return parsed.nodes.map(node =>
-    groupByKeyValue(node.nodes).map(mapToKeyValue)
-  )[0];
+  return nodes.map(node => groupByKeyValue(node.nodes).map(mapToKeyValue))[0];
 }
 
 module.exports = {


### PR DESCRIPTION
Part of #652

Note: This PR uses the same utility (`parseFunctionArguments()`) as #939.
