### PR TITLE
property-no-unknown for deeper nested properties

### DIFF
--- a/src/rules/property-no-unknown/__tests__/index.js
+++ b/src/rules/property-no-unknown/__tests__/index.js
@@ -105,6 +105,14 @@ testRule({
     {
       code: ".foo { border: { style: solid; } }",
       description: "ignore nested properties"
+    },
+    {
+      code: ".foo { border: { style: solid; } }",
+      description: "ignore nested properties"
+    },
+    {
+      code: ".foo { background: { position: { x: left; } } }",
+      description: "ignore deeper nested properties"
     }
   ]
 });

--- a/src/rules/property-no-unknown/index.js
+++ b/src/rules/property-no-unknown/index.js
@@ -97,14 +97,16 @@ function rule(primary, secondaryOptions) {
       }
 
       // Nested properties
-      if (
-        parent &&
-        isType(parent, "rule") &&
-        parent.selector &&
-        parent.selector[parent.selector.length - 1] === ":" &&
-        parent.selector.substring(0, 2) !== "--"
+      let pointer = parent;
+      while (
+        pointer &&
+        isType(pointer, "rule") &&
+        pointer.selector &&
+        pointer.selector[pointer.selector.length - 1] === ":" &&
+        pointer.selector.substring(0, 2) !== "--"
       ) {
-        prop = parent.selector.replace(":", "") + "-" + prop;
+        prop = pointer.selector.replace(":", "") + "-" + prop;
+        pointer = pointer.parent;
       }
 
       if (allValidProperties.has(prop.toLowerCase())) {


### PR DESCRIPTION
Fix: `scss/property-no-unknown` is not recognizing more than two-level nested properties.
E.g.
```
background: {
  position: {
    x: left;
  }
}
```
compiles to: `background-position-x: left;`. This is a [valid property](https://developer.mozilla.org/en-US/docs/Web/CSS/background-position-x).

However, it's currently raising the following error: `Unexpected unknown property "position-x" (scss/property-no-unknown)`.

