### PR TITLE
no-unused-private-members treats hyphens and underscores as equals

### DIFF
--- a/src/rules/no-unused-private-members/__tests__/index.js
+++ b/src/rules/no-unused-private-members/__tests__/index.js
@@ -80,7 +80,7 @@ testRule({
       code: `
       @import 'foo';
 
-      %-toolbelt:hover {
+      %_toolbelt:hover {
         color: red;
       }
 
@@ -96,7 +96,7 @@ testRule({
     },
     {
       code: `
-      $-a: 3px;
+      $_a: 3px;
       $_b: 1px;
       
       .action-buttons {
@@ -124,7 +124,7 @@ testRule({
     {
       code: `
       $_app-bar-height: 65px;
-      $_header-height: 70px;
+      $-header_height: 70px;
       $_explorer-margin: 64px;
       $_total-offset: $_app-bar-height + $_header-height + $_explorer-margin;
 
@@ -137,9 +137,9 @@ testRule({
     {
       code: `
       @function _add-one($n1) { @return $n1 + 1 }
-      @function _add-two($n1) { @return $n1 + 2 }
-      @function _add-three($n1) {
-      @return _add-two (
+      @function -add-two($n1) { @return $n1 + 2 }
+      @function _add_three($n1) {
+      @return _add_two (
         _add-one($n1)
       )}
       
@@ -162,11 +162,19 @@ testRule({
     {
       code: `
       $_gm-toolbar-item-state-offset: 0.5 * 3;
-      @mixin _position-offset($offset: $_gm-toolbar-item-state-offset) {
+      @mixin _position_offset($offset: $_gm-toolbar-item-state-offset) {
         top: $offset;
       }
       .b {
         @include _position-offset;
+      }`,
+      description: "Is used as a mixin default parameter"
+    },
+    {
+      code: `
+      $_a-b: 1px;
+      .b {
+        margin: $-a-b;
       }`,
       description: "Is used as a mixin default parameter"
     }
@@ -187,7 +195,7 @@ testRule({
         margin-left: _addNums(4, 6);
       }
       `,
-      message: messages.expected("_one"),
+      message: messages.expected("-one"),
       description: "Private function",
       line: 6,
       column: 7
@@ -203,7 +211,7 @@ testRule({
         margin: 0;
       }      
       `,
-      message: messages.expected("_reset-list"),
+      message: messages.expected("-reset-list"),
       description: "Private mixin",
       line: 2,
       column: 7
@@ -271,7 +279,7 @@ testRule({
         @include column($_a);
         @include footer();
       }`,
-      message: messages.expected("$_c"),
+      message: messages.expected("$-c"),
       line: 4,
       column: 7,
       description: "Variables used as function parameters"
@@ -285,7 +293,7 @@ testRule({
         margin: 5px map.get($_a);
       }
       `,
-      message: messages.expected("$_b"),
+      message: messages.expected("$-b"),
       line: 3,
       column: 7,
       description: "map.get uses variable"
@@ -304,7 +312,7 @@ testRule({
             )
           );
       }`,
-      message: messages.expected("$_a-color"),
+      message: messages.expected("$-a-color"),
       line: 3,
       column: 7,
       description: "Is in theme declaration"
@@ -319,7 +327,7 @@ testRule({
           margin: 0px;
         }
       }`,
-      message: messages.expected("$_b"),
+      message: messages.expected("$-b"),
       line: 3,
       column: 7,
       description: "Is used in @if"
@@ -334,7 +342,7 @@ testRule({
           margin: 0px;
         }
       }`,
-      message: messages.expected("$_b"),
+      message: messages.expected("$-b"),
       line: 3,
       column: 7,
       description: "Variable in interpolated selector."

--- a/src/rules/no-unused-private-members/__tests__/index.js
+++ b/src/rules/no-unused-private-members/__tests__/index.js
@@ -177,6 +177,15 @@ testRule({
         margin: $-a-b;
       }`,
       description: "Is used as a mixin default parameter"
+    },
+    {
+      code: `
+      @mixin foo {
+        $_a-b: 1px;
+      }
+      @include foo
+      `,
+      description: "Is used as a mixin default parameter"
     }
   ],
 

--- a/src/rules/no-unused-private-members/index.js
+++ b/src/rules/no-unused-private-members/index.js
@@ -29,6 +29,17 @@ function matchUnderscores(inputString) {
   return inputString.replaceAll("_", "-");
 }
 
+function isWithinMixin(node) {
+  let parent = node.parent;
+  while (parent) {
+    if (parent.type === "atrule" && parent.name === "mixin") {
+      return true;
+    }
+    parent = parent.parent;
+  }
+  return false;
+}
+
 function rule(primaryOption) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
@@ -72,7 +83,8 @@ function rule(primaryOption) {
       // Private variables
       const isPrivateVariable =
         node.type === "decl" &&
-        (node.prop.startsWith("$-") || node.prop.startsWith("$_"));
+        (node.prop.startsWith("$-") || node.prop.startsWith("$_")) &&
+        !isWithinMixin(node);
       if (isPrivateVariable) {
         privateMembers.variables.set(matchUnderscores(node.prop), node);
       }
@@ -139,10 +151,10 @@ function rule(primaryOption) {
     });
 
     for (const types in privateMembers) {
-      for (const [key, value] of privateMembers[types].entries()) {
+      for (const [key, node] of privateMembers[types].entries()) {
         utils.report({
           message: messages.expected(key),
-          node: value,
+          node,
           result,
           ruleName
         });

--- a/src/rules/no-unused-private-members/index.js
+++ b/src/rules/no-unused-private-members/index.js
@@ -25,6 +25,10 @@ function getPrivateMembers(inputString) {
   return matches;
 }
 
+function matchUnderscores(inputString) {
+  return inputString.replaceAll("_", "-");
+}
+
 function rule(primaryOption) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
@@ -60,7 +64,7 @@ function rule(primaryOption) {
           );
         selectors.forEach(selector => {
           if (!privateMembers.selectors.has(selector)) {
-            privateMembers.selectors.set(selector, node);
+            privateMembers.selectors.set(matchUnderscores(selector), node);
           }
         });
       }
@@ -70,7 +74,7 @@ function rule(primaryOption) {
         node.type === "decl" &&
         (node.prop.startsWith("$-") || node.prop.startsWith("$_"));
       if (isPrivateVariable) {
-        privateMembers.variables.set(node.prop, node);
+        privateMembers.variables.set(matchUnderscores(node.prop), node);
       }
 
       // Private functions
@@ -81,7 +85,7 @@ function rule(primaryOption) {
       if (isPrivateFunction) {
         const match = extractFunctionName(node.params);
         if (match.length < 2) return;
-        privateMembers.functions.set(match[1], node);
+        privateMembers.functions.set(matchUnderscores(match[1]), node);
       }
 
       // Private mixins
@@ -92,7 +96,7 @@ function rule(primaryOption) {
       if (isPrivateMixin) {
         const match = extractFunctionName(node.params);
         privateMembers.mixins.set(
-          match.length < 2 ? node.params : match[1],
+          matchUnderscores(match.length < 2 ? node.params : match[1]),
           node
         );
       }
@@ -104,6 +108,7 @@ function rule(primaryOption) {
         const valuePrivateMembers = getPrivateMembers(value);
         if (valuePrivateMembers) {
           valuePrivateMembers.forEach(privateMember => {
+            privateMember = matchUnderscores(privateMember);
             if (privateMembers.mixins.get(privateMember) !== node)
               privateMembers.mixins.delete(privateMember);
             if (
@@ -124,6 +129,7 @@ function rule(primaryOption) {
       const valuePrivateMembers = getPrivateMembers(decls.value);
       if (valuePrivateMembers) {
         valuePrivateMembers.forEach(privateMember => {
+          privateMember = matchUnderscores(privateMember);
           if (privateMembers.variables.get(privateMember) !== decls)
             privateMembers.variables.delete(privateMember);
           if (privateMembers.functions.get(privateMember) !== decls)


### PR DESCRIPTION
Fix #986.