### PR TITLE
operator-no-unspaced: ignore operators inside @scope

### DIFF
--- a/src/rules/operator-no-unspaced/__tests__/index.js
+++ b/src/rules/operator-no-unspaced/__tests__/index.js
@@ -1359,6 +1359,17 @@ testRule({
       }
       `,
       description: "issue #709"
+    },
+    {
+      code: `
+      @scope([class*="my-selector-"]) {
+        :scope {
+          // Override the default theme variables
+          --d-font-size-base: 14;
+        }
+      }
+      `,
+      description: "issue #989"
     }
   ],
 

--- a/src/rules/operator-no-unspaced/index.js
+++ b/src/rules/operator-no-unspaced/index.js
@@ -196,11 +196,12 @@ function calculationOperatorSpaceChecker({ root, result, checker }) {
     }
 
     if (item.type === "atrule") {
-      // @forward, @use and @at-root
+      // @forward, @use, @at-root, and @scope
       if (
         item.name === "forward" ||
         item.name === "use" ||
-        item.name === "at-root"
+        item.name === "at-root" ||
+        item.name === "scope"
       ) {
         return;
       }


### PR DESCRIPTION
Fixes #989