### PR TITLE
Fix `partial-no-import` message to include more accurate rule name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "github-contributors-list": "^1.2.5",
         "husky": "^9.0.11",
         "jest": "^29.7.0",
-        "jest-preset-stylelint": "^7.0.1",
+        "jest-preset-stylelint": "^7.1.0",
         "lint-staged": "^14.0.1",
         "np": "^10.0.6",
         "postcss": "^8.4.39",
@@ -5224,9 +5224,9 @@
       }
     },
     "node_modules/jest-preset-stylelint": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/jest-preset-stylelint/-/jest-preset-stylelint-7.0.1.tgz",
-      "integrity": "sha512-umVx7qx/O2pTMdZvG8HcMmExo/7rXpYsNK/22GKQ6ulLBxfgVSINLtkav77ZH505Uy6g0tDoEbWuPoWe5vJuMQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/jest-preset-stylelint/-/jest-preset-stylelint-7.1.0.tgz",
+      "integrity": "sha512-0chPt4l2B1xIMMoTQPhwqcbH1ANBx6W+IhGpMDvPWffIdI5pE7pgti3XVOh9bBBgFutcSY0MCD8yEFABEY07VQ==",
       "dev": true,
       "funding": [
         {
@@ -5238,6 +5238,7 @@
           "url": "https://github.com/sponsors/stylelint"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=18.12.0"
       },
@@ -13647,9 +13648,9 @@
       "requires": {}
     },
     "jest-preset-stylelint": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/jest-preset-stylelint/-/jest-preset-stylelint-7.0.1.tgz",
-      "integrity": "sha512-umVx7qx/O2pTMdZvG8HcMmExo/7rXpYsNK/22GKQ6ulLBxfgVSINLtkav77ZH505Uy6g0tDoEbWuPoWe5vJuMQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/jest-preset-stylelint/-/jest-preset-stylelint-7.1.0.tgz",
+      "integrity": "sha512-0chPt4l2B1xIMMoTQPhwqcbH1ANBx6W+IhGpMDvPWffIdI5pE7pgti3XVOh9bBBgFutcSY0MCD8yEFABEY07VQ==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "github-contributors-list": "^1.2.5",
     "husky": "^9.0.11",
     "jest": "^29.7.0",
-    "jest-preset-stylelint": "^7.0.1",
+    "jest-preset-stylelint": "^7.1.0",
     "lint-staged": "^14.0.1",
     "np": "^10.0.6",
     "postcss": "^8.4.39",

--- a/src/rules/partial-no-import/index.js
+++ b/src/rules/partial-no-import/index.js
@@ -8,7 +8,9 @@ const ruleUrl = require("../../utils/ruleUrl");
 const ruleName = namespace("partial-no-import");
 
 const messages = utils.ruleMessages(ruleName, {
-  expected: "Unexpected @import in a partial"
+  expected: "Unexpected @import in a partial",
+  expectedActualFile:
+    "This rule won't work if linting in a code string without an actual file"
 });
 
 const meta = {
@@ -26,9 +28,14 @@ function rule(on) {
     }
 
     if (root.source.input.file === undefined || !root.source.input.file) {
-      result.warn(
-        "The 'partial-no-import' rule won't work if linting in a code string without an actual file."
-      );
+      utils.report({
+        message: messages.expectedActualFile,
+        node: root,
+        index: 1,
+        endIndex: 2,
+        result,
+        ruleName
+      });
 
       return;
     }


### PR DESCRIPTION
By this change, the `partial-no-import` rule message will be properly associated with the rule name. See the examples below:

Before:

```sh-session
$ echo '@import "file.scss"' | npx stylelint

<input css ZECpLj>
       ✖  The 'partial-no-import' rule won't work if linting in a code string without an actual file

✖ 1 problem (1 error, 0 warnings)
```

After:

```sh-session
$ echo '@import "file.scss"' | npx stylelint

<input css PE6AAM>
  1:2  ✖  This rule won't work if linting in a code string without an actual file  scss/partial-no-import

✖ 1 problem (1 error, 0 warnings)
```

In addition, this change updates `jest-preset-stylelint` to use `testRule()` instead of `postcss`.
Because `testRule()` is closer to the actual use of `stylelint` and easier to avoid any potential troubles.
See https://github.com/stylelint/jest-preset-stylelint/releases/tag/7.1.0
