### PR TITLE
Fix false positive for mixins in `load-partial-extension`

### DIFF
--- a/src/rules/load-partial-extension/__tests__/index.js
+++ b/src/rules/load-partial-extension/__tests__/index.js
@@ -544,6 +544,12 @@ testRule({
       }
     `,
       description: "forward a filename with a dot."
+    },
+    {
+      code: `
+      @include button-variant(primary);
+    `,
+      description: "Include a mixin without meta.load-css."
     }
   ],
 
@@ -1310,6 +1316,12 @@ testRule({
       }
     `,
       description: "meta.load-css a style file with a dot in the name."
+    },
+    {
+      code: `
+      @include button-variant(primary);
+    `,
+      description: "Include a mixin without meta.load-css."
     }
   ],
 

--- a/src/rules/load-partial-extension/index.js
+++ b/src/rules/load-partial-extension/index.js
@@ -66,6 +66,8 @@ function rule(expectation, _, context) {
               .split(",")[0]
               .replace(/[()]/g, "")
           ];
+        } else if (atRule.name === "include") {
+          return;
         }
 
         // Processing comma-separated lists of import paths


### PR DESCRIPTION
Follow-up to #998. Without the code change, these new tests are failing.