### PR TITLE
selector-no-redundant-nesting-selector: Add support for Dart Sass deprecation

### DIFF
--- a/src/rules/selector-no-redundant-nesting-selector/__tests__/index.js
+++ b/src/rules/selector-no-redundant-nesting-selector/__tests__/index.js
@@ -163,6 +163,43 @@ testRule({
       }
       `,
       description: ":where, followed by a pseudo-element selector, issue #1000"
+    },
+    {
+      code: `
+      .example {
+        color: red;
+
+        a {
+          font-weight: bold;
+        }
+
+        & {
+          font-weight: normal;
+        }
+      }
+      `,
+      description:
+        "Dart Sass 1.77.7: https://sass-lang.com/documentation/breaking-changes/mixed-decls/"
+    },
+    {
+      code: `
+      p {
+        & {}
+      }
+    `,
+      description:
+        "when an ampersand is used by itself." +
+        "Dart Sass 1.77.7: https://sass-lang.com/documentation/breaking-changes/mixed-decls/"
+    },
+    {
+      code: `
+      p {
+          &   {}
+      }
+    `,
+      description:
+        "when an ampersand is used by itself and there are extra spaces." +
+        "Dart Sass 1.77.7: https://sass-lang.com/documentation/breaking-changes/mixed-decls/"
     }
   ],
 
@@ -327,27 +364,6 @@ testRule({
       line: 3,
       message: messages.rejected,
       description: "ampersand followed by newline and tag selector"
-    },
-    {
-      code: `
-      p {
-        & {}
-      }
-    `,
-      line: 3,
-      message: messages.rejected,
-      description: "when an ampersand is used by itself"
-    },
-    {
-      code: `
-      p {
-          &   {}
-      }
-    `,
-      line: 3,
-      message: messages.rejected,
-      description:
-        "when an ampersand is used by itself and there are extra spaces"
     },
     {
       code: `

--- a/src/rules/selector-no-redundant-nesting-selector/index.js
+++ b/src/rules/selector-no-redundant-nesting-selector/index.js
@@ -39,6 +39,10 @@ function rule(actual, options) {
     }
 
     root.walkRules(/&/, rule => {
+      if (rule.selector === "&") {
+        return;
+      }
+
       parseSelector(rule.selector, result, rule, fullSelector => {
         // "Ampersand followed by a combinator followed by non-combinator non-ampersand and not the selector end"
         fullSelector.walkNesting(node => {


### PR DESCRIPTION
Related to #1020