### PR TITLE
Add `color.channel` function

### DIFF
--- a/src/utils/functions.js
+++ b/src/utils/functions.js
@@ -41,6 +41,7 @@ const COLOR_FUNCTIONS = Object.freeze([
   "color.blackness",
   "color.blue",
   "color.change",
+  "color.channel",
   "color.complement",
   "color.grayscale",
   "color.green",


### PR DESCRIPTION
It was added in Sass 1.78 (see https://sass-lang.com/documentation/modules/color/#channel). Using it without this PR causes [`function-no-unknown`](https://github.com/stylelint-scss/stylelint-scss/tree/master/src/rules/function-no-unknown) to report it as unknown.