### PR TITLE
Fix false positives for imported custom functions in `scss/declaration-property-value-no-unknown`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "css-tree": "^3.0.0",
         "is-plain-object": "^5.0.0",
         "known-css-properties": "^0.34.0",
+        "mdn-data": "^2.0.30",
         "postcss-media-query-parser": "^0.2.3",
         "postcss-resolve-nested-selector": "^0.1.6",
         "postcss-selector-parser": "^6.1.2",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "css-tree": "^3.0.0",
     "is-plain-object": "^5.0.0",
     "known-css-properties": "^0.34.0",
+    "mdn-data": "^2.0.30",
     "postcss-media-query-parser": "^0.2.3",
     "postcss-resolve-nested-selector": "^0.1.6",
     "postcss-selector-parser": "^6.1.2",

--- a/src/rules/declaration-property-value-no-unknown/__tests__/index.js
+++ b/src/rules/declaration-property-value-no-unknown/__tests__/index.js
@@ -272,6 +272,13 @@ testRule({
         )
         repeat-y;`,
       description: "Function call in shorthand format"
+    },
+    {
+      code: `
+      @use 'foo';
+      .b {
+        font-size: foo.bar(26px);
+      }`
     }
   ],
 

--- a/src/rules/declaration-property-value-no-unknown/index.js
+++ b/src/rules/declaration-property-value-no-unknown/index.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const cssTree = require("css-tree");
+const syntaxes = require("mdn-data/css/syntaxes");
 const isPlainObject = require("is-plain-object");
 const typeGuards = require("../../utils/typeGuards.js");
 const declarationValueIndex = require("../../utils/declarationValueIndex.js");
@@ -310,7 +311,9 @@ function containsCustomFunction(cssTreeNode) {
     cssTree.find(
       cssTreeNode,
       node =>
-        node.type === "Function" && unsupportedFunctions.includes(node.name)
+        node.type === "Function" &&
+        (unsupportedFunctions.includes(node.name) ||
+          !syntaxes[node.name + "()"])
     )
   );
 }


### PR DESCRIPTION
Currently imported custom functions are being flagged as `Unknown value`.
E.g.
```scss
// foo.scss
@function one() {
  @return 1;
}
```

```scss
// bar.scss
@import "foo";
.b {
  margin: one(); // Unexpected unknown value "one(" for property "margin" (scss/declaration-property-value-no-unknown).
}
```
This change checks whether the function exists in the CSS syntax (see: https://github.com/mdn/data/blob/main/css/syntaxes.json). If it doesn't exist, the function is tagged as a custom function, therefore skipped.