### PR TITLE
Include explicit namespace variables in isDollarVar()

### DIFF
--- a/src/rules/declaration-property-value-no-unknown/__tests__/index.js
+++ b/src/rules/declaration-property-value-no-unknown/__tests__/index.js
@@ -279,6 +279,24 @@ testRule({
       .b {
         font-size: foo.bar(26px);
       }`
+    },
+    {
+      code: `
+      @use foo;
+      .b {
+        background-color: foo.$color;
+      }`,
+      description: "Value is a explicit namespace variable."
+    },
+    {
+      code: `
+      @use 'foo';
+      .b {
+        transition: background-color 0.3s 
+        foo.$bar;
+      }
+      `,
+      description: "Value is a explicit namespace variable."
     }
   ],
 

--- a/src/utils/validateTypes.js
+++ b/src/utils/validateTypes.js
@@ -61,7 +61,8 @@ function isIfStatement(value) {
  * @param {unknown} value
  * @returns {value is variable}
  */
-const isDollarVar = value => value.length > 0 && value[0] === "$";
+const isDollarVar = value =>
+  (value.length > 0 && value[0] === "$") || value.includes(".$");
 
 /**
  * Checks if the selector is nested property.


### PR DESCRIPTION
Update `isDollarVar()` to include explicit namespace variables in multi-line values.
E.g.
```scss
@use foo;
.b {
  transition: background-color 0.3s 
  foo.$bar; // isDollarVar('foo.$bar') == true
}
```