### PR TITLE
Unify rule messages

### DIFF
--- a/src/rules/at-mixin-no-risky-nesting-selector/__tests__/index.js
+++ b/src/rules/at-mixin-no-risky-nesting-selector/__tests__/index.js
@@ -171,7 +171,7 @@ testRule({
     `,
       description: "Parent selector nested in selector within a mixin",
       message:
-        "Unexpected nested parent selector in @mixin rule. (scss/at-mixin-no-risky-nesting-selector)",
+        "Unexpected nested parent selector in @mixin rule (scss/at-mixin-no-risky-nesting-selector)",
       column: 11,
       endColumn: 12,
       endLine: 7,
@@ -190,7 +190,7 @@ testRule({
     `,
       description: "Parent selector nested in complex selector within mixin",
       message:
-        "Unexpected nested parent selector in @mixin rule. (scss/at-mixin-no-risky-nesting-selector)",
+        "Unexpected nested parent selector in @mixin rule (scss/at-mixin-no-risky-nesting-selector)",
       column: 11,
       endColumn: 12,
       endLine: 7,
@@ -209,7 +209,7 @@ testRule({
     `,
       description: "Parent selector nested in complex selector within mixin",
       message:
-        "Unexpected nested parent selector in @mixin rule. (scss/at-mixin-no-risky-nesting-selector)",
+        "Unexpected nested parent selector in @mixin rule (scss/at-mixin-no-risky-nesting-selector)",
       column: 11,
       endColumn: 12,
       endLine: 7,

--- a/src/rules/at-mixin-no-risky-nesting-selector/index.js
+++ b/src/rules/at-mixin-no-risky-nesting-selector/index.js
@@ -7,7 +7,7 @@ const ruleUrl = require("../../utils/ruleUrl");
 const ruleName = namespace("at-mixin-no-risky-nesting-selector");
 
 const messages = utils.ruleMessages(ruleName, {
-  rejected: `Unexpected nested parent selector in @mixin rule.`
+  rejected: `Unexpected nested parent selector in @mixin rule`
 });
 
 const meta = {

--- a/src/rules/at-root-no-redundant/index.js
+++ b/src/rules/at-root-no-redundant/index.js
@@ -18,7 +18,7 @@ function isWithinKeyframes(node) {
 }
 
 const messages = utils.ruleMessages(ruleName, {
-  rejected: "Unexpected @at-root rule."
+  rejected: "Unexpected @at-root rule"
 });
 
 const meta = {

--- a/src/rules/function-calculation-no-interpolation/index.js
+++ b/src/rules/function-calculation-no-interpolation/index.js
@@ -8,7 +8,7 @@ const valueParser = require("postcss-value-parser");
 const ruleName = namespace("function-calculation-no-interpolation");
 
 const messages = utils.ruleMessages(ruleName, {
-  rejected: func => `Unexpected interpolation in "${func}".`
+  rejected: func => `Unexpected interpolation in "${func}"`
 });
 
 const meta = {

--- a/src/rules/no-unused-private-members/index.js
+++ b/src/rules/no-unused-private-members/index.js
@@ -8,7 +8,7 @@ const ruleName = namespace("no-unused-private-members");
 
 const messages = utils.ruleMessages(ruleName, {
   expected: privateMember =>
-    `Expected usage of private member "${privateMember}" within the stylesheet.`
+    `Expected usage of private member "${privateMember}" within the stylesheet`
 });
 
 const meta = {


### PR DESCRIPTION
All Stylelint rules and almost all rules in this project use error messages without a trailing punctuation mark. This pull request unifies all of these messages and removes trailing punctuation marks.