### PR TITLE
Add `no-import` rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Added: `no-import` rule.
+
 # 6.8.1
 
 - Fixed: `declaration-property-value-no-unknown` fix false positives for nested properties in nested declarations (#1068).

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Please also see the [example configs](./docs/examples/) for special cases.
 - [`no-duplicate-mixins`](./src/rules/no-duplicate-mixins/README.md): Disallow duplicate mixins within a stylesheet.
 - [`no-global-function-names`](./src/rules/no-global-function-names/README.md): Disallows the use of global function names, as these global functions are now located inside built-in Sass modules.
 - [`no-unused-private-members`](./src/rules/no-unused-private-members/README.md): Disallow unused private members such as functions, mixins, variables or placeholder selectors.
+- [`no-import`](./src/rules/no-import/README.md): Disallow import declarations.
 
 ## Deprecated
 

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -64,6 +64,7 @@ const rules = {
   "no-duplicate-dollar-variables": require("./no-duplicate-dollar-variables"),
   "no-duplicate-mixins": require("./no-duplicate-mixins"),
   "no-global-function-names": require("./no-global-function-names"),
+  "no-import": require("./no-import"),
   "no-unused-private-members": require("./no-unused-private-members"),
   "operator-no-newline-after": require("./operator-no-newline-after"),
   "operator-no-newline-before": require("./operator-no-newline-before"),

--- a/src/rules/no-import/README.md
+++ b/src/rules/no-import/README.md
@@ -1,0 +1,31 @@
+# no-import
+
+Disallow `@import` declarations due to their [deprecation](https://sass-lang.com/documentation/at-rules/import/) in favor of `@use` and `@forward`.
+
+```scss
+@import "file"
+/** ↑
+ * This is the deprecated declaration */
+```
+
+## Options
+
+### `true`
+
+The following patterns are considered warnings:
+
+```scss
+@import "file";
+@import "file.css";
+@import "file.scss";
+@import "_partial";
+@import "http://file.scss";
+@import url("file");
+```
+
+The following patterns are *not* considered warnings:
+
+```scss
+@use "file";
+@forward "file";
+```

--- a/src/rules/no-import/__tests__/index.js
+++ b/src/rules/no-import/__tests__/index.js
@@ -1,0 +1,93 @@
+"use strict";
+
+const { messages, ruleName } = require("..");
+
+testRule({
+  ruleName,
+  config: [true],
+  customSyntax: "postcss-scss",
+
+  accept: [
+    {
+      code: `
+        @use "file";
+      `,
+      description: "`@use` declarations"
+    },
+    {
+      code: `
+        @forward "file";
+      `,
+      description: "`@forward` declarations"
+    }
+  ],
+
+  reject: [
+    {
+      code: `
+        @import "file";
+      `,
+      line: 2,
+      column: 9,
+      endLine: 2,
+      endColumn: 24,
+      message: messages.rejected('@import "file"'),
+      description: "No regular imports"
+    },
+    {
+      code: `
+        @import "file.css";
+      `,
+      line: 2,
+      column: 9,
+      endLine: 2,
+      endColumn: 28,
+      message: messages.rejected('@import "file.css"'),
+      description: "No css imports"
+    },
+    {
+      code: `
+        @import "file.scss";
+      `,
+      line: 2,
+      column: 9,
+      endLine: 2,
+      endColumn: 29,
+      message: messages.rejected('@import "file.scss"'),
+      description: "No imports with extensions"
+    },
+    {
+      code: `
+        @import "_partial";
+      `,
+      line: 2,
+      column: 9,
+      endLine: 2,
+      endColumn: 28,
+      message: messages.rejected('@import "_partial"'),
+      description: "No partial imports"
+    },
+    {
+      code: `
+        @import "http://file.scss";
+      `,
+      line: 2,
+      column: 9,
+      endLine: 2,
+      endColumn: 36,
+      message: messages.rejected('@import "http://file.scss"'),
+      description: "No web imports"
+    },
+    {
+      code: `
+        @import url("file");
+      `,
+      line: 2,
+      column: 9,
+      endLine: 2,
+      endColumn: 29,
+      message: messages.rejected('@import url("file")'),
+      description: "No url imports"
+    }
+  ]
+});

--- a/src/rules/no-import/index.js
+++ b/src/rules/no-import/index.js
@@ -1,0 +1,44 @@
+"use strict";
+
+const { utils } = require("stylelint");
+const namespace = require("../../utils/namespace");
+const ruleUrl = require("../../utils/ruleUrl");
+
+const ruleToCheckAgainst = "no-import";
+
+const ruleName = namespace(ruleToCheckAgainst);
+
+const messages = utils.ruleMessages(ruleName, {
+  rejected: atRule => `Unexpected deprecated at-rule "${atRule}"`
+});
+
+const meta = {
+  url: ruleUrl(ruleName)
+};
+
+function rule(on) {
+  return async (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: on
+    });
+
+    if (!validOptions) {
+      return;
+    }
+
+    root.walkAtRules("import", mixinCall => {
+      utils.report({
+        message: messages.rejected(mixinCall.toString()),
+        node: mixinCall,
+        result,
+        ruleName
+      });
+    });
+  };
+}
+
+rule.ruleName = ruleName;
+rule.messages = messages;
+rule.meta = meta;
+
+module.exports = rule;


### PR DESCRIPTION
`@import` declaration is deprecated and expected to be removed in SASS 3.x.
This rule prohibits the usage of `@import`.