### PR TITLE
Fix multiline value parsing in declaration-property-value-no-unknown

### DIFF
--- a/src/rules/declaration-property-value-no-unknown/__tests__/index.js
+++ b/src/rules/declaration-property-value-no-unknown/__tests__/index.js
@@ -344,6 +344,15 @@ testRule({
         margin: qux.$f-123;
       }
       `
+    },
+    {
+      code: `
+        .a {
+          box-shadow: half(-1px) 0px half(1px) half(2px) 
+            colors.get('first');
+        }
+      `,
+      description: "Multiline values with function calls."
     }
   ],
 

--- a/src/rules/declaration-property-value-no-unknown/index.js
+++ b/src/rules/declaration-property-value-no-unknown/index.js
@@ -155,7 +155,7 @@ function rule(primary, secondaryOptions) {
     root.walkDecls(decl => {
       let { prop } = decl;
       const { parent } = decl;
-      const value = getDeclarationValue(decl);
+      const value = getDeclarationValue(decl).replace(/\n+\s+/, ""); // Strip multiline values.
 
       // Handle nested properties by reasigning `prop` to the compound property.
       if (parent.selector && isNestedProperty(parent.selector)) {


### PR DESCRIPTION
Strip multiline values before processing in `declaration-property-value-no-unknown`