### PR TITLE
Allow CSS round() function

### DIFF
--- a/src/rules/no-global-function-names/index.js
+++ b/src/rules/no-global-function-names/index.js
@@ -37,7 +37,6 @@ const rules = {
   "to-lower-case": "string",
   "unique-id": "string",
   percentage: "math",
-  round: "math",
   ceil: "math",
   floor: "math",
   abs: "math",


### PR DESCRIPTION
Enables `round()` function in `no-global-function-names` since it's widely available https://developer.mozilla.org/en-US/docs/Web/CSS/round

Addresses #1080

Wasn't sure if any new tests were necessary for this PR. Please let me know if they are.