### PR TITLE
Allow functions from explicit namespaces within other functions in `declaration-property-value-no-unknown`

### DIFF
--- a/src/rules/declaration-property-value-no-unknown/__tests__/index.js
+++ b/src/rules/declaration-property-value-no-unknown/__tests__/index.js
@@ -353,6 +353,20 @@ testRule({
         }
       `,
       description: "Multiline values with function calls."
+    },
+    {
+      code: `
+        @use 'foo/bar';
+        .a {
+          background-image: linear-gradient(
+            to right,
+            bar.get('blue') 27%,
+            bar.get('red') 73%
+          );
+        }
+      `,
+      description:
+        "Multiline values with explicit namespace function calls within a function."
     }
   ],
 

--- a/src/rules/declaration-property-value-no-unknown/index.js
+++ b/src/rules/declaration-property-value-no-unknown/index.js
@@ -297,13 +297,14 @@ function containsUnsupportedFunction(cssTreeNode) {
 
 function containsCustomFunction(cssTreeNode) {
   return Boolean(
-    cssTree.find(
-      cssTreeNode,
-      node =>
-        node.type === "Function" &&
-        (unsupportedFunctions.includes(node.name) ||
-          !syntaxes[node.name + "()"])
-    )
+    /[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\(.*\)/g.test(cssTreeNode) ||
+      cssTree.find(
+        cssTreeNode,
+        node =>
+          node.type === "Function" &&
+          (unsupportedFunctions.includes(node.name) ||
+            !syntaxes[node.name + "()"])
+      )
   );
 }
 


### PR DESCRIPTION
Fixes #1112.