### PR TITLE
Add support to Sass `rgba()` in `declaration-property-value-no-unknown`.

### DIFF
--- a/src/rules/declaration-property-value-no-unknown/__tests__/index.js
+++ b/src/rules/declaration-property-value-no-unknown/__tests__/index.js
@@ -367,6 +367,14 @@ testRule({
       `,
       description:
         "Multiline values with explicit namespace function calls within a function."
+    },
+    {
+      code: `
+        .a {
+          background-color: rgba(#000, 0.59);
+        }
+      `,
+      description: "Sass rgba() function supporting hex values."
     }
   ],
 

--- a/src/rules/declaration-property-value-no-unknown/index.js
+++ b/src/rules/declaration-property-value-no-unknown/index.js
@@ -101,7 +101,12 @@ function rule(primary, secondaryOptions) {
         "[ <'view-timeline-name'> [ <'view-timeline-axis'> || <'view-timeline-inset'> ]? ]#",
       ...secondaryOptions?.propertiesSyntax
     };
-    const typesSyntax = { ...secondaryOptions?.typesSyntax };
+    const typesSyntax = {
+      // Sass supports rgba(color, alpha).
+      // https://sass-lang.com/documentation/modules/#rgb
+      "rgba()": "| rgba( <hex-color> , <alpha-value>? )",
+      ...secondaryOptions?.typesSyntax
+    };
 
     /** @type {Map<string, string>} */
     const typedCustomPropertyNames = new Map();


### PR DESCRIPTION
Fixes #1118.