### PR TITLE
Improve double-slash-comment-whitespace-inside

### DIFF
--- a/src/rules/double-slash-comment-whitespace-inside/__tests__/index.js
+++ b/src/rules/double-slash-comment-whitespace-inside/__tests__/index.js
@@ -11,6 +11,7 @@ testRule({
   config: ["always"],
   customSyntax: "postcss-scss",
   skipBasicChecks: true,
+  fix: true,
 
   accept: [
     {
@@ -49,14 +50,14 @@ testRule({
   reject: [
     {
       code: "//Comment with no whitespace",
-      description: "{always} //Comment with no whitespace",
+      fixed: "// Comment with no whitespace",
       message: messages.expected,
       line: 1,
       column: 3
     },
     {
       code: "///3-slash comment with no whitespace",
-      description: "{always} ///3-slash comment with no whitespace",
+      fixed: "/// 3-slash comment with no whitespace",
       message: messages.expected,
       line: 1,
       column: 4
@@ -73,10 +74,20 @@ testRule({
         box-sizing: content-box; //2
       }
     `,
-      description: "\r\n\r\n\r\n\r\n  /// 3-slash comment with space.",
+      fixed: `
+      //
+      // 1. Address appearance set to searchfield in Safari and Chrome.
+      // 2. Address box-sizing set to border-box in Safari and Chrome.
+      //
+
+      input[type="search"] {
+        -webkit-appearance: textfield; // 1
+        box-sizing: content-box; // 2
+      }
+    `,
       message: messages.expected,
-      line: 11,
-      column: 1
+      line: 9,
+      column: 36
     },
     {
       code: `
@@ -87,10 +98,17 @@ testRule({
         box-sizing: content-box; //2
       }
     `,
-      description: "\r\n\r\n\r\n\r\n  /// 3-slash comment with space.",
+      fixed: `
+
+      input[type="search"] {
+
+        -webkit-appearance: textfield; // 1
+        box-sizing: content-box; // 2
+      }
+    `,
       message: messages.expected,
-      line: 7,
-      column: 1
+      line: 6,
+      column: 36
     }
   ]
 });
@@ -138,6 +156,7 @@ testRule({
   config: ["never"],
   customSyntax: "postcss-scss",
   skipBasicChecks: true,
+  fix: true,
 
   accept: [
     {
@@ -165,28 +184,28 @@ testRule({
   reject: [
     {
       code: "// Comment with one space",
-      description: "{never} // Comment with one space.",
+      fixed: "//Comment with one space",
       message: messages.rejected,
       line: 1,
       column: 3
     },
     {
       code: "//    Comment with multiple spaces",
-      description: "{never} //    Comment with multiple spaces.",
+      fixed: "//Comment with multiple spaces",
       message: messages.rejected,
       line: 1,
       column: 3
     },
     {
       code: "\n\n\n\n  /// 3-slash comment with space",
-      description: "\n\n\n\n  /// 3-slash comment with space.",
+      fixed: "\n\n\n\n  ///3-slash comment with space",
       message: messages.rejected,
       line: 5,
       column: 6
     },
     {
       code: "\r\n\r\n\r\n\r\n  /// 3-slash comment with space",
-      description: "\r\n\r\n\r\n\r\n  /// 3-slash comment with space.",
+      fixed: "\r\n\r\n\r\n\r\n  ///3-slash comment with space",
       message: messages.rejected,
       line: 5,
       column: 6
@@ -198,7 +217,12 @@ testRule({
 
       /// 3-slash comment with space
     `,
-      description: "\r\n\r\n\r\n\r\n  /// 3-slash comment with space.",
+      fixed: `
+
+
+
+      ///3-slash comment with space
+    `,
       message: messages.rejected,
       line: 5,
       column: 10

--- a/src/rules/double-slash-comment-whitespace-inside/index.js
+++ b/src/rules/double-slash-comment-whitespace-inside/index.js
@@ -1,8 +1,6 @@
 "use strict";
 
 const { utils } = require("stylelint");
-const eachRoot = require("../../utils/eachRoot");
-const findCommentsInRaws = require("../../utils/findCommentsInRaws");
 const namespace = require("../../utils/namespace");
 const ruleUrl = require("../../utils/ruleUrl");
 
@@ -14,10 +12,11 @@ const messages = utils.ruleMessages(ruleName, {
 });
 
 const meta = {
-  url: ruleUrl(ruleName)
+  url: ruleUrl(ruleName),
+  fixable: true
 };
 
-function rule(expectation) {
+function rule(expectation, options, context) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
       actual: expectation,
@@ -28,48 +27,53 @@ function rule(expectation) {
       return;
     }
 
-    eachRoot(root, checkRoot);
-
-    function checkRoot(root) {
-      const rootString = root.source.input.css;
-
-      if (rootString.trim() === "") {
+    root.walkComments(comment => {
+      if (comment.text.trim() === "") {
         return;
       }
 
-      const comments = findCommentsInRaws(rootString);
+      // Only process // comments
+      if (!comment.raws.inline && !comment.inline) {
+        return;
+      }
 
-      comments.forEach(comment => {
-        // Only process // comments
-        if (comment.type !== "double-slash") {
-          return;
-        }
+      let message;
 
-        // if it's `//` - no warning whatsoever; if `// ` - then trailing
-        // whitespace rule will govern this
-        if (comment.text === "") {
-          return;
-        }
+      if (
+        expectation === "never" &&
+        (comment.raws.left !== "" || /^\/+\s/.test(comment.raws.text))
+      ) {
+        message = messages.rejected;
+      } else if (
+        expectation === "always" &&
+        comment.raws.left === "" &&
+        !/^(\/)*(\s|$)/.test(comment.raws.text)
+      ) {
+        message = messages.expected;
+      } else {
+        return;
+      }
 
-        let message;
-
-        if (expectation === "never" && comment.raws.left !== "") {
-          message = messages.rejected;
-        } else if (comment.raws.left === "" && expectation === "always") {
-          message = messages.expected;
+      if (context.fix) {
+        if (expectation === "always") {
+          comment.raws.text = comment.raws.text.replace(/^(\/*)/, "$1 ");
         } else {
-          return;
+          comment.raws.left = "";
+          comment.raws.text = comment.raws.text.replace(/^(\/*)\s+/, "$1");
         }
+        return;
+      }
 
-        utils.report({
-          message,
-          node: root,
-          index: comment.source.start + comment.raws.startToken.length,
-          result,
-          ruleName
-        });
+      const extraSlashes = comment.raws.text.match(/^\/+/)?.[0]?.length || 0;
+
+      utils.report({
+        message,
+        node: root,
+        index: comment.source.start.offset + 2 + extraSlashes,
+        result,
+        ruleName
       });
-    }
+    });
   };
 }
 


### PR DESCRIPTION
This adds autofixing to the rule and fixes incorrect error locations:

<img width="386" alt="Screenshot 2025-05-02 at 14 55 45" src="https://github.com/user-attachments/assets/0cdf3e65-5f33-40cf-96c1-13e6a2ae036c" />
