### PR TITLE
Add `endIndex` to report objects in multiple rules

### DIFF
--- a/src/rules/at-else-if-parentheses-space-before/index.js
+++ b/src/rules/at-else-if-parentheses-space-before/index.js
@@ -57,7 +57,8 @@ function rule(value, _, context) {
             node: atRule,
             result,
             ruleName,
-            index: paramIndex + index
+            index: paramIndex + index,
+            endIndex: paramIndex + index
           })
       });
     });

--- a/src/rules/at-function-parentheses-space-before/index.js
+++ b/src/rules/at-function-parentheses-space-before/index.js
@@ -54,7 +54,8 @@ function rule(value, _, context) {
             node: atRule,
             result,
             ruleName,
-            index: baseIndex + paranIndex
+            index: baseIndex + paranIndex,
+            endIndex: baseIndex + paranIndex
           })
       });
     });

--- a/src/rules/at-if-closing-brace-newline-after/index.js
+++ b/src/rules/at-if-closing-brace-newline-after/index.js
@@ -88,7 +88,8 @@ function sassConditionalBraceNLAfterChecker({
       ruleName,
       node,
       message,
-      index
+      index,
+      endIndex: index
     });
   }
 

--- a/src/rules/at-if-closing-brace-space-after/index.js
+++ b/src/rules/at-if-closing-brace-space-after/index.js
@@ -71,7 +71,8 @@ function sassConditionalBraceSpaceAfterChecker({
       ruleName,
       node,
       message,
-      index
+      index,
+      endIndex: index
     });
   }
 

--- a/src/rules/at-mixin-parentheses-space-before/index.js
+++ b/src/rules/at-mixin-parentheses-space-before/index.js
@@ -54,7 +54,8 @@ function rule(value, _, context) {
             node: atRule,
             result,
             ruleName,
-            index: baseIndex + parenIndex
+            index: baseIndex + parenIndex,
+            endIndex: baseIndex + parenIndex
           })
       });
     });

--- a/src/rules/dollar-variable-colon-newline-after/index.js
+++ b/src/rules/dollar-variable-colon-newline-after/index.js
@@ -105,6 +105,7 @@ function rule(expectation, options, context) {
               message: m,
               node: decl,
               index: indexToCheck,
+              endIndex: indexToCheck,
               result,
               ruleName
             });

--- a/src/rules/dollar-variable-colon-space-after/index.js
+++ b/src/rules/dollar-variable-colon-space-after/index.js
@@ -106,6 +106,7 @@ function variableColonSpaceChecker({
             message: m,
             node: decl,
             index: i,
+            endIndex: i,
             result,
             ruleName: checkedRuleName
           });

--- a/src/rules/double-slash-comment-whitespace-inside/index.js
+++ b/src/rules/double-slash-comment-whitespace-inside/index.js
@@ -70,6 +70,7 @@ function rule(expectation, options, context) {
         message,
         node: root,
         index: comment.source.start.offset + 2 + extraSlashes,
+        endIndex: comment.source.start.offset + 2 + extraSlashes,
         result,
         ruleName
       });


### PR DESCRIPTION
Ensure all report objects include `endIndex`. This change affects various rules.
The change fixes the deprecation in stylelints utils.report() which is currently blocking linting in IDEs like Webstorm. See https://github.com/stylelint/stylelint/issues/8505
