### PR TITLE
dollar-variable-colon-space-after: prevent TypeError for dynamically created nodes

### DIFF
--- a/src/rules/dollar-variable-colon-space-after/index.js
+++ b/src/rules/dollar-variable-colon-space-after/index.js
@@ -72,6 +72,8 @@ function variableColonSpaceChecker({
         return;
       }
 
+      if (!decl.raws.between) return;
+
       if (position === "before") {
         const replacement = expectation === "never" ? ":" : " :";
 


### PR DESCRIPTION
Good day :)

The `dollar-variable-colon-space-after` rule fails on dynamically created declarations - this PR fixes the issue.

---

I'm developing a Stylelint plugin, and one of the rules in it can append new `$-variable` declaration to a rule:

Before:

```scss
// Error: The component lacks a variable referencing the block: "$b"
.the-component {}
```

After fix:

```scss
.the-component {
  $b: #{&};
}
```

The rule works fine in isolation, but when used in a shared config where `'scss/dollar-variable-colon-space-after': 'at-least-one-space'` is configured, it throws the following error:

> TypeError: Cannot read properties of undefined (reading 'replace') at .../stylelint-scss/src/rules/dollar-variable-colon-space-after/index.js:78:47

The problem is that all properties in `declaration.raws` [are not guaranteed to exist](https://github.com/postcss/postcss/blob/c18159719e4a6d65ad7085edf1dc42e07814f683/lib/declaration.d.ts#L5).
In this case, `declaration.raws.between` is `undefined` for the dynamically created declaration - and the rule doesn't check for that.

This PR adds the necessary check :)
I've tested it locally, and everything works as expected after the fix.