### PR TITLE
Handle mixin calls with content block arguments in `at-mixin-argumentless-call-parentheses` rule

### DIFF
--- a/src/rules/at-mixin-argumentless-call-parentheses/__tests__/index.js
+++ b/src/rules/at-mixin-argumentless-call-parentheses/__tests__/index.js
@@ -11,72 +11,475 @@ testRule({
   accept: [
     {
       code: `
-      @include foo ;
-    `,
+        @include foo ;
+      `,
       description: "No parens; space after mixin name in a call."
     },
     {
       code: `
-      @include foo;
-    `,
+        @include foo;
+      `,
       description: "No parens; no space after mixin name in a call."
     },
     {
       code: `
-      @include foo ("()") ;
-    `,
-      description: "With parens and arguments, '()' as ans argument."
+        @include foo using ($argument) ;
+      `,
+      description:
+        "No parens with content block arguments; space after mixin call."
+    },
+    {
+      code: `
+        @include foo using($argument) ;
+      `,
+      description:
+        "No parens with content block arguments; no space after 'using', space after mixin call."
+    },
+    {
+      code: `
+        @include foo using ($argument);
+      `,
+      description:
+        "No parens with content block arguments; no space after mixin call."
+    },
+    {
+      code: `
+        @include foo using($argument);
+      `,
+      description:
+        "No parens with content block arguments; no space after 'using', no space after mixin call."
+    },
+    {
+      code: `
+        @include foo ("()") ;
+      `,
+      description:
+        "With parens and arguments, '()' as an argument; space after mixin call."
+    },
+    {
+      code: `
+        @include foo ("()") using ($argument) ;
+      `,
+      description:
+        "With parens, arguments and content block arguments, '()' as an argument; space after mixin call."
+    },
+    {
+      code: `
+        @include foo ("()") using($argument) ;
+      `,
+      description:
+        "With parens, arguments and content block arguments, '()' as an argument; no space after 'using', space after mixin call."
+    },
+    // Special tests for mixin names containing "using"
+    {
+      code: `
+        @include using using ($argument);
+      `,
+      description:
+        "No parens with content block arguments; mixin name is 'using'."
+    },
+    {
+      code: `
+        @include focusing using ($argument);
+      `,
+      description:
+        "No parens with content block arguments; mixin name contains 'using'."
+    },
+    {
+      code: `
+        @include using ("()") using ($argument);
+      `,
+      description:
+        "With parens, arguments and content block arguments, '()' as an argument; mixin name is 'using'."
+    },
+    {
+      code: `
+        @include focusing ("()") using ($argument);
+      `,
+      description:
+        "With parens, arguments and content block arguments, '()' as an argument; mixin name contains 'using'."
     }
   ],
 
   reject: [
     {
       code: `
-      @include foo () ;
-    `,
+        @include foo () ;
+      `,
       fixed: `
-      @include foo ;
-    `,
+        @include foo ;
+      `,
       line: 2,
-      column: 16,
+      column: 18,
       endLine: 2,
-      endColumn: 19,
+      endColumn: 21,
       message: messages.rejected("foo"),
       description: "With parens, no space between them."
     },
     {
       code: `
-      @include foo ( ) ;
-    `,
+        @include foo () using ($argument) ;
+      `,
       fixed: `
-      @include foo ;
-    `,
+        @include foo using ($argument) ;
+      `,
       line: 2,
+      column: 18,
+      endLine: 2,
+      endColumn: 21,
       message: messages.rejected("foo"),
-      description: "With parens, space between them"
+      description:
+        "With parens and content block arguments; no space between parens."
     },
     {
       code: `
-      @include foo( ) ;
-    `,
+        @include foo () using($argument) ;
+      `,
       fixed: `
-      @include foo ;
-    `,
+        @include foo using($argument) ;
+      `,
       line: 2,
+      column: 18,
+      endLine: 2,
+      endColumn: 21,
       message: messages.rejected("foo"),
-      description: "With parens, no space before and space between them"
+      description:
+        "With parens and content block arguments; no space between parens, no space after 'using'."
     },
     {
       code: `
-      @include foo(
-      ) ;
-    `,
+        @include foo ()using($argument) ;
+      `,
       fixed: `
-      @include foo ;
-    `,
+        @include foo using($argument) ;
+      `,
+      line: 2,
+      column: 18,
+      endLine: 2,
+      endColumn: 21,
+      message: messages.rejected("foo"),
+      description:
+        "With parens and content block arguments; no space between parens, no space around 'using'."
+    },
+    {
+      code: `
+        @include foo()using($argument) ;
+      `,
+      fixed: `
+        @include foo using($argument) ;
+      `,
+      line: 2,
+      column: 18,
+      endLine: 2,
+      endColumn: 21,
+      message: messages.rejected("foo"),
+      description:
+        "With parens and content block arguments; no space before parens, no space after parens, no space around 'using'."
+    },
+    {
+      code: `
+        @include foo ( ) ;
+      `,
+      fixed: `
+        @include foo ;
+      `,
       line: 2,
       message: messages.rejected("foo"),
-      description: "With parens, newline between them"
+      description: "With parens, space between them."
+    },
+    {
+      code: `
+        @include foo ( ) using ($argument) ;
+      `,
+      fixed: `
+        @include foo using ($argument) ;
+      `,
+      line: 2,
+      message: messages.rejected("foo"),
+      description:
+        "With parens and content block arguments; space between parens, space after 'using'."
+    },
+    {
+      code: `
+        @include foo ( ) using($argument) ;
+      `,
+      fixed: `
+        @include foo using($argument) ;
+      `,
+      line: 2,
+      message: messages.rejected("foo"),
+      description:
+        "With parens and content block arguments; space between parens, no space after 'using'."
+    },
+    {
+      code: `
+        @include foo( ) ;
+      `,
+      fixed: `
+        @include foo ;
+      `,
+      line: 2,
+      message: messages.rejected("foo"),
+      description: "With parens, no space before and space between them."
+    },
+    {
+      code: `
+        @include foo( ) using ($argument) ;
+      `,
+      fixed: `
+        @include foo using ($argument) ;
+      `,
+      line: 2,
+      message: messages.rejected("foo"),
+      description:
+        "With parens and content block arguments; no space before and space between parens, space after 'using'."
+    },
+    {
+      code: `
+        @include foo( ) using($argument) ;
+      `,
+      fixed: `
+        @include foo using($argument) ;
+      `,
+      line: 2,
+      message: messages.rejected("foo"),
+      description:
+        "With parens and content block arguments; no space before and space between parens, no space after 'using'."
+    },
+    {
+      code: `
+        @include foo(
+        ) ;
+      `,
+      fixed: `
+        @include foo ;
+      `,
+      line: 2,
+      message: messages.rejected("foo"),
+      description: "With parens, newline between them."
+    },
+    {
+      code: `
+        @include foo(
+        ) using ($argument) ;
+      `,
+      fixed: `
+        @include foo using ($argument) ;
+      `,
+      line: 2,
+      message: messages.rejected("foo"),
+      description:
+        "With parens and content block arguments; newline between parens, space after 'using'."
+    },
+    {
+      code: `
+        @include foo(
+        ) using($argument) ;
+      `,
+      fixed: `
+        @include foo using($argument) ;
+      `,
+      line: 2,
+      message: messages.rejected("foo"),
+      description:
+        "With parens and content block arguments; newline between parens, no space after 'using'."
+    },
+    {
+      code: `
+        @include foo(
+        )using($argument) ;
+      `,
+      fixed: `
+        @include foo using($argument) ;
+      `,
+      line: 2,
+      message: messages.rejected("foo"),
+      description:
+        "With parens and content block arguments; newline between parens, no space around 'using'."
+    },
+    // Special tests for mixin names containing "using"
+    {
+      code: `
+        @include using () ;
+      `,
+      fixed: `
+        @include using ;
+      `,
+      line: 2,
+      column: 18,
+      endLine: 2,
+      endColumn: 23,
+      message: messages.rejected("using"),
+      description: "With parens, no space between them; mixin name is 'using'."
+    },
+    {
+      code: `
+        @include using () using ($argument) ;
+      `,
+      fixed: `
+        @include using using ($argument) ;
+      `,
+      line: 2,
+      column: 18,
+      endLine: 2,
+      endColumn: 23,
+      message: messages.rejected("using"),
+      description:
+        "With parens and content block arguments; no space between parens, space after 'using', mixin name is 'using'."
+    },
+    {
+      code: `
+        @include using () using($argument) ;
+      `,
+      fixed: `
+        @include using using($argument) ;
+      `,
+      line: 2,
+      column: 18,
+      endLine: 2,
+      endColumn: 23,
+      message: messages.rejected("using"),
+      description:
+        "With parens and content block arguments; no space between parens, no space after 'using', mixin name is 'using'."
+    },
+    {
+      code: `
+        @include using ()using($argument) ;
+      `,
+      fixed: `
+        @include using using($argument) ;
+      `,
+      line: 2,
+      column: 18,
+      endLine: 2,
+      endColumn: 23,
+      message: messages.rejected("using"),
+      description:
+        "With parens and content block arguments; no space between parens, no space around 'using', mixin name is 'using'."
+    },
+    {
+      code: `
+        @include using()using($argument) ;
+      `,
+      fixed: `
+        @include using using($argument) ;
+      `,
+      line: 2,
+      column: 18,
+      endLine: 2,
+      endColumn: 23,
+      message: messages.rejected("using"),
+      description:
+        "With parens and content block arguments; no space before parens, no space after parens, no space around 'using', mixin name is 'using'."
+    },
+    {
+      code: `
+        @include using ( ) ;
+      `,
+      fixed: `
+        @include using ;
+      `,
+      line: 2,
+      message: messages.rejected("using"),
+      description: "With parens, space between them; mixin name is 'using'."
+    },
+    {
+      code: `
+        @include using ( ) using ($argument) ;
+      `,
+      fixed: `
+        @include using using ($argument) ;
+      `,
+      line: 2,
+      message: messages.rejected("using"),
+      description:
+        "With parens and content block arguments; space between parens, mixin name is 'using'."
+    },
+    {
+      code: `
+        @include using ( ) using($argument) ;
+      `,
+      fixed: `
+        @include using using($argument) ;
+      `,
+      line: 2,
+      message: messages.rejected("using"),
+      description:
+        "With parens and content block arguments; space between parens, no space after 'using', mixin name is 'using'."
+    },
+    {
+      code: `
+        @include using( ) ;
+      `,
+      fixed: `
+        @include using ;
+      `,
+      line: 2,
+      message: messages.rejected("using"),
+      description:
+        "With parens, no space before and space between them; mixin name is 'using'."
+    },
+    {
+      code: `
+        @include using( ) using ($argument) ;
+      `,
+      fixed: `
+        @include using using ($argument) ;
+      `,
+      line: 2,
+      message: messages.rejected("using"),
+      description:
+        "With parens and content block arguments; no space before and space between parens, space after 'using', mixin name is 'using'."
+    },
+    {
+      code: `
+        @include using( ) using($argument) ;
+      `,
+      fixed: `
+        @include using using($argument) ;
+      `,
+      line: 2,
+      message: messages.rejected("using"),
+      description:
+        "With parens and content block arguments; no space before and space between parens, no space after 'using', mixin name is 'using'."
+    },
+    {
+      code: `
+        @include using(
+        ) ;
+      `,
+      fixed: `
+        @include using ;
+      `,
+      line: 2,
+      message: messages.rejected("using"),
+      description: "With parens, newline between them; mixin name is 'using'."
+    },
+    {
+      code: `
+        @include using(
+        ) using ($argument) ;
+      `,
+      fixed: `
+        @include using using ($argument) ;
+      `,
+      line: 2,
+      message: messages.rejected("using"),
+      description:
+        "With parens and content block arguments; newline between parens, space after 'using', mixin name is 'using'."
+    },
+    {
+      code: `
+        @include using(
+        ) using($argument) ;
+      `,
+      fixed: `
+        @include using using($argument) ;
+      `,
+      line: 2,
+      message: messages.rejected("using"),
+      description:
+        "With parens and content block arguments; newline between parens, no space after 'using', mixin name is 'using'."
     }
   ]
 });
@@ -90,67 +493,364 @@ testRule({
   accept: [
     {
       code: `
-      @include foo ();
-    `,
+        @include foo ();
+      `,
       description: "With parens, no space between them."
     },
     {
       code: `
-      @include foo ( );
-    `,
-      description: "With parens, space between them"
+        @include foo () using ($argument);
+      `,
+      description:
+        "With parens and content block arguments; no space between parens, space after 'using'."
     },
     {
       code: `
-      @include foo( 10)
-    `,
-      description: "With parens, no space before and space between them"
+        @include foo () using($argument);
+      `,
+      description:
+        "With parens and content block arguments; no space between parens, no space after 'using'."
     },
     {
       code: `
-      @include foo
-      (10)
-    `,
-      description: "With parens, newline between them"
+        @include foo ()using($argument);
+      `,
+      description:
+        "With parens and content block arguments; no space between parens, no space around 'using'."
+    },
+    {
+      code: `
+        @include foo ( );
+      `,
+      description: "With parens, space between them."
+    },
+    {
+      code: `
+        @include foo ( ) using ($argument);
+      `,
+      description:
+        "With parens and content block arguments; space between parens, space after 'using'."
+    },
+    {
+      code: `
+        @include foo ( ) using($argument);
+      `,
+      description:
+        "With parens and content block arguments; space between parens, no space after 'using'."
+    },
+    {
+      code: `
+        @include foo( 10)
+      `,
+      description: "With parens, no space before and space between them."
+    },
+    {
+      code: `
+        @include foo( 10) using ($argument)
+      `,
+      description:
+        "With parens and content block arguments; no space before and space between parens, space after 'using'."
+    },
+    {
+      code: `
+        @include foo( 10) using($argument)
+      `,
+      description:
+        "With parens and content block arguments; no space before and space between parens, no space after 'using'."
+    },
+    {
+      code: `
+        @include foo
+        (10)
+      `,
+      description: "With parens, newline before them."
+    },
+    {
+      code: `
+        @include foo
+        (10) using ($argument)
+      `,
+      description:
+        "With parens and content block arguments; newline before parens."
+    },
+    {
+      code: `
+        @include foo
+        (10)
+        using ($argument)
+      `,
+      description:
+        "With parens and content block arguments; newline before parens, newline before 'using'."
+    },
+    {
+      code: `
+        @include foo
+        (10) using($argument)
+      `,
+      description:
+        "With parens and content block arguments; newline before parens, no space after 'using'."
+    },
+    {
+      code: `
+        @include foo
+        (10)
+        using($argument)
+      `,
+      description:
+        "With parens and content block arguments; newline before parens, newline before 'using', no space after 'using'."
     }
   ],
 
   reject: [
     {
       code: `
-      @include foo;
-    `,
+        @include foo;
+      `,
       fixed: `
-      @include foo ();
-    `,
+        @include foo();
+      `,
       line: 2,
-      column: 16,
+      column: 18,
       endLine: 2,
-      endColumn: 19,
+      endColumn: 21,
       message: messages.expected("foo"),
       description: "No parens."
     },
     {
       code: `
-      @include foo ;
-    `,
+        @include foo ;
+      `,
       fixed: `
-      @include foo () ;
-    `,
+        @include foo() ;
+      `,
       line: 2,
       message: messages.expected("foo"),
-      description: "No parens; a space after mixin name in a call."
+      description: "No parens; space after mixin name in a call."
     },
     {
       code: `
-      @include foo
-    `,
+        @include foo
+      `,
       fixed: `
-      @include foo ()
-    `,
+        @include foo()
+      `,
       line: 2,
       message: messages.expected("foo"),
       description: "No parens; no trailing semicolon."
+    },
+    {
+      code: `
+        @include foo using ($argument);
+      `,
+      fixed: `
+        @include foo() using ($argument);
+      `,
+      line: 2,
+      column: 18,
+      endLine: 2,
+      endColumn: 21,
+      message: messages.expected("foo"),
+      description:
+        "No parens with content block arguments; space after 'using'."
+    },
+    {
+      code: `
+        @include foo using($argument);
+      `,
+      fixed: `
+        @include foo() using($argument);
+      `,
+      line: 2,
+      column: 18,
+      endLine: 2,
+      endColumn: 21,
+      message: messages.expected("foo"),
+      description:
+        "No parens with content block arguments; no space after 'using'."
+    },
+    {
+      code: `
+        @include foo using ($argument) ;
+      `,
+      fixed: `
+        @include foo() using ($argument) ;
+      `,
+      line: 2,
+      message: messages.expected("foo"),
+      description:
+        "No parens with content block arguments; space after mixin call, space after 'using'."
+    },
+    {
+      code: `
+        @include foo using($argument) ;
+      `,
+      fixed: `
+        @include foo() using($argument) ;
+      `,
+      line: 2,
+      message: messages.expected("foo"),
+      description:
+        "No parens with content block arguments; space after mixin call, no space after 'using'."
+    },
+    {
+      code: `
+        @include foo using ($argument)
+      `,
+      fixed: `
+        @include foo() using ($argument)
+      `,
+      line: 2,
+      message: messages.expected("foo"),
+      description:
+        "No parens with content block arguments; space after 'using', no trailing semicolon."
+    },
+    {
+      code: `
+        @include foo using($argument)
+      `,
+      fixed: `
+        @include foo() using($argument)
+      `,
+      line: 2,
+      message: messages.expected("foo"),
+      description:
+        "No parens with content block arguments; no space after 'using', no trailing semicolon."
+    },
+    // Special tests for mixin names containing "using"
+    {
+      code: `
+        @include using;
+      `,
+      fixed: `
+        @include using();
+      `,
+      line: 2,
+      column: 18,
+      endLine: 2,
+      endColumn: 23,
+      message: messages.expected("using"),
+      description: "No parens, mixin name is 'using'."
+    },
+    {
+      code: `
+        @include focusing;
+      `,
+      fixed: `
+        @include focusing();
+      `,
+      line: 2,
+      column: 18,
+      endLine: 2,
+      endColumn: 26,
+      message: messages.expected("focusing"),
+      description: "No parens, mixin name contains 'using'."
+    },
+    {
+      code: `
+        @include using ;
+      `,
+      fixed: `
+        @include using() ;
+      `,
+      line: 2,
+      message: messages.expected("using"),
+      description:
+        "No parens; space after mixin name in a call, mixin name is 'using'."
+    },
+    {
+      code: `
+        @include focusing ;
+      `,
+      fixed: `
+        @include focusing() ;
+      `,
+      line: 2,
+      message: messages.expected("focusing"),
+      description:
+        "No parens; space after mixin name in a call, mixin name contains 'using'."
+    },
+    {
+      code: `
+        @include using
+      `,
+      fixed: `
+        @include using()
+      `,
+      line: 2,
+      message: messages.expected("using"),
+      description: "No parens; no trailing semicolon, mixin name is 'using'."
+    },
+    {
+      code: `
+        @include focusing
+      `,
+      fixed: `
+        @include focusing()
+      `,
+      line: 2,
+      message: messages.expected("focusing"),
+      description:
+        "No parens; no trailing semicolon, mixin name contains 'using'."
+    },
+    {
+      code: `
+        @include using using ($argument);
+      `,
+      fixed: `
+        @include using() using ($argument);
+      `,
+      line: 2,
+      column: 18,
+      endLine: 2,
+      endColumn: 23,
+      message: messages.expected("using"),
+      description:
+        "No parens with content block arguments; mixin name is 'using', space after 'using'."
+    },
+    {
+      code: `
+        @include using using($argument);
+      `,
+      fixed: `
+        @include using() using($argument);
+      `,
+      line: 2,
+      column: 18,
+      endLine: 2,
+      endColumn: 23,
+      message: messages.expected("using"),
+      description:
+        "No parens with content block arguments; mixin name is 'using', no space after 'using'."
+    },
+    {
+      code: `
+        @include focusing using ($argument);
+      `,
+      fixed: `
+        @include focusing() using ($argument);
+      `,
+      line: 2,
+      column: 18,
+      endLine: 2,
+      endColumn: 26,
+      message: messages.expected("focusing"),
+      description:
+        "No parens with content block arguments; mixin name contains 'using', space after 'using'."
+    },
+    {
+      code: `
+        @include focusing using($argument);
+      `,
+      fixed: `
+        @include focusing() using($argument);
+      `,
+      line: 2,
+      column: 18,
+      endLine: 2,
+      endColumn: 26,
+      message: messages.expected("focusing"),
+      description:
+        "No parens with content block arguments; mixin name contains 'using', no space after 'using'."
     }
   ]
 });

--- a/src/rules/at-mixin-argumentless-call-parentheses/index.js
+++ b/src/rules/at-mixin-argumentless-call-parentheses/index.js
@@ -28,27 +28,41 @@ function rule(value, _, context) {
     }
 
     root.walkAtRules("include", mixinCall => {
+      // Remove the "using (...)" part of the mixin call if present and save it for later.
+      // We only care about whether there are parentheses after the mixin name and before any "using" clause.
+      // Note that the mixin name itself can be "using" or contain "using".
+      const usingClauseRegex = /([) ]+)(\busing\s*\([^)]+\)+\s*)$/;
+      const usingClauseMatch = mixinCall.params.match(usingClauseRegex);
+      const usingClause = usingClauseMatch?.[2] ?? "";
+
+      const mixinCallParams = mixinCall.params
+        .replace(usingClauseRegex, "$1")
+        .trim();
+
       // If it is "No parens in argumentless calls"
-      if (value === "never" && mixinCall.params.search(/\(\s*\)\s*$/) === -1) {
+      if (value === "never" && mixinCallParams.search(/\(\s*\)\s*$/) === -1) {
         return;
       }
 
       // If it is "Always use parens"
-      if (value === "always" && mixinCall.params.search(/\(/) !== -1) {
+      if (value === "always" && mixinCallParams.search(/\(/) !== -1) {
         return;
       }
 
       if (context.fix) {
         if (value === "always") {
-          mixinCall.params = `${mixinCall.params} ()`;
+          mixinCall.params = `${mixinCallParams}()`;
         } else {
-          mixinCall.params = mixinCall.params.replace(/\s*\([\s\S]*?\)$/, "");
+          mixinCall.params = mixinCallParams.replace(/\s*\([\s\S]*?\)\s*$/, "");
         }
+
+        // Restore the "using (...)" part if it was present.
+        mixinCall.params += usingClause ? ` ${usingClause}` : "";
 
         return;
       }
 
-      const mixinName = /\s*(\S*?)\s*(?:\(|$)/.exec(mixinCall.params)[1];
+      const mixinName = /\s*(\S*?)\s*(?:\(|$)/.exec(mixinCallParams)[1];
 
       utils.report({
         message:


### PR DESCRIPTION
Fixes https://github.com/stylelint-scss/stylelint-scss/issues/1184