### PR TITLE
Add rule 'at-mixin-call-parentheses-space-before'

### DIFF
--- a/src/rules/at-mixin-call-parentheses-space-before/README.md
+++ b/src/rules/at-mixin-call-parentheses-space-before/README.md
@@ -1,0 +1,58 @@
+# at-mixin-call-parentheses-space-before
+
+Require or disallow a space before `@include` parentheses.
+
+```scss
+@include foo ($arg)
+/**        ↑
+ * The space before this parenthesis */
+```
+
+The [`fix` option](https://stylelint.io/user-guide/usage/options#fix) can automatically fix all of the problems reported by this rule.
+
+## Options
+
+`string`: `"always"|"never"`
+
+### `"always"`
+
+There *must always* be exactly one space between the mixin name and the opening parenthesis.
+
+*Note: This rule does not enforce parentheses to be present in a declaration without arguments.*
+
+The following patterns are considered warnings:
+
+```scss
+@include foo($arg)
+```
+```scss
+@include foo  ($arg)
+```
+
+The following patterns are *not* considered warnings:
+
+```scss
+@include foo ($arg)
+```
+```scss
+@include foo
+```
+
+### `"never"`
+
+There *must never* be any whitespace between the mixin name and the opening parenthesis.
+
+The following patterns are considered warnings:
+
+```scss
+@include foo ($arg)
+```
+
+The following patterns are *not* considered warnings:
+
+```scss
+@include foo($arg)
+```
+```scss
+@include foo
+```

--- a/src/rules/at-mixin-call-parentheses-space-before/__tests__/index.js
+++ b/src/rules/at-mixin-call-parentheses-space-before/__tests__/index.js
@@ -1,0 +1,213 @@
+"use strict";
+
+const { messages, ruleName } = require("..");
+
+testRule({
+  ruleName,
+  config: ["always"],
+  customSyntax: "postcss-scss",
+  fix: true,
+
+  accept: [
+    {
+      code: `
+      @include foo ()
+    `,
+      description: "No params with parentheses."
+    },
+    {
+      code: `
+      @include foo
+    `,
+      description: "No params without parentheses."
+    },
+    {
+      code: `
+      @include foo ($links: 10)
+    `,
+      description: "With default params."
+    },
+    {
+      code: `
+      @include foo ($n)
+    `,
+      description: "With params."
+    },
+    {
+      code: `
+      @include  foo ($n)
+    `,
+      description: "Extra spaces after @include."
+    },
+    {
+      code: `
+      @bar foo ($n)
+    `,
+      description: "Not a SCSS include, skipping."
+    },
+    {
+      code: `
+      @include foo-bar ()
+    `,
+      description: "No params with parentheses, hyphenated name."
+    }
+  ],
+
+  reject: [
+    {
+      code: `
+      @include
+      foo
+      ($n)
+    `,
+      fixed: `
+      @include
+      foo ($n)
+    `,
+      line: 4,
+      column: 7,
+      endLine: 4,
+      endColumn: 8,
+      message: messages.expectedBefore(),
+      description: "Newline after mixin name"
+    },
+    {
+      code: `
+      @include foo($n)
+    `,
+      fixed: `
+      @include foo ($n)
+    `,
+      line: 2,
+      message: messages.expectedBefore(),
+      description: "No space before parentheses."
+    },
+    {
+      code: `
+      @include  foo($n)
+    `,
+      fixed: `
+      @include  foo ($n)
+    `,
+      line: 2,
+      message: messages.expectedBefore(),
+      description: "Extra spaces after @include."
+    },
+    {
+      code: `
+      @include foo-bar($n)
+    `,
+      fixed: `
+      @include foo-bar ($n)
+    `,
+      line: 2,
+      message: messages.expectedBefore(),
+      description: "No space before parentheses, hyphenated name."
+    }
+  ]
+});
+
+testRule({
+  ruleName,
+  config: ["never"],
+  customSyntax: "postcss-scss",
+  fix: true,
+
+  accept: [
+    {
+      code: `
+      @include foo()
+    `,
+      description: "No params with parentheses."
+    },
+    {
+      code: `
+      @include foo
+    `,
+      description: "No params without parentheses."
+    },
+    {
+      code: `
+      @include foo($links: 10)
+    `,
+      description: "With default params."
+    },
+    {
+      code: `
+      @include foo($n)
+    `,
+      description: "With params."
+    },
+    {
+      code: `
+      @include  foo($n)
+    `,
+      description: "Extra spaces after @include."
+    },
+    {
+      code: `
+      @bar foo($n)
+    `,
+      description: "Not a SCSS include, skipping."
+    },
+    {
+      code: `
+      @include foo-bar()
+    `,
+      description: "No params with parentheses, hyphenated name."
+    }
+  ],
+
+  reject: [
+    {
+      code: `
+      @include
+      foo
+      ($n)
+    `,
+      fixed: `
+      @include
+      foo($n)
+    `,
+      line: 4,
+      column: 7,
+      endLine: 4,
+      endColumn: 8,
+      message: messages.rejectedBefore(),
+      description: "Newline after mixin name"
+    },
+    {
+      code: `
+      @include foo ($n)
+    `,
+      fixed: `
+      @include foo($n)
+    `,
+      line: 2,
+      message: messages.rejectedBefore(),
+      description: "Single space before parentheses."
+    },
+    {
+      code: `
+      @include foo  ($n)
+    `,
+      fixed: `
+      @include foo($n)
+    `,
+      line: 2,
+      message: messages.rejectedBefore(),
+      description: "Multiple spaces before parentheses."
+    },
+    {
+      code: `
+      @include foo-bar ($n)
+    `,
+      fixed: `
+      @include foo-bar($n)
+    `,
+      line: 2,
+      message: messages.rejectedBefore(),
+      description: "Single space before parentheses, hyphenated name."
+    }
+  ]
+});

--- a/src/rules/at-mixin-call-parentheses-space-before/index.js
+++ b/src/rules/at-mixin-call-parentheses-space-before/index.js
@@ -1,0 +1,69 @@
+"use strict";
+
+const { utils } = require("stylelint");
+const atRuleParamIndex = require("../../utils/atRuleParamIndex");
+const whitespaceChecker = require("../../utils/whitespaceChecker");
+const namespace = require("../../utils/namespace");
+const ruleUrl = require("../../utils/ruleUrl");
+
+const ruleName = namespace("at-mixin-call-parentheses-space-before");
+
+const messages = utils.ruleMessages(ruleName, {
+  rejectedBefore: () =>
+    "Unexpected whitespace before parentheses in mixin call",
+  expectedBefore: () =>
+    "Expected a single space before parentheses in mixin call"
+});
+
+const meta = {
+  url: ruleUrl(ruleName)
+};
+
+function rule(value, _, context) {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: value,
+      possible: ["always", "never"]
+    });
+
+    if (!validOptions) {
+      return;
+    }
+
+    const match = /^([\w-]+)\s*\(/;
+    const replacement = value === "always" ? "$1 (" : "$1(";
+
+    const checker = whitespaceChecker("space", value, messages).before;
+
+    root.walkAtRules("include", atRule => {
+      if (context.fix) {
+        atRule.params = atRule.params.replace(match, replacement);
+
+        return;
+      }
+
+      const parenIndex = atRule.params.indexOf("(");
+      const baseIndex = atRuleParamIndex(atRule);
+
+      checker({
+        source: atRule.params,
+        index: parenIndex,
+        err: message =>
+          utils.report({
+            message,
+            node: atRule,
+            result,
+            ruleName,
+            index: baseIndex + parenIndex,
+            endIndex: baseIndex + parenIndex
+          })
+      });
+    });
+  };
+}
+
+rule.ruleName = ruleName;
+rule.messages = messages;
+rule.meta = meta;
+
+module.exports = rule;

--- a/src/rules/index.js
+++ b/src/rules/index.js
@@ -22,6 +22,7 @@ const rules = {
   "at-import-partial-extension-whitelist": require("./at-import-partial-extension-whitelist"),
   "at-import-partial-extension": require("./at-import-partial-extension"),
   "at-mixin-argumentless-call-parentheses": require("./at-mixin-argumentless-call-parentheses"),
+  "at-mixin-call-parentheses-space-before": require("./at-mixin-call-parentheses-space-before"),
   "at-mixin-named-arguments": require("./at-mixin-named-arguments"),
   "at-mixin-parentheses-space-before": require("./at-mixin-parentheses-space-before"),
   "at-mixin-pattern": require("./at-mixin-pattern"),


### PR DESCRIPTION
Hello, I want to enforce a linter rule in a project that currently has a mix of

```scss
@include my-mixin();
@include my-mixin ();
```

I straight up copied `at-mixin-parentheses-space-before`. I have never maintained linter rules before, so I’m not sure whether that’s fine.

I was tempted to name it `at-include-parentheses-space-before`, but I saw there is `at-mixin-argumentless-call-parentheses`, so I named it `at-mixin-call-*` too.
