### PR TITLE
Add missing link to load-partial-extension docs

### DIFF
--- a/src/rules/load-partial-extension/README.md
+++ b/src/rules/load-partial-extension/README.md
@@ -1,6 +1,6 @@
 # load-partial-extension
 
-Require or disallow extension in `@import`, `@use`, `@forward`, and [`meta.load-css`] commands.
+Require or disallow extension in `@import`, `@use`, `@forward`, and [`meta.load-css`](https://sass-lang.com/documentation/modules/meta/#load-css) commands.
 
 ```scss
 @use "file.scss";


### PR DESCRIPTION
Looks like a copy-paste mistake from `load-no-partial-leading-underscore`. Hope this helps!