### PR TITLE
Prepare version 6.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# 6.13.0
+
+- Added: `at-mixin-argumentless-call-parentheses` handle mixin calls with content block arguments (#1185).
+- Added: `at-function-pattern`, `at-mixin-pattern`, `dollar-variable-pattern`, `percent-placeholder-pattern` add support for arguments in custom messages (#1187).
+- Added: `dollar-variable-no-missing-interpolation` check for CSS custom properties, add autofix, rule documentation improvements (#1195).
+- Fixed: `dollar-variable-colon-space-after` prevent TypeError for dynamically created nodes (#1159).
+- Fixed: `load-partial-extension` add missing link to docs (#1202).
+- Fixed: migrate rules to use autofix callback instead of deprecated `context.fix` (#1206).
+- Updated: `stylelint` peer dependency version to `^16.8.2` (required by autofix callback) (#1206).
+
+**Full Changelog**: https://github.com/stylelint-scss/stylelint-scss/compare/v6.12.1...v6.13.0
+
 # 6.12.1
 
 - Fixed: `stylelint` deprecation warnings by adding `endIndex` to report objects in multiple rules (#1150).


### PR DESCRIPTION
- Added: `at-mixin-argumentless-call-parentheses` handle mixin calls with content block arguments (#1185).
- Added: `at-function-pattern`, `at-mixin-pattern`, `dollar-variable-pattern`, `percent-placeholder-pattern` add support for arguments in custom messages (#1187).
- Added: `dollar-variable-no-missing-interpolation` check for CSS custom properties, add autofix, rule documentation improvements (#1195).
- Fixed: `dollar-variable-colon-space-after` prevent TypeError for dynamically created nodes (#1159).
- Fixed: `load-partial-extension` add missing link to docs (#1202).
- Fixed: migrate rules to use autofix callback instead of deprecated `context.fix` (#1206).
- Updated: `stylelint` peer dependency version to `^16.8.2` (required by autofix callback) (#1206).

**Full Changelog**: https://github.com/stylelint-scss/stylelint-scss/compare/v6.12.1...v6.13.0