### PR TITLE
Fix: check disallowed functions inside @return expressions (#1151)

### DIFF
--- a/src/rules/function-disallowed-list/__tests__/index.js
+++ b/src/rules/function-disallowed-list/__tests__/index.js
@@ -94,3 +94,24 @@ testRule({
     }
   ]
 });
+
+// Testing @return expression
+testRule({
+  ruleName,
+  config: ["random"],
+  customSyntax: "postcss-scss",
+
+  reject: [
+    {
+      code: `
+        @use "sass:math"
+        @function get-random-value() {
+          @return math.random(100.5);
+        }
+        .a { margin-left: get-random-value(); }
+      `,
+      message: messages.rejected("random"),
+      description: "Math library function in @return expression, not allowed."
+    }
+  ]
+});


### PR DESCRIPTION
### Summary
This PR fixes an issue where `scss/function-disallowed-list` fails to report disallowed functions when they appear inside `@return` expressions in SCSS `@function` blocks.  
Related issue: #1151

### Problem
The rule currently only inspects declaration values using `root.walkDecls()`.  
As a result, function calls inside SCSS `@return` statements are never parsed:

```scss
@function foo($n) {
  @return math.random($n); // should be reported but isn't
}
