### PR TITLE
Remove support for Node.js 18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "stylelint": "16.26.1"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": ">=20.19.0"
       },
       "peerDependencies": {
         "stylelint": "^16.8.2 || ^17.0.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "type": "module",
   "exports": "./src/index.js",
   "engines": {
-    "node": ">=18.12.0"
+    "node": ">=20.19.0"
   },
   "peerDependencies": {
     "stylelint": "^16.8.2 || ^17.0.0"


### PR DESCRIPTION
Ref https://github.com/stylelint-scss/stylelint-scss/issues/1215

> [!NOTE]
Set base to `v7` once `esm` is merged.