### PR TITLE
Add support for Stylelint 17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "node": ">=18.12.0"
       },
       "peerDependencies": {
-        "stylelint": "^16.8.2"
+        "stylelint": "^16.8.2 || ^17.0.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "node": ">=18.12.0"
   },
   "peerDependencies": {
-    "stylelint": "^16.8.2"
+    "stylelint": "^16.8.2 || ^17.0.0"
   },
   "dependencies": {
     "css-tree": "^3.0.1",


### PR DESCRIPTION
Ref https://github.com/stylelint-scss/stylelint-scss/issues/1215

> [!NOTE]
Set base to `v7` once `esm` is merged.