### PR TITLE
Document 7.0.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 7.0.0
+
+- Removed: support for Node.js less than 20.19.0 (#1221)
+- Removed: deprecated rules (#1220):
+  - `at-import-no-partial-leading-underscore`
+  - `at-import-partial-extension-blacklist`
+  - `at-import-partial-extension-whitelist`
+  - `at-import-partial-extension`
+- Changed: to ES Modules (#931)
+- Added: `stylelint@^17.0.0` to peer dependency (#1222)
+- Added: `selector-class-pattern` rule (#1219)
+
+**Full Changelog**: https://github.com/stylelint-scss/stylelint-scss/compare/v6.14.0...v7.0.0
+
 # 6.14.0
 
 - Added: `dollar-variable-no-missing-interpolation` report namespaced variables in custom properties (#1225).


### PR DESCRIPTION
Ref https://github.com/stylelint-scss/stylelint-scss/issues/1215

> [!NOTE]
Set base to `v7` once `esm` is merged.