### PR TITLE
Fix CJS/ESM interop for postcss-media-query-parser import for Bun compatability

### DIFF
--- a/src/rules/operator-no-unspaced/index.js
+++ b/src/rules/operator-no-unspaced/index.js
@@ -10,7 +10,7 @@ import ruleUrl from "../../utils/ruleUrl.js";
 import stylelint from "stylelint";
 
 const { utils } = stylelint;
-const mediaQueryParser = mediaQueryParserModule.default;
+const mediaQueryParser = mediaQueryParserModule.default || mediaQueryParserModule;
 
 const ruleName = namespace("operator-no-unspaced");
 


### PR DESCRIPTION
When running under Bun, the default import of postcss-media-query-parser resolves directly to the parseMedia function rather than a module object with a .default property. This causes a `TypeError: mediaQueryParser is not a function` error at runtime when linting.

This PR adds a fallback to the initial import if the .default property is not present.