### PR TITLE
Add support for `postcss-scss` in `declaration-nested-properties-no-divided-groups` rule

### DIFF
--- a/src/rules/declaration-nested-properties-no-divided-groups/__tests__/index.js
+++ b/src/rules/declaration-nested-properties-no-divided-groups/__tests__/index.js
@@ -2,33 +2,38 @@ import rule from "../index.js";
 
 const { ruleName, messages } = rule;
 
-testRule({
-  ruleName,
-  config: [true],
-  customSyntax: "postcss-scss",
-  skipBasicChecks: true,
+const syntaxVariants = [
+  { syntaxLabel: "default syntax" },
+  { syntaxLabel: "postcss-scss", customSyntax: "postcss-scss" }
+];
 
-  accept: [
-    {
-      code: `
+const withSyntaxLabel = (syntaxLabel, testCases) =>
+  testCases.map(testCase => ({
+    ...testCase,
+    description: `${testCase.description} (${syntaxLabel})`
+  }));
+
+const acceptCases = [
+  {
+    code: `
       a {
         background: no-repeat;
         margin: 1px;
       }
     `,
-      description: "No groups."
-    },
-    {
-      code: `
+    description: "No groups."
+  },
+  {
+    code: `
       a {
         background: url(img.png) center;
         background-repeat: no-repeat;
       }
     `,
-      description: "No groups #2."
-    },
-    {
-      code: `
+    description: "No groups #2."
+  },
+  {
+    code: `
       a {
         background: url(img.png) center {
           size: auto;
@@ -36,10 +41,10 @@ testRule({
         background-repeat: no-repeat;
       }
     `,
-      description: "One group, one unnested."
-    },
-    {
-      code: `
+    description: "One group, one unnested."
+  },
+  {
+    code: `
       a {
         background: url(img.png) center {
           size: auto;
@@ -48,10 +53,10 @@ testRule({
         background-repeat: no-repeat;
       }
     `,
-      description: "One group, two unnested."
-    },
-    {
-      code: `
+    description: "One group, two unnested."
+  },
+  {
+    code: `
       a {
         background: url(img.png) center {
           size: auto;
@@ -61,10 +66,10 @@ testRule({
         }
       }
     `,
-      description: "One group, one selector."
-    },
-    {
-      code: `
+    description: "One group, one selector."
+  },
+  {
+    code: `
       a {
         background: url(img.png) center {
           size: auto;
@@ -74,10 +79,10 @@ testRule({
         }
       }
     `,
-      description: "Multiple groups, different namespaces."
-    },
-    {
-      code: `
+    description: "Multiple groups, different namespaces."
+  },
+  {
+    code: `
       a {
         background: url(img.png) center {
           size: auto;
@@ -89,27 +94,22 @@ testRule({
         }
       }
     `,
-      description: "Two groups on one namespace, one nested in @media."
-    },
-    {
-      code: `
+    description: "Two groups on one namespace, one nested in @media."
+  },
+  {
+    code: `
       a {
         &:not(.other-class) { }
         &:not(.another-class) { }
       }
     `,
-      description: "Two groups of &:not()."
-    }
-  ]
-});
+    description: "Two groups of &:not()."
+  }
+];
 
-// Warnings
-testRule({
-  ruleName,
-  config: [true],
-  reject: [
-    {
-      code: `
+const rejectCases = [
+  {
+    code: `
       a {
         background: url(img.png) center {
           size: auto;
@@ -119,26 +119,51 @@ testRule({
         }
       }
     `,
-      description: "2 groups of the same namespace.",
-      warnings: [
-        {
-          line: 3,
-          column: 9,
-          endLine: 3,
-          endColumn: 19,
-          message: messages.expected("background")
-        },
-        {
-          line: 6,
-          column: 9,
-          endLine: 6,
-          endColumn: 19,
-          message: messages.expected("background")
+    description: "2 groups of the same namespace.",
+    warnings: [
+      {
+        line: 3,
+        column: 9,
+        endLine: 3,
+        endColumn: 19,
+        message: messages.expected("background")
+      },
+      {
+        line: 6,
+        column: 9,
+        endLine: 6,
+        endColumn: 19,
+        message: messages.expected("background")
+      }
+    ]
+  },
+  {
+    code: `
+      a {
+        background: url(img.png) center {
+          size: auto;
         }
-      ]
-    },
-    {
-      code: `
+        background : {
+          repeat: no-repeat;
+        }
+      }
+    `,
+    description: "2 groups, second one has no value",
+    warnings: [
+      {
+        line: 3,
+        column: 9,
+        message: messages.expected("background")
+      },
+      {
+        line: 6,
+        column: 9,
+        message: messages.expected("background")
+      }
+    ]
+  },
+  {
+    code: `
       a {
         background: url(img.png) center {
           size: auto;
@@ -152,22 +177,22 @@ testRule({
         }
       }
     `,
-      description: "3 groups, 1 and 3 has the same namespace",
-      warnings: [
-        {
-          line: 3,
-          column: 9,
-          message: messages.expected("background")
-        },
-        {
-          line: 10,
-          column: 9,
-          message: messages.expected("background")
-        }
-      ]
-    },
-    {
-      code: `
+    description: "3 groups, 1 and 3 has the same namespace",
+    warnings: [
+      {
+        line: 3,
+        column: 9,
+        message: messages.expected("background")
+      },
+      {
+        line: 10,
+        column: 9,
+        message: messages.expected("background")
+      }
+    ]
+  },
+  {
+    code: `
       a {
         background: url(img.png) center {
           size: auto;
@@ -181,24 +206,48 @@ testRule({
         }
       }
     `,
-      description: "3 groups of the same namespace",
-      warnings: [
-        {
-          line: 3,
-          column: 9,
-          message: messages.expected("background")
-        },
-        {
-          line: 6,
-          column: 9,
-          message: messages.expected("background")
-        },
-        {
-          line: 10,
-          column: 9,
-          message: messages.expected("background")
-        }
-      ]
-    }
-  ]
+    description: "3 groups of the same namespace",
+    warnings: [
+      {
+        line: 3,
+        column: 9,
+        message: messages.expected("background")
+      },
+      {
+        line: 6,
+        column: 9,
+        message: messages.expected("background")
+      },
+      {
+        line: 10,
+        column: 9,
+        message: messages.expected("background")
+      }
+    ]
+  }
+];
+
+// Run test with basic checks
+testRule({
+  ruleName,
+  config: [true]
 });
+
+// Run tests for each syntax variant
+for (const { syntaxLabel, ...options } of syntaxVariants) {
+  testRule({
+    ruleName,
+    config: [true],
+    ...options,
+    skipBasicChecks: true,
+    accept: withSyntaxLabel(syntaxLabel, acceptCases)
+  });
+
+  testRule({
+    ruleName,
+    config: [true],
+    ...options,
+    skipBasicChecks: true,
+    reject: withSyntaxLabel(syntaxLabel, rejectCases)
+  });
+}

--- a/src/rules/declaration-nested-properties-no-divided-groups/index.js
+++ b/src/rules/declaration-nested-properties-no-divided-groups/index.js
@@ -37,11 +37,15 @@ function rule(expectation) {
 
       // Find all nested property groups
       item.each(decl => {
-        if (decl.type !== "rule") {
+        const { type, prop, value, selector } = decl;
+
+        if (type !== "rule" && !(type === "decl" && decl.isNested)) {
           return;
         }
 
-        const testForProp = parseNestedPropRoot(decl.selector);
+        const testForProp = parseNestedPropRoot(
+          selector || `${prop}: ${value}`
+        );
 
         if (testForProp && testForProp.propName !== undefined) {
           const ns = testForProp.propName.value;

--- a/src/rules/declaration-nested-properties-no-divided-groups/index.js
+++ b/src/rules/declaration-nested-properties-no-divided-groups/index.js
@@ -5,8 +5,6 @@ import stylelint from "stylelint";
 
 const { utils } = stylelint;
 
-const hasOwnProp = Object.prototype.hasOwnProperty;
-
 const ruleName = namespace("declaration-nested-properties-no-divided-groups");
 
 const messages = utils.ruleMessages(ruleName, {
@@ -18,62 +16,62 @@ const meta = {
   url: ruleUrl(ruleName)
 };
 
-function rule(expectation) {
+function rule(primary) {
   return (root, result) => {
     const validOptions = utils.validateOptions(result, ruleName, {
-      actual: expectation
+      actual: primary
     });
 
     if (!validOptions) {
       return;
     }
 
-    root.walk(item => {
-      if (item.type !== "rule" && item.type !== "atrule") {
+    root.walk(node => {
+      if (node.type !== "rule" && node.type !== "atrule") {
         return;
       }
 
-      const nestedGroups = {};
+      /** @type {Map<string, Array<import('postcss').Declaration | import('postcss').Rule>>} */
+      const nestedGroups = new Map();
 
       // Find all nested property groups
-      item.each(decl => {
-        const { type, prop, value, selector } = decl;
+      node.each(child => {
+        const { type, prop, value, selector } = child;
 
-        if (type !== "rule" && !(type === "decl" && decl.isNested)) {
+        if (type !== "rule" && !(type === "decl" && child.isNested)) {
           return;
         }
 
-        const testForProp = parseNestedPropRoot(
-          selector || `${prop}: ${value}`
-        );
+        const parsedProp = parseNestedPropRoot(selector || `${prop}: ${value}`);
 
-        if (testForProp && testForProp.propName !== undefined) {
-          const ns = testForProp.propName.value;
-
-          if (!hasOwnProp.call(nestedGroups, ns)) {
-            nestedGroups[ns] = [];
-          }
-
-          nestedGroups[ns].push(decl);
+        if (parsedProp?.propName === undefined) {
+          return;
         }
+
+        const propNamespace = parsedProp.propName.value;
+
+        if (!nestedGroups.has(propNamespace)) {
+          nestedGroups.set(propNamespace, []);
+        }
+
+        nestedGroups.get(propNamespace).push(child);
       });
 
-      Object.entries(nestedGroups).forEach(([namespaceName, groups]) => {
-        // Only warn if there are more than one nested groups with equal namespaces
-        if (groups.length === 1) {
-          return;
+      for (const [namespaceName, groupNodes] of nestedGroups) {
+        if (groupNodes.length === 1) {
+          continue;
         }
 
-        groups.forEach(group => {
+        for (const groupNode of groupNodes) {
           utils.report({
             message: messages.expected(namespaceName),
-            node: group,
+            node: groupNode,
             result,
             ruleName,
             word: namespaceName
           });
-        });
-      });
+        }
+      }
     });
   };
 }


### PR DESCRIPTION
Closes https://github.com/stylelint-scss/stylelint-scss/issues/1262

I also refactored the rule a bit to improve its performance and readability.