### PR TITLE
Fix missing interpolation autofix for Sass functions in custom properties

### DIFF
--- a/src/rules/dollar-variable-no-missing-interpolation/__tests__/index.js
+++ b/src/rules/dollar-variable-no-missing-interpolation/__tests__/index.js
@@ -758,6 +758,73 @@ testRule({
     },
     {
       code: `
+      @use 'svg';
+
+      $external-link-icon: "<svg></svg>";
+
+      :root {
+        --external-link-icon: svg.encode-svg($external-link-icon);
+      }
+      `,
+      fixed: `
+      @use 'svg';
+
+      $external-link-icon: "<svg></svg>";
+
+      :root {
+        --external-link-icon: #{svg.encode-svg($external-link-icon)};
+      }
+      `,
+      message: messages.rejected("--external-link-icon", "$external-link-icon"),
+      description:
+        "should fix Sass function calls in CSS custom properties by interpolating the function"
+    },
+    {
+      code: `
+      @use 'sass:map';
+      @use 'sass:meta';
+
+      $theme: (font: serif);
+
+      :root {
+        --font: meta.inspect(map.get($theme, font));
+      }
+      `,
+      fixed: `
+      @use 'sass:map';
+      @use 'sass:meta';
+
+      $theme: (font: serif);
+
+      :root {
+        --font: #{meta.inspect(map.get($theme, font))};
+      }
+      `,
+      message: messages.rejected("--font", "$theme"),
+      description:
+        "should fix nested Sass function calls in CSS custom properties by interpolating the outer function"
+    },
+    {
+      code: `
+      $size: 10px;
+
+      :root {
+        --custom-size: calc($size * 2);
+      }
+      `,
+      fixed: `
+      $size: 10px;
+
+      :root {
+        --custom-size: calc(#{$size} * 2);
+      }
+      `,
+      message: messages.rejected("--custom-size", "$size"),
+      description:
+        "should fix variables inside native CSS functions in CSS custom properties"
+    },
+    {
+      code: `
       $primary: "blue";
       $secondary: "green";
 

--- a/src/rules/dollar-variable-no-missing-interpolation/__tests__/index.js
+++ b/src/rules/dollar-variable-no-missing-interpolation/__tests__/index.js
@@ -216,6 +216,44 @@ testRule({
       `,
       description:
         "when namespaced variable is interpolated in CSS custom property"
+    },
+    {
+      code: `
+      @use 'svg';
+
+      $external-link-icon: "<svg></svg>";
+
+      :root {
+        --external-link-icon: #{svg.encode-svg($external-link-icon)};
+      }
+      `,
+      description:
+        "when Sass function call is interpolated in CSS custom property"
+    },
+    {
+      code: `
+      @use 'sass:map';
+      @use 'sass:meta';
+
+      $theme: (font: serif);
+
+      :root {
+        --font: #{meta.inspect(map.get($theme, font))};
+      }
+      `,
+      description:
+        "when nested Sass function call is interpolated in CSS custom property"
+    },
+    {
+      code: `
+      $size: 10px;
+
+      :root {
+        --custom-size: calc(#{$size} * 2);
+      }
+      `,
+      description:
+        "when variable inside native CSS function is interpolated in CSS custom property"
     }
   ],
 

--- a/src/rules/dollar-variable-no-missing-interpolation/index.js
+++ b/src/rules/dollar-variable-no-missing-interpolation/index.js
@@ -102,13 +102,6 @@ function findSassFunctionToInterpolate(functionStack) {
     .find(functionNode => !isNativeCssFunction(functionNode.value));
 }
 
-/**
- * Wrap uninterpolated SCSS variables with interpolation syntax.
- * Examples:
- *   "animation-name: $bar" → "animation-name: #{$bar}"
- *   "animation: $a 5s, $b 3s" → "animation: #{$a} 5s, #{$b} 3s"
- *   "--foo: variables.$someVariable" → "--foo: #{variables.$someVariable}"
- */
 function getInterpolationRanges(value, wrapFunctionCalls) {
   const ranges = [];
 
@@ -141,19 +134,19 @@ function getInterpolationRanges(value, wrapFunctionCalls) {
 
   walkNodes(valueParser(value).nodes);
 
-  return ranges
-    .sort((a, b) => a[0] - b[0] || b[1] - a[1])
-    .filter(
-      (range, index, sortedRanges) =>
-        !sortedRanges
-          .slice(0, index)
-          .some(
-            previousRange =>
-              previousRange[0] <= range[0] && previousRange[1] >= range[1]
-          )
-    );
+  return ranges;
 }
 
+/**
+ * Wrap uninterpolated SCSS variables with interpolation syntax.
+ * When fixing CSS custom properties, wrap Sass function calls around variables
+ * while leaving native CSS functions such as calc() in place.
+ * Examples:
+ *   "animation-name: $bar" → "animation-name: #{$bar}"
+ *   "--foo: variables.$someVariable" → "--foo: #{variables.$someVariable}"
+ *   "--icon: svg.encode-svg($icon)" → "--icon: #{svg.encode-svg($icon)}"
+ *   "--size: calc($size * 2)" → "--size: calc(#{$size} * 2)"
+ */
 function wrapVariablesWithInterpolation(value, wrapFunctionCalls = false) {
   let fixed = value;
   const ranges = getInterpolationRanges(value, wrapFunctionCalls);

--- a/src/rules/dollar-variable-no-missing-interpolation/index.js
+++ b/src/rules/dollar-variable-no-missing-interpolation/index.js
@@ -1,4 +1,5 @@
 import { isDollarVar } from "../../utils/validateTypes.js";
+import isNativeCssFunction from "../../utils/isNativeCssFunction.js";
 import namespace from "../../utils/namespace.js";
 import ruleUrl from "../../utils/ruleUrl.js";
 import stylelint from "stylelint";
@@ -18,7 +19,7 @@ const meta = {
   fixable: true
 };
 
-const SCSS_VARIABLE_PATTERN = /([\w-]+\.)?\$[\w-]+/g;
+const SCSS_VARIABLE_REFERENCE_PATTERN = /^(?:[\w-]+\.)?\$[\w-]+$/;
 
 const CUSTOM_IDENT_PROPERTIES = [
   "animation",
@@ -86,6 +87,21 @@ function isStringValue(value) {
   return /^["'].*["']$/.test(value);
 }
 
+function findSassFunctionToInterpolate(functionStack) {
+  let nativeFunctionBoundaryIndex = -1;
+
+  for (let i = functionStack.length - 1; i >= 0; i--) {
+    if (isNativeCssFunction(functionStack[i].value)) {
+      nativeFunctionBoundaryIndex = i;
+      break;
+    }
+  }
+
+  return functionStack
+    .slice(nativeFunctionBoundaryIndex + 1)
+    .find(functionNode => !isNativeCssFunction(functionNode.value));
+}
+
 /**
  * Wrap uninterpolated SCSS variables with interpolation syntax.
  * Examples:
@@ -93,27 +109,65 @@ function isStringValue(value) {
  *   "animation: $a 5s, $b 3s" → "animation: #{$a} 5s, #{$b} 3s"
  *   "--foo: variables.$someVariable" → "--foo: #{variables.$someVariable}"
  */
-function wrapVariablesWithInterpolation(value) {
-  let fixed = value;
-  const matches = [...value.matchAll(SCSS_VARIABLE_PATTERN)];
+function getInterpolationRanges(value, wrapFunctionCalls) {
+  const ranges = [];
 
-  // Process matches in reverse order to maintain correct string indices.
+  function walkNodes(nodes, functionStack = []) {
+    for (const node of nodes) {
+      const nextFunctionStack =
+        node.type === "function" ? [...functionStack, node] : functionStack;
+
+      if (
+        node.type === "word" &&
+        SCSS_VARIABLE_REFERENCE_PATTERN.test(node.value) &&
+        !isInsideInterpolationBlock(value, node.sourceIndex)
+      ) {
+        const sassFunction = wrapFunctionCalls
+          ? findSassFunctionToInterpolate(functionStack)
+          : undefined;
+
+        ranges.push(
+          sassFunction
+            ? [sassFunction.sourceIndex, sassFunction.sourceEndIndex]
+            : [node.sourceIndex, node.sourceEndIndex]
+        );
+      }
+
+      if (node.nodes) {
+        walkNodes(node.nodes, nextFunctionStack);
+      }
+    }
+  }
+
+  walkNodes(valueParser(value).nodes);
+
+  return ranges
+    .sort((a, b) => a[0] - b[0] || b[1] - a[1])
+    .filter(
+      (range, index, sortedRanges) =>
+        !sortedRanges
+          .slice(0, index)
+          .some(
+            previousRange =>
+              previousRange[0] <= range[0] && previousRange[1] >= range[1]
+          )
+    );
+}
+
+function wrapVariablesWithInterpolation(value, wrapFunctionCalls = false) {
+  let fixed = value;
+  const ranges = getInterpolationRanges(value, wrapFunctionCalls);
+
+  // Process ranges in reverse order to maintain correct string indices.
   // If we processed left-to-right, wrapping "$a" would shift the indices
   // for "$b" in a string like "animation: $a 5s, $b 3s".
-  for (let i = matches.length - 1; i >= 0; i--) {
-    const match = matches[i];
-    const variable = match[0];
-    const varIndex = match.index;
+  for (let i = ranges.length - 1; i >= 0; i--) {
+    const [startIndex, endIndex] = ranges[i];
 
-    // Skip variables that are already interpolated
-    if (isInsideInterpolationBlock(value, varIndex)) {
-      continue;
-    }
-
-    // Wrap the variable with interpolation syntax: $var → #{$var}
-    fixed = `${fixed.slice(0, varIndex)}#{${variable}}${fixed.slice(
-      varIndex + variable.length
-    )}`;
+    fixed = `${fixed.slice(0, startIndex)}#{${fixed.slice(
+      startIndex,
+      endIndex
+    )}}${fixed.slice(endIndex)}`;
   }
 
   return fixed;
@@ -205,7 +259,10 @@ function reportViolation(node, variableName, result) {
     if (type === "atrule") {
       node.params = wrapVariablesWithInterpolation(node.params);
     } else {
-      node.value = wrapVariablesWithInterpolation(node.value);
+      node.value = wrapVariablesWithInterpolation(
+        node.value,
+        isCustomProperty(node)
+      );
     }
   };
 
@@ -220,7 +277,7 @@ function reportViolation(node, variableName, result) {
 }
 
 function shouldSkipValueNode(node) {
-  return node.type !== "word" || !node.value;
+  return node.type !== "word" || !node.value || node.value.startsWith("#{");
 }
 
 function checkValueForVariables(
@@ -250,7 +307,7 @@ function checkValueForVariables(
     }
 
     // Skip variables that are already inside interpolation blocks
-    if (isInsideInterpolationBlock(value, value.indexOf("$"))) {
+    if (isInsideInterpolationBlock(value, valueNode.sourceIndex)) {
       return;
     }
 


### PR DESCRIPTION
## Summary

Fixes the autofix for Sass function calls in CSS custom properties.

## What changed

- Added regression tests for Sass function calls in custom property values.
- Updated the autofix to interpolate the full Sass function call when a variable appears inside one.
- Preserved native CSS function behavior such as `calc($size * 2)`.

## Why

Issue #1228 reports that `svg.encode-svg($icon)` is fixed as though only the argument needs interpolation, but the correct custom property value is `#{svg.encode-svg($icon)}`.

## Testing

- `npm run jest -- src/rules/dollar-variable-no-missing-interpolation/__tests__/index.js --runInBand`
- `npm run lint`
- `npm test`

Fixes #1228